### PR TITLE
feat(FindResult): add getFirstError method to retrieve the first error from the error list

### DIFF
--- a/src/Queries/QueryBuilder/Results/FindResult.php
+++ b/src/Queries/QueryBuilder/Results/FindResult.php
@@ -3,6 +3,7 @@
 namespace Assegai\Orm\Queries\QueryBuilder\Results;
 
 use Assegai\Orm\Interfaces\QueryResultInterface;
+use Throwable;
 use Traversable;
 
 /**
@@ -17,7 +18,7 @@ readonly class FindResult implements QueryResultInterface
   /**
    * @param mixed $raw Raw SQL result returned by executed query.
    * @param mixed $data The result data.
-   * @param array $errors List of errors.
+   * @param Throwable[] $errors List of errors.
    */
   public function __construct(
     protected mixed $raw,
@@ -47,6 +48,7 @@ readonly class FindResult implements QueryResultInterface
 
   /**
    * @inheritDoc
+   * @return Throwable[] List of errors.
    */
   public function getErrors(): array
   {
@@ -83,6 +85,26 @@ readonly class FindResult implements QueryResultInterface
     if (is_countable($this->data) || $this->data instanceof Traversable) {
       foreach ($this->data as $item) {
         return $item;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns the first error from the error list.
+   *
+   * @return Throwable|null The first error, or null if there are no errors.
+   */
+  public function getFirstError(): ?Throwable
+  {
+    if (is_array($this->errors) && count($this->errors) > 0) {
+      return $this->errors[0];
+    }
+
+    if (is_countable($this->errors) || $this->errors instanceof Traversable) {
+      foreach ($this->errors as $error) {
+        return $error;
       }
     }
 


### PR DESCRIPTION
This pull request enhances error handling in the `FindResult` class by clarifying the expected error types and adding a convenient method for retrieving the first error. The changes improve type safety and usability for developers working with query results.

**Error handling improvements:**

* Updated the constructor and `getErrors()` method to specify that the `$errors` property contains an array of `Throwable` objects, making error types explicit and improving documentation. [[1]](diffhunk://#diff-95c9bec405fa3900a3903f069d829a1388d7e3e17052cbf8d0095a9af7450fdcL20-R21) [[2]](diffhunk://#diff-95c9bec405fa3900a3903f069d829a1388d7e3e17052cbf8d0095a9af7450fdcR51)
* Added a new `getFirstError()` method to return the first error from the error list, or `null` if there are no errors, providing an easy way to access the primary error.

**Type hinting and imports:**

* Imported the `Throwable` type at the top of the file to support type hinting for errors.