### PR TITLE
Add PR guidelines and PostgreSQL tests

### DIFF
--- a/.env.pgsql.example
+++ b/.env.pgsql.example
@@ -1,0 +1,5 @@
+PG_DB_HOST=127.0.0.1
+PG_DB_NAME=assegai_pgsql_test_db
+PG_DB_PORT=5432
+PG_DB_USER=postgres
+PG_DB_PASS=postgres

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,70 @@
+# GitHub Copilot Instructions
+
+Use these repository instructions when helping with code, commits, or pull requests in this repository.
+
+## Release and milestone discipline
+
+- Follow the milestone-driven workflow described in `docs/standalone-orm-roadmap.md` and the shared release guidance in the Assegai docs.
+- Keep work aligned to one milestone at a time.
+- Do not bundle unrelated feature work into one change.
+
+## Commit guidance
+
+When suggesting a commit message, prefer:
+
+```text
+type(scope): short summary
+```
+
+Examples:
+
+- `fix(orm): avoid rolling back shared SQLite transactions on disconnect`
+- `feature(orm): improve insert result typing for repositories`
+- `test(orm): cover SQLite migration run and revert flows`
+
+Preferred types:
+
+- `fix`
+- `feature`
+- `docs`
+- `test`
+- `refactor`
+- `chore`
+
+Keep commits small and single-purpose.
+
+## Pull request guidance
+
+When suggesting or drafting a pull request, use these sections:
+
+- `Milestone`
+- `Type`
+- `Why this belongs in this milestone`
+- `What changed`
+- `What did not change`
+- `Verification`
+- `User impact`
+- `Release notes`
+- `Upgrade notes`
+
+Keep the PR body concise and milestone-focused.
+
+## Verification guidance
+
+When suggesting verification steps:
+
+- prefer the real repo checks that matter for the touched area
+- include `composer analyze` because static analysis is part of CI
+- do not claim work is green unless the relevant checks actually passed
+
+For ORM work, the default checks are usually:
+
+- `composer test`
+- `composer test:sqlite`
+- `composer analyze`
+
+## 1.0.0 framing
+
+Treat `1.0.0` as the minimum viable identity of AssegaiPHP, not the complete list of everything the framework could eventually become.
+
+Do not frame optional or future expansion work as a `1.0.0` blocker unless the repository guidance clearly says it is identity-defining.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Milestone
+<!-- Example: 0.9.0, 1.0.0, 1.0+ -->
+
+## Type
+<!-- Example labels: feature, bug, docs, test, refactor, breaking -->
+
+## Why this belongs in this milestone
+<!-- Explain why this work belongs here instead of another milestone. -->
+
+## What changed
+- 
+
+## What did not change
+- 
+
+## Verification
+- `composer test`
+- `composer test:sqlite`
+- `composer analyze`
+
+## User impact
+- 
+
+## Release notes
+<!-- Use: Needed / Not needed -->
+
+## Upgrade notes
+<!-- Use: Needed / Not needed -->

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -51,3 +51,58 @@ jobs:
 
       - name: Run SQLite integration lane
         run: composer test:sqlite
+
+  postgresql-integration:
+    runs-on: ubuntu-24.04
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: assegai_pgsql_test_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres -d assegai_pgsql_test_db"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      PG_DB_HOST: 127.0.0.1
+      PG_DB_NAME: assegai_pgsql_test_db
+      PG_DB_PORT: 5432
+      PG_DB_USER: postgres
+      PG_DB_PASS: postgres
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.5"
+          coverage: none
+          tools: composer:v2
+          extensions: curl, intl, pdo_mysql, pdo_pgsql, pdo_sqlite, sqlite3
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+
+      - name: Cache Composer packages
+        id: composer-cache-pgsql
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-pgsql-php-8.5-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pgsql-php-8.5-
+            ${{ runner.os }}-php-8.5-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run PostgreSQL integration lane
+        run: composer test:pgsql

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ For standalone PHP projects that are not using Assegai, install the package dire
 $ composer require assegaiphp/orm
 ```
 
+Then enable only the PDO driver you actually plan to use:
+
+- `pdo_mysql` for MySQL or MariaDB
+- `pdo_pgsql` for PostgreSQL
+- `pdo_sqlite` for SQLite
+
+AssegaiORM no longer forces all three database extensions at install time. If you choose a driver without enabling its
+matching PDO extension, the ORM will tell you exactly which extension is missing when you try to connect.
+
 ## Guide map
 
 This package is designed to feel familiar to teams coming from TypeORM:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@
 An object-relational mapper for modern PHP applications. You can use it on its own, or plug it into
 [AssegaiPHP](https://github.com/assegaiphp) when you want repository injection and framework conventions.
 
+## Contribution workflow
+
+For commit and pull request conventions in this repo, see:
+
+- [docs/commit-and-pr-guidelines.md](./docs/commit-and-pr-guidelines.md)
+
+
 ## Installation
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,6 @@
         "ext-pdo": "*",
         "ext-curl": "*",
         "ext-intl": "*",
-        "ext-pdo_mysql": "*",
-        "ext-pdo_pgsql": "*",
-        "ext-pdo_sqlite": "*",
         "assegaiphp/util": "^0.4.4",
         "psr/log": "^3.0",
         "symfony/console": "^7.1",
@@ -29,7 +26,10 @@
     },
     "suggest": {
         "assegaiphp/core": "Optional: enables framework-aware config and repository integration inside Assegai applications.",
-        "assegaiphp/console": "Optional: enables Assegai CLI installers and ORM command discovery."
+        "assegaiphp/console": "Optional: enables Assegai CLI installers and ORM command discovery.",
+        "ext-pdo_mysql": "Enable this if your app uses MySQL or MariaDB connections.",
+        "ext-pdo_pgsql": "Enable this if your app uses PostgreSQL connections.",
+        "ext-pdo_sqlite": "Enable this if your app uses SQLite connections."
     },
     "require-dev": {
         "codeception/codeception": "^5.0",
@@ -42,6 +42,7 @@
         "test": "vendor/bin/phpunit -c phpunit.xml",
         "test:unit": "vendor/bin/phpunit -c phpunit.xml",
         "test:mysql": "vendor/bin/phpunit -c phpunit.mysql.xml",
+        "test:pgsql": "vendor/bin/phpunit -c phpunit.pgsql.xml",
         "test:sqlite": "php -d register_argc_argv=On vendor/bin/codecept run SQLite",
         "test:legacy-unit": "php -d register_argc_argv=On vendor/bin/codecept run Unit"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ecf74bc9776140c5f63aaceadd8aad99",
+    "content-hash": "fba3632427b9d32cda6c15d58d7a09d8",
     "packages": [
         {
             "name": "assegaiphp/util",
@@ -4863,10 +4863,7 @@
         "php": ">=8.3",
         "ext-pdo": "*",
         "ext-curl": "*",
-        "ext-intl": "*",
-        "ext-pdo_mysql": "*",
-        "ext-pdo_pgsql": "*",
-        "ext-pdo_sqlite": "*"
+        "ext-intl": "*"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/docs/commit-and-pr-guidelines.md
+++ b/docs/commit-and-pr-guidelines.md
@@ -1,0 +1,170 @@
+# Commit And PR Guidelines
+
+This note turns the release playbook into a simple day-to-day format for commits and pull requests in `assegaiphp/orm`.
+
+The goal is not to add ceremony.
+
+The goal is to make the history easier to understand and make milestone scope easier to protect.
+
+## Commit guideline
+
+Keep commits:
+
+- small
+- single-purpose
+- easy to review
+- easy to revert
+
+### Recommended format
+
+```text
+type(scope): short summary
+```
+
+Examples:
+
+```text
+fix(orm): avoid rolling back shared SQLite transactions on disconnect
+feature(orm): improve insert result typing for repositories
+test(orm): cover SQLite migration run and revert flows
+docs(orm): define the standalone package workflow more clearly
+```
+
+### Recommended commit types
+
+- `fix`
+- `feature`
+- `docs`
+- `test`
+- `refactor`
+- `chore`
+
+### Optional commit body
+
+Use a body when it helps explain:
+
+- why the change exists
+- what constraint or bug it addresses
+- how it was verified
+
+Example:
+
+```text
+fix(orm): avoid rolling back shared SQLite transactions on disconnect
+
+Only release the shared SQLite handle when the final owner disconnects.
+Preserve transaction safety for owned connections.
+Add regression coverage for shared-handle teardown.
+```
+
+### Commit rule of thumb
+
+If the summary needs "and" to describe two unrelated changes, it probably wants two commits.
+
+## Pull request guideline
+
+Every PR should clearly answer:
+
+1. which milestone it belongs to
+2. why it belongs there
+3. what changed
+4. what did not change
+5. how it was verified
+
+## Recommended PR structure
+
+### Title
+
+Keep the PR title short and outcome-focused.
+
+Examples:
+
+```text
+Stabilize shared SQLite disconnect behavior
+Improve ORM result typing for inserts and updates
+Keep SQLite migration discovery safe across repeated runs
+```
+
+### Body template
+
+```md
+## Milestone
+0.9.0
+
+## Type
+bug
+test
+
+## Why this belongs in this milestone
+Explain why this work belongs here instead of another milestone.
+
+## What changed
+- change one
+- change two
+
+## What did not change
+- boundary one
+- boundary two
+
+## Verification
+- `composer test`
+- `composer test:sqlite`
+- `composer analyze`
+
+## User impact
+- short user-facing effect
+
+## Release notes
+Not needed
+
+## Upgrade notes
+Not needed
+```
+
+## Milestone rule
+
+If a PR does not clearly belong to a milestone, it should not be merged until that is resolved.
+
+## Release notes rule
+
+Use these simple defaults:
+
+- `Release notes: Not needed` for internal refactors, tests, and narrow fixes
+- `Release notes: Needed` when the change is user-visible enough to matter in a release summary
+- `Upgrade notes: Needed` when a user may need to change code, config, workflow, or expectations
+
+## Copilot and GitHub setup
+
+There are two useful automation hooks here:
+
+### 1. Repository Copilot instructions
+
+GitHub Copilot supports repository-wide custom instructions through:
+
+- `.github/copilot-instructions.md`
+
+That is the right place to teach Copilot the commit and PR format for this repository.
+
+GitHub Docs:
+
+- [Adding repository custom instructions for GitHub Copilot](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot?tool=visualstudio)
+
+### 2. GitHub PR templates
+
+GitHub supports repository PR templates through:
+
+- `.github/pull_request_template.md`
+
+GitHub Docs:
+
+- [Creating a pull request template for your repository](https://docs.github.com/en/enterprise-server%403.14/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)
+
+### 3. Organization-wide defaults
+
+If you want the same PR template across multiple repositories, GitHub supports default community health files through a public or internal `.github` repository owned by the organization or account.
+
+That is the cleanest way to scale templates across all Assegai repos later.
+
+GitHub Docs:
+
+- [Creating a default community health file](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file)

--- a/docs/entity-driven-database-sync-plan.md
+++ b/docs/entity-driven-database-sync-plan.md
@@ -1,0 +1,546 @@
+# Entity-Driven Database Sync Plan
+
+## Goal
+
+Add a new entity-first workflow to Assegai:
+
+- `assegai database:sync`
+- `assegai db:sync`
+
+The command should treat entity files as the source of truth, inspect the entities in scope, compare them to the live database schema, and generate normal migration files from the diff.
+
+This does **not** replace the current manual migration workflow. It adds a preferred higher-level workflow on top of it.
+
+## Why This Work Matters
+
+Right now the framework can:
+
+- define schema intent in entity attributes
+- inspect entities through [EntityInspector.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/Management/Inspectors/EntityInspector.php)
+- inspect and alter tables through [Schema.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/DataSource/Schema.php)
+- run SQL-file migrations through the console migrators
+
+But it still asks developers to manually keep three things in sync:
+
+1. entity files
+2. live database schema
+3. handwritten migration files
+
+That is where drift creeps in.
+
+The new sync command should reduce that drift by making entity metadata the canonical schema input, while still preserving explicit migration history as an output artifact.
+
+## External Reference Points
+
+Two useful reference ideas:
+
+- Diesel CLI keeps migrations as first-class artifacts and can regenerate schema representation after schema-affecting commands. That is a good model for "schema source and migration history work together" rather than competing with each other. Source: [Configuring Diesel CLI](https://diesel.rs/guides/configuring-diesel-cli/)
+- Marko-style tutorial ergonomics are a useful reminder that developers want a simple, guided path from models to a working database, even if the internal architecture is more capable than the tutorial shows.
+
+We should borrow the good parts without forcing Assegai into a Rust- or Laravel-shaped mental model.
+
+## Product Direction
+
+The preferred Assegai workflow going forward should be:
+
+1. define or update entities
+2. run `assegai db:sync`
+3. review the generated migration
+4. run the normal migration commands
+
+The manual workflow remains supported:
+
+1. run `assegai migration:create`
+2. write SQL by hand
+3. run the normal migration commands
+
+The new workflow is additive, not breaking.
+
+## Command UX
+
+### Primary command
+
+```bash
+assegai database:sync
+assegai db:sync
+```
+
+### Proposed options
+
+```bash
+assegai db:sync \
+  --db-type=mysql \
+  --db-name=orders_db
+```
+
+```bash
+assegai db:sync \
+  --db-type=sqlite \
+  --db-name=marketace_db \
+  --entity="App\\Users\\UserEntity" \
+  --entity="App\\Orders\\OrderEntity"
+```
+
+### Recommended option surface
+
+- `--db-type=mysql|sqlite|pgsql`
+- `--db-name=<name>`
+- `--entity=<fqcn>` repeatable
+- `--path=<directory>` repeatable
+- `--module=<module class>` optional future convenience
+- `--data-source=<driver:name>` optional shorthand for the above two flags
+- `--dry-run` show the plan without writing files
+- `--name=<migration-name>` override the generated migration name
+- `--write-empty` write a migration even when the diff is empty
+- `--join-tables=auto|off`
+- `--apply` optional later phase, not required for the first implementation
+
+### Defaults
+
+- if no entity scope is provided, scan the current workspace
+- if no migration name is provided, generate one like `sync_schema`
+- if no join-table mode is provided, use the project default
+
+## Workspace Scanning Rules
+
+This command should assume a **single project workspace**, not a monorepo.
+
+Entity discovery should:
+
+1. start from the current workspace's `composer.json`
+2. resolve the workspace's own PSR-4 autoload roots
+3. scan only that workspace unless the user explicitly points elsewhere
+4. load only classes marked with [Entity.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/Attributes/Entity.php)
+
+Recommended scanning precedence:
+
+1. explicit `--entity`
+2. explicit `--path`
+3. workspace PSR-4 scan
+
+That keeps the feature predictable and avoids hidden assumptions about sibling repos.
+
+## What The Command Should Generate
+
+`database:sync` should generate a normal migration folder in the existing migrations layout, not bypass it.
+
+Recommended output:
+
+- `migrations/<driver>/<db>/<timestamp>_<name>/up.sql`
+- `migrations/<driver>/<db>/<timestamp>_<name>/down.sql`
+- `migrations/<driver>/<db>/<timestamp>_<name>/sync.json`
+
+Why add `sync.json`:
+
+- records which entities were scanned
+- records the datasource used
+- records whether join-table inference was enabled
+- records warnings or manual follow-up items
+- helps future tooling and upgrade diagnostics
+
+## Proposed Architecture
+
+### 1. Keep the command in `console`
+
+The CLI UX belongs in `console`, likely alongside:
+
+- [DatabaseConfigure.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/console/src/Commands/Database/DatabaseConfigure.php)
+- [DatabaseSetup.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/console/src/Commands/Database/DatabaseSetup.php)
+
+Proposed new command:
+
+- `console/src/Commands/Database/DatabaseSync.php`
+
+### 2. Put sync planning in `orm`
+
+The entity-to-schema planning logic belongs in `orm`, not `console`.
+
+Recommended new services:
+
+- `EntityScopeResolver`
+- `SchemaSnapshotReader`
+- `EntitySchemaSnapshotBuilder`
+- `JoinTableInferenceService`
+- `SchemaDiffPlanner`
+- `MigrationSqlGenerator`
+- `SyncMigrationWriter`
+
+`console` should orchestrate. `orm` should decide what the schema means.
+
+### 3. Reuse existing metadata and schema machinery
+
+The plan should build on:
+
+- [EntityInspector.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/Management/Inspectors/EntityInspector.php)
+- [EntityMetadata.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/Metadata/EntityMetadata.php)
+- [RelationMetadata.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/Metadata/RelationMetadata.php)
+- [Schema.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/DataSource/Schema.php)
+- [SchemaChangeManifest.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/Migrations/SchemaChangeManifest.php)
+
+But we should not call `Schema::alter(...)` directly from the command and call it done. That path is useful, but it is currently too table-local and too live-database-oriented to be the whole sync architecture.
+
+Instead, the new planner should produce an intermediate diff model, and SQL generation should happen from that model.
+
+## Sync pipeline
+
+### Step 1. Resolve the datasource
+
+Inputs:
+
+- `--db-type`
+- `--db-name`
+- optional `--data-source`
+
+Output:
+
+- a resolved datasource identity such as `sqlite:blog_api_db`
+
+This should align with the current Assegai direction around fully qualified datasource names.
+
+### Step 2. Resolve entity scope
+
+Inputs:
+
+- explicit entities
+- explicit paths
+- or workspace scan
+
+Output:
+
+- a stable ordered list of entity FQCNs
+
+Rules:
+
+- skip entities with `#[Entity(..., synchronize: false)]`
+- fail early on invalid classes
+- warn when duplicate table names are detected
+
+### Step 3. Build the desired schema snapshot
+
+For every entity in scope, derive:
+
+- table name
+- columns
+- primary key
+- nullability
+- defaults
+- indexes
+- unique constraints
+- foreign keys
+- relation-driven join columns
+- relation-driven join tables when enabled
+
+This desired snapshot is the entity-side truth model.
+
+### Step 4. Read the live schema snapshot
+
+For the target datasource, inspect the current database:
+
+- tables
+- columns
+- indexes
+- unique constraints
+- foreign keys
+- join tables already present
+
+This snapshot should be dialect-aware and should reuse the existing schema readers where possible.
+
+### Step 5. Compute a diff plan
+
+Generate a normalized diff model, for example:
+
+- create table
+- drop table
+- add column
+- alter column
+- drop column
+- add index
+- drop index
+- add foreign key
+- drop foreign key
+- create join table
+- drop join table
+
+This diff model is the important seam. It keeps planning separate from SQL rendering.
+
+### Step 6. Generate `up.sql` and `down.sql`
+
+Render the diff to SQL for the active dialect.
+
+Rules:
+
+- `up.sql` applies the desired entity-driven changes
+- `down.sql` reverses them using the pre-sync live schema snapshot
+- when a reverse operation is ambiguous or lossy, generate the best safe reverse we can and emit a warning in `sync.json`
+
+### Step 7. Write the migration artifact
+
+Write the standard migration directory and print:
+
+- entities scanned
+- tables affected
+- join tables inferred
+- warnings
+- next recommended command
+
+## Join-table strategy
+
+This needs to be smart, but not magical in a dangerous way.
+
+### Goal
+
+When many-to-many relationships are declared, the sync command should be able to create and configure join tables without developers having to hand-specify every detail.
+
+### Proposed behavior
+
+Add a sync-level setting for join-table inference:
+
+- `auto`
+- `off`
+
+This plan assumes "opt-out" means the feature is enabled by default and can be turned off easily per project, per command run, or per relation.
+
+Recommended product behavior:
+
+- default project setting: `auto`
+- easy opt-out via config or CLI
+
+That matches the intention that the feature should help by default, but still be configurable.
+
+### Inference rules
+
+When join-table inference is `auto`:
+
+1. only act on owner-side many-to-many relations
+2. honor an explicit [JoinTable.php](/home/amasiye/development/atatusoft/projects/external/assegaiphp/orm/src/Attributes/Relations/JoinTable.php) when it is present
+3. if `JoinTable(..., synchronize: false)` is set, skip the table
+4. if no `JoinTable` is present, generate:
+   - table name
+   - join column
+   - inverse join column
+   - composite primary key or unique key
+   - foreign keys
+5. if the relation metadata is ambiguous, warn and require the developer to be explicit
+
+### Naming defaults
+
+Use deterministic names so repeated syncs remain stable.
+
+Recommended defaults:
+
+- join table: `<owner_table>_<inverse_table>`
+- owner FK column: `<owner_table_singular>_id`
+- inverse FK column: `<inverse_table_singular>_id`
+
+If the framework already has a stronger naming strategy elsewhere, use that strategy centrally instead of duplicating it in the command.
+
+## Safety rules
+
+The first version should be conservative.
+
+### Default behavior
+
+- generate migration files
+- do not auto-apply them
+- show a readable change summary
+- warn loudly about destructive operations
+
+### Destructive changes
+
+Examples:
+
+- dropping tables
+- dropping columns
+- tightening nullability
+- changing column types in incompatible ways
+
+Recommended behavior:
+
+- allow generation
+- mark these steps as destructive in `sync.json`
+- print a warning in the CLI summary
+- consider a future `--allow-destructive` gate if we find teams want stricter defaults
+
+### Rename detection
+
+Rename detection is dangerous to guess.
+
+Recommendation:
+
+- first release should **not** guess renames automatically
+- treat unknown renames as drop + add
+- later we can add explicit rename hints or heuristics
+
+That keeps the implementation honest.
+
+## Coexistence with the manual workflow
+
+We should keep both workflows clearly supported.
+
+### Manual SQL workflow
+
+- `migration:create`
+- hand-edit `up.sql` and `down.sql`
+- `migration:up`
+- `migration:down`
+
+### Entity-driven workflow
+
+- edit entities
+- `database:sync`
+- review generated migration
+- `migration:up`
+
+The generated migration files should look normal and remain editable. Developers should never feel trapped in an opaque one-way system.
+
+## Recommended configuration
+
+Add a project-level config section for sync defaults, for example under ORM config:
+
+```php
+'orm' => [
+  'sync' => [
+    'join_tables' => 'auto',
+    'write_empty' => false,
+    'scan_paths' => ['src'],
+    'migration_name' => 'sync_schema',
+  ],
+],
+```
+
+The exact config file location can be decided later, but the feature should not force every project to retype the same flags.
+
+## Implementation phases
+
+### Phase 1: scaffolding and dry-run plan
+
+Deliver:
+
+- `database:sync` / `db:sync` command
+- datasource resolution
+- workspace entity scan
+- desired schema snapshot
+- live schema snapshot
+- diff summary output
+- `--dry-run`
+
+No SQL files yet. This phase proves discovery and planning.
+
+### Phase 2: migration generation
+
+Deliver:
+
+- write `up.sql`
+- write `down.sql`
+- write `sync.json`
+- support create/add/change/drop for tables and columns
+- reuse existing migration folder layout
+
+This is the first version that is useful for daily development.
+
+### Phase 3: relation-aware sync
+
+Deliver:
+
+- foreign keys
+- indexes from entity metadata
+- relation-driven join columns
+- many-to-many join-table inference
+- configurable join-table opt-out
+
+This is where the feature becomes truly entity-first.
+
+### Phase 4: polish and dialect parity
+
+Deliver:
+
+- MySQL, SQLite, and PostgreSQL behavior aligned
+- better diff explanations
+- better destructive-change warnings
+- optional `--apply`
+- optional rename hints
+
+## Testing strategy
+
+This feature needs more than happy-path unit tests.
+
+### Unit tests
+
+Add fast tests for:
+
+- entity scope resolution
+- diff planning
+- join-table inference
+- SQL rendering per dialect
+- destructive-change classification
+
+### Integration tests
+
+For each dialect:
+
+- start with a live schema
+- change entities
+- run sync
+- assert generated `up.sql`
+- apply migration
+- inspect resulting schema
+- run `down.sql`
+- inspect rollback result
+
+SQLite should be the first fully automated integration lane because it is easiest to run in CI.
+
+### Golden-file tests
+
+This feature is a good candidate for snapshot-style tests:
+
+- entities in
+- migration files out
+
+That will help keep CLI output and generated SQL stable.
+
+## Risks
+
+### 1. Down migrations are harder than up migrations
+
+Generating `up.sql` is relatively straightforward. Generating reliable `down.sql` requires a good snapshot of the pre-sync schema and careful dialect handling.
+
+### 2. Schema diffs can become dialect-specific quickly
+
+SQLite alter behavior is not the same as MySQL or PostgreSQL. The diff model must stay portable, but the renderer must remain dialect-aware.
+
+### 3. Relationship metadata may still need hardening
+
+Many-to-many and join-column behavior is where ORM drift usually gets subtle. This feature will expose weak spots in relation metadata quickly.
+
+### 4. Developers may expect "sync" to mutate the database immediately
+
+We should be explicit in docs and command help:
+
+- `database:sync` generates migrations
+- migration commands apply them
+
+If we later add `--apply`, that should remain an explicit opt-in.
+
+## Definition of done
+
+We should consider the feature ready when:
+
+1. `assegai db:sync` can scan a workspace or explicit entity list
+2. it can generate normal migration files from entity diffs
+3. it supports MySQL, SQLite, and PostgreSQL
+4. join-table inference works predictably and is configurable
+5. manual migrations still work unchanged
+6. docs clearly explain when to use sync vs manual SQL
+
+## Recommended next implementation slice
+
+Start with Phase 1 plus the migration writer shell from Phase 2:
+
+1. add `DatabaseSync` command in `console`
+2. add entity-scope resolution in `orm`
+3. build a desired schema snapshot model from entity metadata
+4. build a live schema snapshot reader
+5. print a dry-run diff summary
+6. once the diff model feels trustworthy, add SQL generation and migration writing
+
+That gives us the safest path to a feature we can trust, instead of jumping straight to SQL file generation before the planner is stable.

--- a/phpunit.pgsql.xml
+++ b/phpunit.pgsql.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+         bootstrap="tests/PHPUnit/bootstrap.php"
+         colors="true"
+         cacheDirectory="tests/_output/.phpunit.pgsql.cache"
+>
+    <testsuites>
+        <testsuite name="ORM PHPUnit PostgreSQL Integration">
+            <directory suffix="Test.php">./tests/PHPUnit/PostgreSQLIntegration</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/DataSource/DBFactory.php
+++ b/src/DataSource/DBFactory.php
@@ -125,8 +125,19 @@ final class DBFactory
         $databases = OrmRuntime::databaseConfigs();
 
         if (!isset($databases[$type]) || !isset($databases[$type][$dbName])) {
-            throw new DataSourceConnectionException();
+            throw new DataSourceConnectionException(self::getDataSourceTypeForConnectionPool($type));
         }
+    }
+
+    private static function getDataSourceTypeForConnectionPool(string $type): DataSourceType
+    {
+        return match ($type) {
+            'mariadb' => DataSourceType::MARIADB,
+            'pgsql' => DataSourceType::POSTGRESQL,
+            'sqlite' => DataSourceType::SQLITE,
+            'mongodb' => DataSourceType::MONGODB,
+            default => DataSourceType::MYSQL,
+        };
     }
 
     public static function buildMySqlDsn(

--- a/src/DataSource/DBFactory.php
+++ b/src/DataSource/DBFactory.php
@@ -72,6 +72,7 @@ final class DBFactory
     public static function getMySQLConnection(string $dbName): PDO
     {
         $type = 'mysql';
+        self::ensureDriverIsAvailable(SQLDialect::MYSQL);
 
         if (empty($dbName)) {
             throw new DataSourceConnectionException();
@@ -217,6 +218,7 @@ final class DBFactory
     public static function getPostgresSQLConnection(string $dbName): PDO
     {
         $type = 'pgsql';
+        self::ensureDriverIsAvailable(SQLDialect::POSTGRESQL);
 
         if (empty($dbName)) {
             throw new DataSourceConnectionException();
@@ -263,6 +265,7 @@ final class DBFactory
     public static function getSQLiteConnection(string $dbName): PDO
     {
         $type = 'sqlite';
+        self::ensureDriverIsAvailable(SQLDialect::SQLITE);
 
         if (empty($dbName)) {
             throw new DataSourceConnectionException();
@@ -374,6 +377,50 @@ final class DBFactory
 
         self::$connections[$type][$cacheKey] = null;
         unset(self::$connections[$type][$cacheKey]);
+    }
+
+    public static function getRequiredPdoExtension(SQLDialect $dialect): ?string
+    {
+        return match ($dialect) {
+            SQLDialect::MYSQL, SQLDialect::MARIADB => 'pdo_mysql',
+            SQLDialect::POSTGRESQL => 'pdo_pgsql',
+            SQLDialect::SQLITE => 'pdo_sqlite',
+            default => null,
+        };
+    }
+
+    public static function getRequiredPdoDriverName(SQLDialect $dialect): ?string
+    {
+        return match ($dialect) {
+            SQLDialect::MYSQL, SQLDialect::MARIADB => 'mysql',
+            SQLDialect::POSTGRESQL => 'pgsql',
+            SQLDialect::SQLITE => 'sqlite',
+            default => null,
+        };
+    }
+
+    private static function ensureDriverIsAvailable(SQLDialect $dialect): void
+    {
+        $extension = self::getRequiredPdoExtension($dialect);
+        $driver = self::getRequiredPdoDriverName($dialect);
+
+        if ($extension === null || $driver === null) {
+            return;
+        }
+
+        if (!extension_loaded($extension) || !in_array($driver, PDO::getAvailableDrivers(), true)) {
+            $type = match ($dialect) {
+                SQLDialect::MARIADB => DataSourceType::MARIADB,
+                SQLDialect::POSTGRESQL => DataSourceType::POSTGRESQL,
+                SQLDialect::SQLITE => DataSourceType::SQLITE,
+                default => DataSourceType::MYSQL,
+            };
+
+            throw new DataSourceConnectionException(
+                $type,
+                sprintf('Missing required PDO driver. Install or enable the %s extension to use %s.', $extension, $type->value),
+            );
+        }
     }
 
     /**

--- a/src/DataSource/Schema.php
+++ b/src/DataSource/Schema.php
@@ -788,6 +788,7 @@ class Schema implements ISchema
         self::applyPostgreSqlColumnChange(
           $connection,
           $tableName,
+          $columnName,
           $changeStatement->columnDefinition,
           $currentField,
         );
@@ -821,11 +822,11 @@ class Schema implements ISchema
   private static function applyPostgreSqlColumnChange(
     PDO|IDataObject $connection,
     string $tableName,
+    string $columnName,
     \Assegai\Orm\Queries\Sql\SQLColumnDefinition $columnDefinition,
     ?SQLTableDescription $currentField,
   ): void {
     $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::POSTGRESQL);
-    $columnName = $columnDefinition->name;
     $quotedColumnName = SqlDialectHelper::quoteIdentifier($columnName, SQLDialect::POSTGRESQL);
 
     self::executeDialectStatement(

--- a/src/DataSource/Schema.php
+++ b/src/DataSource/Schema.php
@@ -179,16 +179,26 @@ class Schema implements ISchema
       return null;
     }
 
-    if (in_array($options->dialect, [SQLDialect::SQLITE, SQLDialect::POSTGRESQL], true))
+    if ($options->dialect === SQLDialect::SQLITE)
     {
       return self::commitRebuiltSchemaChanges($db, $entityReflection, $entityInstance, $options, $tableFields);
     }
 
     $changes = self::compileChanges($entityReflection, $tableFields, $options->dialect);
 
-    if (empty($changes))
+    if (!self::hasSchemaChanges($changes))
     {
       return null;
+    }
+
+    if ($options->dialect === SQLDialect::POSTGRESQL)
+    {
+      return self::commitPostgreSqlSchemaChanges(
+        $db,
+        $entityInspector->getTableName($entityInstance),
+        $changes,
+        $tableFields,
+      );
     }
 
     return self::commitSchemaChanges($db, $changes);
@@ -563,6 +573,13 @@ class Schema implements ISchema
     return true;
   }
 
+  private static function hasSchemaChanges(SchemaChangeManifest $changes): bool
+  {
+    return $changes->getAddList() !== []
+      || $changes->getChangeList() !== []
+      || $changes->getDropList() !== [];
+  }
+
   /**
    * @param SQLTableDescription $tableField
    * @param Column $columnAttribute
@@ -712,6 +729,276 @@ class Schema implements ISchema
     }
 
     return true;
+  }
+
+  /**
+   * @param PDO|IDataObject $connection
+   * @param string $tableName
+   * @param SchemaChangeManifest $changes
+   * @param SQLTableDescription[] $tableFields
+   * @return bool
+   * @throws ORMException
+   */
+  private static function commitPostgreSqlSchemaChanges(
+    PDO|IDataObject $connection,
+    string $tableName,
+    SchemaChangeManifest $changes,
+    array $tableFields,
+  ): bool {
+    $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::POSTGRESQL);
+    $tableFieldMap = [];
+
+    foreach ($tableFields as $tableField)
+    {
+      if (is_string($tableField->Field) && $tableField->Field !== '')
+      {
+        $tableFieldMap[$tableField->Field] = $tableField;
+      }
+    }
+
+    try
+    {
+      $connection->beginTransaction();
+
+      foreach ($changes->getDropList() as $dropStatement)
+      {
+        $columnName = $dropStatement->columnDefinition?->name ?: $dropStatement->columnName;
+        $quotedColumnName = SqlDialectHelper::quoteIdentifier($columnName, SQLDialect::POSTGRESQL);
+        self::executeDialectStatement(
+          $connection,
+          "ALTER TABLE $quotedTableName DROP COLUMN IF EXISTS $quotedColumnName",
+          SQLDialect::POSTGRESQL,
+        );
+      }
+
+      foreach ($changes->getAddList() as $addStatement)
+      {
+        self::executeDialectStatement(
+          $connection,
+          "ALTER TABLE $quotedTableName ADD COLUMN {$addStatement->columnDefinition}",
+          SQLDialect::POSTGRESQL,
+        );
+      }
+
+      foreach ($changes->getChangeList() as $changeStatement)
+      {
+        $columnName = $changeStatement->columnDefinition->name ?: $changeStatement->columnName;
+        $currentField = $tableFieldMap[$columnName] ?? null;
+
+        self::applyPostgreSqlColumnChange(
+          $connection,
+          $tableName,
+          $changeStatement->columnDefinition,
+          $currentField,
+        );
+      }
+
+      self::synchronizePostgreSqlSequences($connection, $tableName);
+      $connection->commit();
+    }
+    catch (PDOException $e)
+    {
+      if ($connection->inTransaction())
+      {
+        $connection->rollBack();
+      }
+
+      throw new ORMException($e->getMessage());
+    }
+    catch (ORMException $e)
+    {
+      if ($connection->inTransaction())
+      {
+        $connection->rollBack();
+      }
+
+      throw $e;
+    }
+
+    return true;
+  }
+
+  private static function applyPostgreSqlColumnChange(
+    PDO|IDataObject $connection,
+    string $tableName,
+    \Assegai\Orm\Queries\Sql\SQLColumnDefinition $columnDefinition,
+    ?SQLTableDescription $currentField,
+  ): void {
+    $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::POSTGRESQL);
+    $columnName = $columnDefinition->name;
+    $quotedColumnName = SqlDialectHelper::quoteIdentifier($columnName, SQLDialect::POSTGRESQL);
+
+    self::executeDialectStatement(
+      $connection,
+      sprintf(
+        'ALTER TABLE %s ALTER COLUMN %s TYPE %s',
+        $quotedTableName,
+        $quotedColumnName,
+        $columnDefinition->getTypeExpression(),
+      ),
+      SQLDialect::POSTGRESQL,
+    );
+
+    $defaultExpression = $columnDefinition->getDefaultExpression();
+
+    if ($defaultExpression === null)
+    {
+      self::executeDialectStatement(
+        $connection,
+        "ALTER TABLE $quotedTableName ALTER COLUMN $quotedColumnName DROP DEFAULT",
+        SQLDialect::POSTGRESQL,
+      );
+    }
+    else
+    {
+      self::executeDialectStatement(
+        $connection,
+        "ALTER TABLE $quotedTableName ALTER COLUMN $quotedColumnName SET DEFAULT $defaultExpression",
+        SQLDialect::POSTGRESQL,
+      );
+    }
+
+    if ($columnDefinition->isNullable())
+    {
+      self::executeDialectStatement(
+        $connection,
+        "ALTER TABLE $quotedTableName ALTER COLUMN $quotedColumnName DROP NOT NULL",
+        SQLDialect::POSTGRESQL,
+      );
+    }
+    else
+    {
+      if ($defaultExpression !== null && ($currentField?->Null ?? 'YES') === 'YES')
+      {
+        self::executeDialectStatement(
+          $connection,
+          "UPDATE $quotedTableName SET $quotedColumnName = $defaultExpression WHERE $quotedColumnName IS NULL",
+          SQLDialect::POSTGRESQL,
+        );
+      }
+
+      self::executeDialectStatement(
+        $connection,
+        "ALTER TABLE $quotedTableName ALTER COLUMN $quotedColumnName SET NOT NULL",
+        SQLDialect::POSTGRESQL,
+      );
+    }
+
+    self::synchronizePostgreSqlColumnConstraints($connection, $tableName, $columnName, $currentField, $columnDefinition);
+  }
+
+  private static function synchronizePostgreSqlColumnConstraints(
+    PDO|IDataObject $connection,
+    string $tableName,
+    string $columnName,
+    ?SQLTableDescription $currentField,
+    \Assegai\Orm\Queries\Sql\SQLColumnDefinition $columnDefinition,
+  ): void {
+    $currentKey = $currentField?->Key ?? '';
+    $wantsPrimaryKey = $columnDefinition->isPrimaryKey();
+    $wantsUnique = !$wantsPrimaryKey && $columnDefinition->isUnique();
+    $hasPrimaryKey = $currentKey === 'PRI';
+    $hasUniqueKey = $currentKey === 'UNI';
+    $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::POSTGRESQL);
+    $quotedColumnName = SqlDialectHelper::quoteIdentifier($columnName, SQLDialect::POSTGRESQL);
+
+    if (!$wantsPrimaryKey && $hasPrimaryKey)
+    {
+      foreach (self::getPostgreSqlConstraintNames($connection, $tableName, $columnName, 'p') as $constraintName)
+      {
+        $quotedConstraintName = SqlDialectHelper::quoteIdentifier($constraintName, SQLDialect::POSTGRESQL);
+        self::executeDialectStatement(
+          $connection,
+          "ALTER TABLE $quotedTableName DROP CONSTRAINT IF EXISTS $quotedConstraintName",
+          SQLDialect::POSTGRESQL,
+        );
+      }
+    }
+
+    if (!$wantsUnique && $hasUniqueKey)
+    {
+      foreach (self::getPostgreSqlConstraintNames($connection, $tableName, $columnName, 'u') as $constraintName)
+      {
+        $quotedConstraintName = SqlDialectHelper::quoteIdentifier($constraintName, SQLDialect::POSTGRESQL);
+        self::executeDialectStatement(
+          $connection,
+          "ALTER TABLE $quotedTableName DROP CONSTRAINT IF EXISTS $quotedConstraintName",
+          SQLDialect::POSTGRESQL,
+        );
+      }
+    }
+
+    if ($wantsPrimaryKey && !$hasPrimaryKey)
+    {
+      self::executeDialectStatement(
+        $connection,
+        "ALTER TABLE $quotedTableName ADD PRIMARY KEY ($quotedColumnName)",
+        SQLDialect::POSTGRESQL,
+      );
+    }
+
+    if ($wantsUnique && !$hasUniqueKey)
+    {
+      $constraintName = self::generatePostgreSqlUniqueConstraintName($tableName, $columnName);
+      $quotedConstraintName = SqlDialectHelper::quoteIdentifier($constraintName, SQLDialect::POSTGRESQL);
+
+      self::executeDialectStatement(
+        $connection,
+        "ALTER TABLE $quotedTableName ADD CONSTRAINT $quotedConstraintName UNIQUE ($quotedColumnName)",
+        SQLDialect::POSTGRESQL,
+      );
+    }
+  }
+
+  /**
+   * @return string[]
+   * @throws ORMException
+   */
+  private static function getPostgreSqlConstraintNames(
+    PDO|IDataObject $connection,
+    string $tableName,
+    string $columnName,
+    string $constraintType,
+  ): array {
+    $statement = $connection->prepare(
+      <<<'SQL'
+SELECT con.conname
+FROM pg_constraint con
+JOIN pg_class rel ON rel.oid = con.conrelid
+JOIN pg_namespace n ON n.oid = rel.relnamespace
+JOIN pg_attribute a ON a.attrelid = rel.oid AND a.attnum = ANY(con.conkey)
+WHERE rel.relname = :table
+  AND n.nspname = current_schema()
+  AND con.contype = :type
+  AND a.attname = :column
+  AND array_length(con.conkey, 1) = 1
+ORDER BY con.conname
+SQL
+    );
+
+    if (!$statement || !$statement->execute([
+      'table' => $tableName,
+      'type' => $constraintType,
+      'column' => $columnName,
+    ])) {
+      throw new ORMException("Failed to inspect PostgreSQL constraints for '$tableName.$columnName'.");
+    }
+
+    /** @var array<int, array{conname?: mixed}> $rows */
+    $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+    return array_values(array_filter(
+      array_map(
+        static fn(array $row): ?string => is_string($row['conname'] ?? null) ? $row['conname'] : null,
+        $rows,
+      ),
+      static fn(?string $constraintName): bool => $constraintName !== null && $constraintName !== '',
+    ));
+  }
+
+  private static function generatePostgreSqlUniqueConstraintName(string $tableName, string $columnName): string
+  {
+    return preg_replace('/[^A-Za-z0-9_]+/', '_', "{$tableName}_{$columnName}_key") ?: "{$tableName}_{$columnName}_key";
   }
 
   private static function getEntityColumnNames(ReflectionClass $entityReflection): array

--- a/src/DataSource/Schema.php
+++ b/src/DataSource/Schema.php
@@ -179,9 +179,9 @@ class Schema implements ISchema
       return null;
     }
 
-    if ($options->dialect === SQLDialect::SQLITE)
+    if (in_array($options->dialect, [SQLDialect::SQLITE, SQLDialect::POSTGRESQL], true))
     {
-      return self::commitSqliteSchemaChanges($db, $entityReflection, $entityInstance, $options, $tableFields);
+      return self::commitRebuiltSchemaChanges($db, $entityReflection, $entityInstance, $options, $tableFields);
     }
 
     $changes = self::compileChanges($entityReflection, $tableFields, $options->dialect);
@@ -604,13 +604,13 @@ class Schema implements ISchema
     return false;
   }
 
-  private static function commitSqliteSchemaChanges(PDO|IDataObject $connection, ReflectionClass $entityReflection, object $entityInstance, SchemaOptions $options, array $tableFields): bool
+  private static function commitRebuiltSchemaChanges(PDO|IDataObject $connection, ReflectionClass $entityReflection, object $entityInstance, SchemaOptions $options, array $tableFields): bool
   {
     $entityInspector = EntityInspector::getInstance();
     $tableName = $entityInspector->getTableName($entityInstance);
-    $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::SQLITE);
+    $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, $options->dialect);
     $temporaryTableName = self::generateTemporaryTableName($tableName);
-    $quotedTemporaryTableName = SqlDialectHelper::quoteIdentifier($temporaryTableName, SQLDialect::SQLITE);
+    $quotedTemporaryTableName = SqlDialectHelper::quoteIdentifier($temporaryTableName, $options->dialect);
     $createTableOptions = new SchemaOptions(
       dbName: $options->dbName,
       dialect: $options->dialect,
@@ -624,37 +624,49 @@ class Schema implements ISchema
       engine: $options->engine,
     );
     $createTableSql = self::getDDLStatementFromEntity($entityInstance, $createTableOptions);
-    $temporaryCreateTableSql = self::replaceSqliteCreateTableName($createTableSql, $quotedTemporaryTableName);
+    $temporaryCreateTableSql = self::replaceCreateTableName($createTableSql, $quotedTemporaryTableName);
     $targetColumns = self::getEntityColumnNames($entityReflection);
     $currentColumns = array_map(fn(SQLTableDescription $field) => $field->Field, $tableFields);
     $sharedColumns = array_values(array_intersect($currentColumns, $targetColumns));
+    $requiresForeignKeyToggle = $options->dialect === SQLDialect::SQLITE;
 
     try
     {
-      self::executeSqliteStatement($connection, 'PRAGMA foreign_keys = OFF');
+      if ($requiresForeignKeyToggle)
+      {
+        self::executeDialectStatement($connection, 'PRAGMA foreign_keys = OFF', $options->dialect);
+      }
+
       $connection->beginTransaction();
-      self::executeSqliteStatement($connection, $temporaryCreateTableSql);
+      self::executeDialectStatement($connection, $temporaryCreateTableSql, $options->dialect);
 
       if (!empty($sharedColumns))
       {
         $quotedColumns = implode(', ', array_map(
-          fn(string $columnName) => SqlDialectHelper::quoteIdentifier($columnName, SQLDialect::SQLITE),
+          fn(string $columnName) => SqlDialectHelper::quoteIdentifier($columnName, $options->dialect),
           $sharedColumns,
         ));
 
-        self::executeSqliteStatement(
+        self::executeDialectStatement(
           $connection,
-          "INSERT INTO $quotedTemporaryTableName ($quotedColumns) SELECT $quotedColumns FROM $quotedTableName"
+          "INSERT INTO $quotedTemporaryTableName ($quotedColumns) SELECT $quotedColumns FROM $quotedTableName",
+          $options->dialect
         );
       }
 
-      self::executeSqliteStatement($connection, "DROP TABLE $quotedTableName");
-      self::executeSqliteStatement(
+      self::executeDialectStatement($connection, "DROP TABLE $quotedTableName", $options->dialect);
+      self::executeDialectStatement(
         $connection,
-        'ALTER TABLE ' . $quotedTemporaryTableName . ' RENAME TO ' . SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::SQLITE)
+        'ALTER TABLE ' . $quotedTemporaryTableName . ' RENAME TO ' . SqlDialectHelper::quoteIdentifier($tableName, $options->dialect),
+        $options->dialect
       );
+      self::synchronizeRebuiltTableState($connection, $tableName, $options->dialect);
       $connection->commit();
-      self::executeSqliteStatement($connection, 'PRAGMA foreign_keys = ON');
+
+      if ($requiresForeignKeyToggle)
+      {
+        self::executeDialectStatement($connection, 'PRAGMA foreign_keys = ON', $options->dialect);
+      }
     }
     catch (PDOException $e)
     {
@@ -665,7 +677,10 @@ class Schema implements ISchema
 
       try
       {
-        self::executeSqliteStatement($connection, 'PRAGMA foreign_keys = ON');
+        if ($requiresForeignKeyToggle)
+        {
+          self::executeDialectStatement($connection, 'PRAGMA foreign_keys = ON', $options->dialect);
+        }
       }
       catch (ORMException)
       {
@@ -683,7 +698,10 @@ class Schema implements ISchema
 
       try
       {
-        self::executeSqliteStatement($connection, 'PRAGMA foreign_keys = ON');
+        if ($requiresForeignKeyToggle)
+        {
+          self::executeDialectStatement($connection, 'PRAGMA foreign_keys = ON', $options->dialect);
+        }
       }
       catch (ORMException)
       {
@@ -715,7 +733,7 @@ class Schema implements ISchema
     return $columnNames;
   }
 
-  private static function replaceSqliteCreateTableName(string $query, string $quotedTemporaryTableName): string
+  private static function replaceCreateTableName(string $query, string $quotedTemporaryTableName): string
   {
     $updatedQuery = preg_replace(
       '/^(CREATE(?:\s+TEMPORARY)?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+)([`\"]?[A-Za-z0-9_]+[`\"]?)/i',
@@ -726,7 +744,7 @@ class Schema implements ISchema
 
     if (!is_string($updatedQuery))
     {
-      throw new ORMException('Failed to rewrite the SQLite CREATE TABLE statement for schema alteration.');
+      throw new ORMException('Failed to rewrite the CREATE TABLE statement for schema alteration.');
     }
 
     return $updatedQuery;
@@ -737,12 +755,77 @@ class Schema implements ISchema
     return '__assegai_tmp_' . $tableName . '_' . str_replace('.', '', uniqid('', true));
   }
 
-  private static function executeSqliteStatement(PDO|IDataObject $connection, string $query): void
+  private static function executeDialectStatement(PDO|IDataObject $connection, string $query, SQLDialect $dialect): void
   {
     if (false === $connection->exec($query))
     {
       $errorMessage = json_encode($connection->errorInfo());
-      throw new ORMException($errorMessage ?: "Failed to execute SQLite statement: $query");
+      $label = strtolower($dialect->value);
+      throw new ORMException($errorMessage ?: "Failed to execute {$label} statement: $query");
+    }
+  }
+
+  private static function synchronizeRebuiltTableState(PDO|IDataObject $connection, string $tableName, SQLDialect $dialect): void
+  {
+    if ($dialect !== SQLDialect::POSTGRESQL) {
+      return;
+    }
+
+    self::synchronizePostgreSqlSequences($connection, $tableName);
+  }
+
+  private static function synchronizePostgreSqlSequences(PDO|IDataObject $connection, string $tableName): void
+  {
+    $tableLiteral = $connection->quote($tableName);
+    $sql = <<<SQL
+SELECT
+  a.attname AS column_name,
+  pg_get_serial_sequence(format('%I.%I', current_schema(), c.relname), a.attname) AS sequence_name
+FROM pg_attribute a
+JOIN pg_class c ON c.oid = a.attrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
+WHERE c.relkind = 'r'
+  AND n.nspname = current_schema()
+  AND c.relname = $tableLiteral
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+  AND (
+    a.attidentity IN ('a', 'd')
+    OR pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval(%'
+  )
+ORDER BY a.attnum
+SQL;
+
+    $statement = $connection->query($sql);
+
+    if (!$statement || !$statement->execute()) {
+      throw new ORMException("Failed to inspect PostgreSQL sequences for '$tableName'.");
+    }
+
+    /** @var array<int, array{column_name?: mixed, sequence_name?: mixed}> $rows */
+    $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+    foreach ($rows as $row) {
+      $columnName = is_string($row['column_name'] ?? null) ? $row['column_name'] : null;
+      $sequenceName = is_string($row['sequence_name'] ?? null) ? $row['sequence_name'] : null;
+
+      if ($columnName === null || $sequenceName === null || $sequenceName === '') {
+        continue;
+      }
+
+      $quotedSequenceName = $connection->quote($sequenceName);
+      $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::POSTGRESQL);
+      $quotedColumnName = SqlDialectHelper::quoteIdentifier($columnName, SQLDialect::POSTGRESQL);
+      $syncSql = <<<SQL
+SELECT setval(
+  $quotedSequenceName,
+  COALESCE((SELECT MAX($quotedColumnName) FROM $quotedTableName), 1),
+  (SELECT MAX($quotedColumnName) IS NOT NULL FROM $quotedTableName)
+)
+SQL;
+
+      self::executeDialectStatement($connection, $syncSql, SQLDialect::POSTGRESQL);
     }
   }
   /**
@@ -847,6 +930,7 @@ class Schema implements ISchema
   {
     return match ($dialect) {
       SQLDialect::SQLITE => self::getSQLiteTableDefinitionSql($connection, $tableName),
+      SQLDialect::POSTGRESQL => self::getPostgreSqlTableDefinitionSql($connection, $tableName),
       default => self::getMySqlTableDefinitionSql($connection, $tableName),
     };
   }
@@ -877,6 +961,23 @@ class Schema implements ISchema
     return is_string($result) ? $result : null;
   }
 
+  private static function getPostgreSqlTableDefinitionSql(PDO $connection, string $tableName): ?string
+  {
+    $tableFields = self::getPostgreSqlTableDescriptions($connection, $tableName);
+
+    if (empty($tableFields)) {
+      return null;
+    }
+
+    $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::POSTGRESQL);
+    $definitions = array_map(
+      fn(SQLTableDescription $field): string => '  ' . self::buildPostgreSqlColumnDefinition($field),
+      $tableFields,
+    );
+
+    return sprintf("CREATE TABLE %s (\n%s\n)", $quotedTableName, implode(",\n", $definitions));
+  }
+
   private static function getMySqlTableDescriptions(PDO $connection, string $tableName): array
   {
     $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::MYSQL);
@@ -894,15 +995,41 @@ class Schema implements ISchema
     $quotedTableName = $connection->quote($tableName);
     $sql = <<<SQL
 SELECT
-  column_name AS "Field",
-  data_type AS "Type",
-  CASE WHEN is_nullable = 'YES' THEN 'YES' ELSE 'NO' END AS "Null",
-  CASE WHEN column_default LIKE 'nextval(%' THEN 'PRI' ELSE '' END AS "Key",
-  column_default AS "Default",
-  CASE WHEN column_default LIKE 'nextval(%' THEN 'auto_increment' ELSE '' END AS "Extra"
-FROM information_schema.columns
-WHERE table_name = $quotedTableName
-ORDER BY ordinal_position
+  a.attname AS "Field",
+  pg_catalog.format_type(a.atttypid, a.atttypmod) AS "Type",
+  CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS "Null",
+  CASE
+    WHEN EXISTS (
+      SELECT 1
+      FROM pg_constraint con
+      WHERE con.conrelid = c.oid
+        AND con.contype = 'p'
+        AND a.attnum = ANY(con.conkey)
+    ) THEN 'PRI'
+    WHEN EXISTS (
+      SELECT 1
+      FROM pg_constraint con
+      WHERE con.conrelid = c.oid
+        AND con.contype = 'u'
+        AND a.attnum = ANY(con.conkey)
+    ) THEN 'UNI'
+    ELSE ''
+  END AS "Key",
+  pg_get_expr(ad.adbin, ad.adrelid) AS "Default",
+  CASE
+    WHEN a.attidentity IN ('a', 'd') OR pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval(%' THEN 'auto_increment'
+    ELSE ''
+  END AS "Extra"
+FROM pg_attribute a
+JOIN pg_class c ON c.oid = a.attrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
+WHERE c.relkind = 'r'
+  AND n.nspname = current_schema()
+  AND c.relname = $quotedTableName
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+ORDER BY a.attnum
 SQL;
 
     $statement = $connection->query($sql);
@@ -912,6 +1039,30 @@ SQL;
     }
 
     return $statement->fetchAll(PDO::FETCH_CLASS, SQLTableDescription::class);
+  }
+
+  private static function buildPostgreSqlColumnDefinition(SQLTableDescription $field): string
+  {
+    $columnName = SqlDialectHelper::quoteIdentifier((string) $field->Field, SQLDialect::POSTGRESQL);
+    $definition = $columnName . ' ' . (string) $field->Type;
+
+    if (($field->Null ?? 'YES') === 'NO') {
+      $definition .= ' NOT NULL';
+    }
+
+    if (is_string($field->Default) && $field->Default !== '') {
+      $definition .= ' DEFAULT ' . $field->Default;
+    } elseif (($field->Extra ?? '') === 'auto_increment') {
+      $definition .= ' GENERATED BY DEFAULT AS IDENTITY';
+    }
+
+    if (($field->Key ?? '') === 'PRI') {
+      $definition .= ' PRIMARY KEY';
+    } elseif (($field->Key ?? '') === 'UNI') {
+      $definition .= ' UNIQUE';
+    }
+
+    return $definition;
   }
 
   private static function getSQLiteTableDescriptions(PDO $connection, string $tableName): array

--- a/src/DataSource/Schema.php
+++ b/src/DataSource/Schema.php
@@ -544,7 +544,7 @@ class Schema implements ISchema
       }
 
       $tableField = $tableFieldMap[$columnName];
-      if (self::shouldModifyField($tableField, $columnAttribute))
+      if (self::shouldModifyField($tableField, $columnAttribute, $dialect))
       {
         $changes->change(new DDLChangeStatement($tableField->Field, $columnAttribute->getSqlDefinition($dialect)));
       }
@@ -585,11 +585,22 @@ class Schema implements ISchema
    * @param Column $columnAttribute
    * @return bool Returns true if the columnAttribute contains difference from the $tableField, false otherwise
    */
-  private static function shouldModifyField(SQLTableDescription $tableField, Column $columnAttribute): bool
+  private static function shouldModifyField(
+    SQLTableDescription $tableField,
+    Column $columnAttribute,
+    SQLDialect $dialect = SQLDialect::MYSQL,
+  ): bool
   {
     if ($tableField->Default !== $columnAttribute->default)
     {
-      return true;
+      if (
+        !($dialect === SQLDialect::POSTGRESQL
+        && ($tableField->Extra ?? '') === 'auto_increment'
+        && $columnAttribute->autoIncrement
+        && ($columnAttribute->default === null || $columnAttribute->default === ''))
+      ) {
+        return true;
+      }
     }
 
     if (
@@ -608,7 +619,7 @@ class Schema implements ISchema
       return true;
     }
 
-    if ($tableField->Type !== $columnAttribute->getFieldType())
+    if (!self::fieldTypesMatch($tableField, $columnAttribute, $dialect))
     {
       return true;
     }
@@ -619,6 +630,32 @@ class Schema implements ISchema
     }
 
     return false;
+  }
+
+  private static function fieldTypesMatch(SQLTableDescription $tableField, Column $columnAttribute, SQLDialect $dialect): bool
+  {
+    if ($dialect !== SQLDialect::POSTGRESQL)
+    {
+      return $tableField->Type === $columnAttribute->getFieldType();
+    }
+
+    $currentType = self::normalizePostgreSqlType((string) $tableField->Type);
+    $targetType = self::normalizePostgreSqlType($columnAttribute->getSqlDefinition(SQLDialect::POSTGRESQL)->getTypeExpression());
+
+    return $currentType === $targetType;
+  }
+
+  private static function normalizePostgreSqlType(string $type): string
+  {
+    $normalized = strtolower(trim($type));
+    $normalized = preg_replace('/\s+/', ' ', $normalized) ?? $normalized;
+    $normalized = str_replace('character varying', 'varchar', $normalized);
+    $normalized = str_replace('timestamp without time zone', 'timestamp', $normalized);
+    $normalized = str_replace('timestamp with time zone', 'timestamptz', $normalized);
+    $normalized = str_replace('double precision', 'double precision', $normalized);
+    $normalized = preg_replace('/\(\s*\)/', '', $normalized) ?? $normalized;
+
+    return $normalized;
   }
 
   private static function commitRebuiltSchemaChanges(PDO|IDataObject $connection, ReflectionClass $entityReflection, object $entityInstance, SchemaOptions $options, array $tableFields): bool
@@ -829,18 +866,23 @@ class Schema implements ISchema
     $quotedTableName = SqlDialectHelper::quoteIdentifier($tableName, SQLDialect::POSTGRESQL);
     $quotedColumnName = SqlDialectHelper::quoteIdentifier($columnName, SQLDialect::POSTGRESQL);
 
-    self::executeDialectStatement(
-      $connection,
-      sprintf(
-        'ALTER TABLE %s ALTER COLUMN %s TYPE %s',
-        $quotedTableName,
-        $quotedColumnName,
-        $columnDefinition->getTypeExpression(),
-      ),
-      SQLDialect::POSTGRESQL,
-    );
+    if (!self::postgreSqlFieldMatchesColumnDefinition($currentField, $columnDefinition)) {
+      self::executeDialectStatement(
+        $connection,
+        sprintf(
+          'ALTER TABLE %s ALTER COLUMN %s TYPE %s',
+          $quotedTableName,
+          $quotedColumnName,
+          $columnDefinition->getTypeExpression(),
+        ),
+        SQLDialect::POSTGRESQL,
+      );
+    }
 
     $defaultExpression = $columnDefinition->getDefaultExpression();
+    if ($columnDefinition->isAutoIncrement()) {
+      $defaultExpression = self::resolvePostgreSqlAutoIncrementDefault($connection, $tableName, $columnName, $currentField);
+    }
 
     if ($defaultExpression === null)
     {
@@ -886,6 +928,50 @@ class Schema implements ISchema
     }
 
     self::synchronizePostgreSqlColumnConstraints($connection, $tableName, $columnName, $currentField, $columnDefinition);
+  }
+
+  private static function postgreSqlFieldMatchesColumnDefinition(
+    ?SQLTableDescription $currentField,
+    \Assegai\Orm\Queries\Sql\SQLColumnDefinition $columnDefinition,
+  ): bool {
+    if (!$currentField instanceof SQLTableDescription) {
+      return false;
+    }
+
+    return self::normalizePostgreSqlType((string) $currentField->Type)
+      === self::normalizePostgreSqlType($columnDefinition->getTypeExpression());
+  }
+
+  private static function resolvePostgreSqlAutoIncrementDefault(
+    PDO|IDataObject $connection,
+    string $tableName,
+    string $columnName,
+    ?SQLTableDescription $currentField,
+  ): ?string {
+    if (is_string($currentField?->Default) && $currentField->Default !== '')
+    {
+      return $currentField->Default;
+    }
+
+    $tableLiteral = $connection->quote($tableName);
+    $columnLiteral = $connection->quote($columnName);
+    $statement = $connection->query(
+      "SELECT pg_get_serial_sequence($tableLiteral, $columnLiteral)"
+    );
+
+    if (!$statement || !$statement->execute())
+    {
+      throw new ORMException("Failed to resolve PostgreSQL serial sequence for '$tableName.$columnName'.");
+    }
+
+    $sequenceName = $statement->fetchColumn();
+
+    if (!is_string($sequenceName) || $sequenceName === '')
+    {
+      return null;
+    }
+
+    return sprintf('nextval(%s::regclass)', $connection->quote($sequenceName));
   }
 
   private static function synchronizePostgreSqlColumnConstraints(

--- a/src/Exceptions/DataSourceConnectionException.php
+++ b/src/Exceptions/DataSourceConnectionException.php
@@ -6,8 +6,14 @@ use Assegai\Orm\Enumerations\DataSourceType;
 
 class DataSourceConnectionException extends DataSourceException
 {
-  public function __construct(DataSourceType $type = DataSourceType::MYSQL)
+  public function __construct(DataSourceType $type = DataSourceType::MYSQL, ?string $reason = null)
   {
-    parent::__construct(sprintf("Connection Error: %s", $type->value));
+    $message = sprintf("Connection Error: %s", $type->value);
+
+    if ($reason) {
+      $message .= " - $reason";
+    }
+
+    parent::__construct($message);
   }
 }

--- a/src/Management/DatabaseManager.php
+++ b/src/Management/DatabaseManager.php
@@ -85,10 +85,11 @@ final class DatabaseManager
       $databaseName,
       $dataSource->getOptions()->charSet
     );
-    $client = $this->getManagementClient($dataSource, $databaseName);
+    $client = null;
 
     try
     {
+      $client = $this->getManagementClient($dataSource, $databaseName);
       $result = $client->exec($statement);
 
       if ($result === false)
@@ -103,7 +104,10 @@ final class DatabaseManager
     }
     finally
     {
-      $this->closeTemporaryManagementClient($dataSource, $client);
+      if ($client instanceof PDO)
+      {
+        $this->closeTemporaryManagementClient($dataSource, $client);
+      }
     }
   }
 
@@ -140,10 +144,12 @@ final class DatabaseManager
       return;
     }
 
-    $client = $this->getManagementClient($dataSource, $databaseName);
+    $client = null;
 
     try
     {
+      $client = $this->getManagementClient($dataSource, $databaseName);
+
       if ($dataSource->type === DataSourceType::POSTGRESQL)
       {
         $this->terminatePostgreSqlConnections($client, $databaseName);
@@ -165,7 +171,10 @@ final class DatabaseManager
     }
     finally
     {
-      $this->closeTemporaryManagementClient($dataSource, $client);
+      if ($client instanceof PDO)
+      {
+        $this->closeTemporaryManagementClient($dataSource, $client);
+      }
     }
   }
 

--- a/src/Management/DatabaseManager.php
+++ b/src/Management/DatabaseManager.php
@@ -3,6 +3,7 @@
 namespace Assegai\Orm\Management;
 
 use Assegai\Orm\Support\OrmRuntime;
+use Assegai\Orm\DataSource\DBFactory;
 use Assegai\Orm\DataSource\DataSource;
 use Assegai\Orm\DataSource\SQLCharacterSet;
 use Assegai\Orm\Enumerations\DataSourceType;
@@ -84,20 +85,25 @@ final class DatabaseManager
       $databaseName,
       $dataSource->getOptions()->charSet
     );
+    $client = $this->getManagementClient($dataSource, $databaseName);
 
     try
     {
-      $result = $dataSource->getClient()->exec($statement);
+      $result = $client->exec($statement);
 
       if ($result === false)
       {
         throw new DataSourceException("Failed to create database: $databaseName" .
-          PHP_EOL . print_r($dataSource->getClient()->errorInfo(), true));
+          PHP_EOL . print_r($client->errorInfo(), true));
       }
     }
     catch (PDOException $exception)
     {
       throw new DataSourceException($exception->getMessage());
+    }
+    finally
+    {
+      $this->closeTemporaryManagementClient($dataSource, $client);
     }
   }
 
@@ -134,21 +140,32 @@ final class DatabaseManager
       return;
     }
 
+    $client = $this->getManagementClient($dataSource, $databaseName);
+
     try
     {
-      $result = $dataSource->getClient()->exec(
+      if ($dataSource->type === DataSourceType::POSTGRESQL)
+      {
+        $this->terminatePostgreSqlConnections($client, $databaseName);
+      }
+
+      $result = $client->exec(
         self::buildDropDatabaseStatement($dataSource->type, $databaseName)
       );
 
       if ($result === false)
       {
         throw new DataSourceException("Failed to drop database: $databaseName" .
-          PHP_EOL . print_r($dataSource->getClient()->errorInfo(), true));
+          PHP_EOL . print_r($client->errorInfo(), true));
       }
     }
     catch (PDOException $exception)
     {
       throw new DataSourceException($exception->getMessage());
+    }
+    finally
+    {
+      $this->closeTemporaryManagementClient($dataSource, $client);
     }
   }
 
@@ -175,6 +192,8 @@ final class DatabaseManager
    */
   public function exists(DataSource $dataSource, string $databaseName, bool $logErrors = true): bool
   {
+    $client = null;
+
     try
     {
       if ($dataSource->type === DataSourceType::SQLITE)
@@ -189,12 +208,14 @@ final class DatabaseManager
         return file_exists($path);
       }
 
+      $client = $this->getManagementClient($dataSource, $databaseName);
+
       $query = match ($dataSource->type) {
         DataSourceType::POSTGRESQL => 'SELECT datname FROM pg_database WHERE datname = ?',
         default => 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?',
       };
 
-      $statement = $dataSource->getClient()->prepare($query);
+      $statement = $client->prepare($query);
       $statement->execute([$databaseName]);
       $result = $statement->fetch(PDO::FETCH_ASSOC);
 
@@ -208,6 +229,13 @@ final class DatabaseManager
       }
 
       return false;
+    }
+    finally
+    {
+      if ($client instanceof PDO)
+      {
+        $this->closeTemporaryManagementClient($dataSource, $client);
+      }
     }
   }
 
@@ -245,9 +273,44 @@ final class DatabaseManager
 
     return match ($type) {
       DataSourceType::MSSQL,
-      DataSourceType::POSTGRESQL => "DROP DATABASE $quotedDatabaseName",
+      DataSourceType::POSTGRESQL => "DROP DATABASE IF EXISTS $quotedDatabaseName",
       default => "DROP DATABASE IF EXISTS $quotedDatabaseName",
     };
+  }
+
+  private function getManagementClient(DataSource $dataSource, string $databaseName): PDO
+  {
+    if ($dataSource->type !== DataSourceType::POSTGRESQL)
+    {
+      return $dataSource->getClient();
+    }
+
+    $options = $dataSource->getOptions();
+    $maintenanceDatabase = $databaseName === 'postgres' ? 'template1' : 'postgres';
+    $client = new PDO(
+      DBFactory::buildPostgreSqlDsn($options->host, $options->port, $maintenanceDatabase),
+      $options->username ?? 'postgres',
+      $options->password ?? '',
+    );
+    DBFactory::applyConnectionAttributes($client, SqlDialectHelper::fromDataSourceType(DataSourceType::POSTGRESQL));
+
+    return $client;
+  }
+
+  private function closeTemporaryManagementClient(DataSource $dataSource, ?PDO &$client): void
+  {
+    if ($dataSource->type === DataSourceType::POSTGRESQL)
+    {
+      $client = null;
+    }
+  }
+
+  private function terminatePostgreSqlConnections(PDO $client, string $databaseName): void
+  {
+    $statement = $client->prepare(
+      'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = :database AND pid <> pg_backend_pid()'
+    );
+    $statement->execute(['database' => $databaseName]);
   }
 
   private static function quoteDatabaseIdentifier(DataSourceType $type, string $databaseName): string

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -19,6 +19,7 @@ use Assegai\Orm\Attributes\Relations\OneToOne;
 use Assegai\Orm\DataSource\DataSource;
 use Assegai\Orm\Enumerations\DataSourceType;
 use Assegai\Orm\Enumerations\RelationType;
+use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Exceptions\ClassNotFoundException;
 use Assegai\Orm\Exceptions\ContainerException;
 use Assegai\Orm\Exceptions\EmptyCriteriaException;
@@ -374,11 +375,16 @@ class EntityManager implements IEntityStoreOwner
 
     $this->query->insertInto(tableName: $this->entityInspector->getTableName(entity: $instance))->singleRow(columns: $columns)->values(valuesList: $values);
 
+    if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+      $this->query->appendQueryString('RETURNING ' . $this->buildReturningProjection($instance));
+    }
+
     if ($this->isDebug || $options?->isDebug) {
       $this->query->debug();
     }
 
     $result = $this->query->execute();
+    $raw = $result->getRaw();
 
     if ($result->isError()) {
       if (!headers_sent()) {
@@ -387,7 +393,25 @@ class EntityManager implements IEntityStoreOwner
       $error = new GeneralSQLQueryException($this->query);
       OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
 
-      return new InsertResult(identifiers: $entity, raw: $this->query->queryString(), generatedMaps: $result, errors: [$error]);
+      return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$error]);
+    }
+
+    if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+      $generatedMaps = $this->hydrateGeneratedMaps($entityClass, $result->getData()) ?? $instance;
+      $generatedMaps = $this->sanitizeGeneratedMaps($generatedMaps);
+      $identifierValue = $generatedMaps?->{$primaryKeyField} ?? $instance->{$primaryKeyField} ?? $this->lastInsertId();
+
+      if ($identifierValue !== null && $identifierValue !== '') {
+        $instance->{$primaryKeyField} = $identifierValue;
+      }
+
+      return new InsertResult(
+        identifiers: (object)[$primaryKeyField => $identifierValue],
+        raw: $raw,
+        generatedMaps: $generatedMaps,
+        errors: [],
+        affected: $this->query->rowCount() ?? 0,
+      );
     }
 
     # Find the record by the resolved primary key and hydrate the entity
@@ -401,7 +425,7 @@ class EntityManager implements IEntityStoreOwner
       $error = new GeneralSQLQueryException($this->query);
       OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
 
-      return new InsertResult(identifiers: $entity, raw: $this->query->queryString(), generatedMaps: $result, errors: [$result->getErrors()]);
+      return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$result->getErrors()]);
     }
 
     $entity = is_array($result->getData()) && array_is_list($result->getData())
@@ -419,7 +443,7 @@ class EntityManager implements IEntityStoreOwner
 
     $identifiers = is_array($entity) ? (object)$entity : $entity;
 
-    return new InsertResult(identifiers: $identifiers, raw: $this->query->queryString(), generatedMaps: $generatedMaps);
+    return new InsertResult(identifiers: $identifiers, raw: $raw, generatedMaps: $generatedMaps);
   }
 
   /**
@@ -442,7 +466,6 @@ class EntityManager implements IEntityStoreOwner
     if (!empty($entityLike)) {
       foreach ($entityLike as $entityLikePropertyName => $entityLikePropertyValue) {
         if (property_exists($entity, $entityLikePropertyName)) {
-          $entityLikeReflectionProperty = new ReflectionProperty($entityLike, $entityLikePropertyName);
           $entityClassReflectionProperty = new ReflectionProperty($entityClass, $entityLikePropertyName);
 
           if (is_null($entityLikePropertyValue)) {
@@ -453,10 +476,12 @@ class EntityManager implements IEntityStoreOwner
             }
           }
 
-          $entityLikeReflectionPropertyType = match (true) {
-            $entityLikeReflectionProperty->getType() instanceof ReflectionUnionType => strtolower(gettype($entityLikePropertyValue)),
-            default => $entityLikeReflectionProperty->getType()?->getName()
-          };
+          $entityLikeReflectionPropertyType = is_array($entityLike)
+            ? strtolower(gettype($entityLikePropertyValue))
+            : match (true) {
+              (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType() instanceof ReflectionUnionType => strtolower(gettype($entityLikePropertyValue)),
+              default => (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType()?->getName()
+            };
           $entityClassReflectionPropertyType = match (true) {
             $entityClassReflectionProperty->getType() instanceof ReflectionUnionType => strval($entityClassReflectionProperty->getType()),
             default => $entityClassReflectionProperty->getType()?->getName()
@@ -1631,7 +1656,7 @@ class EntityManager implements IEntityStoreOwner
       throw new ORMException("Empty criteria(s) are not allowed for the update method.");
     }
 
-    if (is_array($partialEntity)) {
+    if (is_array($partialEntity) && array_is_list($partialEntity)) {
       $raw = '';
       $affected = 0;
       $generatedMaps = new stdClass();
@@ -1705,20 +1730,46 @@ class EntityManager implements IEntityStoreOwner
       : $this->buildConditionClause($conditions, $this->query, $entityInstance);
     $statement->where(condition: $conditionString);
 
+    if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+      $this->query->appendQueryString('RETURNING ' . $this->buildReturningProjection($entityInstance));
+    }
+
     if ($this->isDebug || $options?->isDebug) {
       $this->query->debug();
     }
 
     $result = $this->query->execute();
+    $raw = $result->getRaw();
 
     if ($result->isError()) {
       throw new GeneralSQLQueryException($this->query);
     }
 
-    $updatedEntity = $this->findOne(entityClass: $entityClass, options: new FindOptions(where: $conditions));
-    $generatedMaps = $updatedEntity->getData() ?? new stdClass();
+    $generatedMaps = null;
 
-    return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: $partialEntity, generatedMaps: $generatedMaps);
+    if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+      $generatedMaps = $this->hydrateGeneratedMaps($entityClass, $result->getData());
+    }
+
+    if (!$generatedMaps) {
+      $updatedEntity = $this->findOne(entityClass: $entityClass, options: new FindOptions(where: $conditions));
+      $generatedMaps = $updatedEntity->getData() ?? new stdClass();
+    }
+
+    $generatedMaps = $this->sanitizeGeneratedMaps($generatedMaps);
+
+    $identifiers = is_array($partialEntity) ? (object)$partialEntity : $partialEntity;
+    if ($generatedMaps && is_object($generatedMaps)) {
+      $primaryKeyMetadata = $this->getPrimaryKeyMetadata($entityInstance);
+      $primaryKeyField = $primaryKeyMetadata['field'];
+      $identifierValue = $generatedMaps->{$primaryKeyField} ?? null;
+
+      if ($identifierValue !== null && $identifierValue !== '') {
+        $identifiers = (object)(array_merge((array)$identifiers, [$primaryKeyField => $identifierValue]));
+      }
+    }
+
+    return new UpdateResult(raw: $raw, affected: $this->query->rowCount(), identifiers: $identifiers, generatedMaps: $generatedMaps);
   }
 
   /**
@@ -1956,10 +2007,25 @@ class EntityManager implements IEntityStoreOwner
     $values = $this->entityInspector->getValues(entity: $entityOrEntities);
     $tableName = $this->entityInspector->getTableName(entity: $entityOrEntities);
 
-    if ($this->connection->type === DataSourceType::SQLITE) {
-      return $this->executeSqliteUpsert($tableName, $entityOrEntities, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn);
-    }
+    return match ($this->query->getDialect()) {
+      SQLDialect::SQLITE => $this->executeSqliteUpsert($tableName, $entityOrEntities, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
+      SQLDialect::POSTGRESQL => $this->executePostgreSqlUpsert($entityClass, $tableName, $entityOrEntities, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
+      default => $this->executeMySqlUpsert($entityClass, $tableName, $entityOrEntities, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
+    };
+  }
 
+  private function executeMySqlUpsert(
+    string $entityClass,
+    string $tableName,
+    object $entityOrEntities,
+    array $columns,
+    array $updateColumns,
+    array $values,
+    UpsertOptions $options,
+    string $primaryKeyField,
+    string $primaryColumn,
+  ): InsertResult
+  {
     $assignmentList = array_map(function($column): string {
       $column = $this->stripTableName($column);
       return "$column=VALUES($column)";
@@ -1974,6 +2040,7 @@ class EntityManager implements IEntityStoreOwner
     }
 
     $result = $this->query->execute();
+    $raw = $result->getRaw();
 
     $errors = [];
     if ($result->isError()) {
@@ -2009,7 +2076,7 @@ class EntityManager implements IEntityStoreOwner
 
     return new InsertResult(
       identifiers: (object)[$primaryKeyField => $identifierValue],
-      raw: $this->query->queryString(),
+      raw: $raw,
       generatedMaps: $generatedMaps,
       errors: $errors,
       affected: $this->query->rowCount() ?? 0,
@@ -2059,24 +2126,8 @@ class EntityManager implements IEntityStoreOwner
     $originalId = $entity->{$primaryKeyField} ?? null;
     $columns = array_map([$this, 'stripTableName'], array_values($columns));
     $updateColumns = array_map([$this, 'stripTableName'], array_values($updateColumns));
-    $conflictPaths = array_map([$this, 'stripTableName'], $options->conflictPaths ?: [$primaryColumn]);
-
-    $filteredColumns = [];
-    $filteredValues = [];
-
-    foreach ($columns as $index => $column) {
-      $value = $values[$index] ?? null;
-
-      if ($value === null && !in_array($column, $conflictPaths, true) && !in_array($column, $updateColumns, true)) {
-        continue;
-      }
-
-      $filteredColumns[] = $column;
-      $filteredValues[] = $value;
-    }
-
-    $columns = $filteredColumns;
-    $values = $filteredValues;
+    $conflictPaths = $this->resolveUpsertConflictColumns($entity, $options->conflictPaths ?: [$primaryColumn]);
+    [$columns, $values] = $this->filterNullableUpsertColumns($columns, $values, $conflictPaths, $updateColumns);
 
     $quotedColumns = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $columns));
     $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
@@ -2096,6 +2147,7 @@ class EntityManager implements IEntityStoreOwner
     }
 
     $result = $this->query->execute();
+    $raw = $result->getRaw();
     $errors = [];
 
     if ($result->isError()) {
@@ -2114,11 +2166,228 @@ class EntityManager implements IEntityStoreOwner
 
     return new InsertResult(
       identifiers: (object)[$primaryKeyField => $identifier],
-      raw: $this->query->queryString(),
+      raw: $raw,
       generatedMaps: $entity,
       errors: $errors,
       affected: $this->query->rowCount() ?? 0,
     );
+  }
+
+  private function executePostgreSqlUpsert(
+    string $entityClass,
+    string $tableName,
+    object $entity,
+    array $columns,
+    array $updateColumns,
+    array $values,
+    UpsertOptions $options,
+    string $primaryKeyField,
+    string $primaryColumn,
+  ): InsertResult
+  {
+    $originalId = $entity->{$primaryKeyField} ?? null;
+    $columns = array_map([$this, 'stripTableName'], array_values($columns));
+    $updateColumns = array_map([$this, 'stripTableName'], array_values($updateColumns));
+    $conflictPaths = $this->resolveUpsertConflictColumns($entity, $options->conflictPaths ?: [$primaryColumn]);
+    [$columns, $values] = $this->filterNullableUpsertColumns($columns, $values, $conflictPaths, $updateColumns);
+
+    $quotedColumns = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $columns));
+    $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
+    $placeholders = array_fill(0, count($values), '?');
+    $valueList = implode(', ', $placeholders);
+    $assignmentList = implode(', ', array_map(
+      fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()) . '=excluded.' . SqlIdentifier::quote($column, $this->query->getDialect()),
+      $updateColumns
+    ));
+    $conflictAction = empty($assignmentList) ? 'DO NOTHING' : "DO UPDATE SET $assignmentList";
+    $returning = $this->query->quoteIdentifier($primaryColumn) . ' AS ' . $this->query->quoteIdentifier($primaryKeyField);
+
+    $queryString = 'INSERT INTO ' . $this->query->quoteIdentifier($tableName)
+      . " ($quotedColumns) VALUES ($valueList) ON CONFLICT ($quotedConflictPaths) $conflictAction RETURNING $returning";
+
+    $this->query->init();
+    $this->query->insertInto(tableName: $tableName);
+    $this->query->setQueryString($queryString);
+    $this->query->addParams($values);
+
+    if ($this->isDebug) {
+      $this->query->debug();
+    }
+
+    $result = $this->query->execute();
+    $raw = $result->getRaw();
+    $errors = [];
+
+    if ($result->isError()) {
+      $errors[] = $this->query->getConnection()->errorInfo();
+      $errors[] = new GeneralSQLQueryException($this->query);
+    }
+
+    $identifierValue = $this->extractReturningIdentifier($result->getData(), $primaryKeyField, $primaryColumn)
+      ?? $originalId
+      ?? $this->lastInsertId();
+    $generatedMaps = $entity;
+
+    if ($result->isOk()) {
+      if ($identifierValue !== null && $identifierValue !== '') {
+        $entity->{$primaryKeyField} = $identifierValue;
+      }
+
+      $lookupConditions = $this->buildUpsertLookupConditions($entity, $options, $primaryKeyField);
+
+      if ($identifierValue !== null && $identifierValue !== '') {
+        $lookupConditions = [$primaryKeyField => $identifierValue];
+      }
+
+      if (!empty($lookupConditions)) {
+        $persistedResult = $this->findOne(entityClass: $entityClass, options: new FindOneOptions(where: $lookupConditions));
+        $persistedEntity = $persistedResult->getData();
+
+        if (is_object($persistedEntity)) {
+          $generatedMaps = $persistedEntity;
+          $identifierValue = $persistedEntity->{$primaryKeyField} ?? $identifierValue;
+        }
+      }
+    }
+
+    return new InsertResult(
+      identifiers: (object)[$primaryKeyField => $identifierValue],
+      raw: $raw,
+      generatedMaps: $generatedMaps,
+      errors: $errors,
+      affected: $this->query->rowCount() ?? 0,
+    );
+  }
+
+  private function resolveUpsertConflictColumns(object $entity, array $conflictPaths): array
+  {
+    $columnMap = [];
+
+    foreach ($this->entityInspector->getColumns($entity) as $field => $column) {
+      $columnName = $this->stripTableName($column);
+
+      if (is_string($field)) {
+        $columnMap[$field] = $columnName;
+      }
+
+      $columnMap[$columnName] = $columnName;
+    }
+
+    $resolved = array_map(function(string $conflictPath) use ($columnMap): string {
+      $conflictPath = $this->stripTableName($conflictPath);
+
+      return $columnMap[$conflictPath] ?? $conflictPath;
+    }, $conflictPaths);
+
+    return array_values(array_unique($resolved));
+  }
+
+  private function filterNullableUpsertColumns(array $columns, array $values, array $conflictPaths, array $updateColumns): array
+  {
+    $filteredColumns = [];
+    $filteredValues = [];
+
+    foreach ($columns as $index => $column) {
+      $value = $values[$index] ?? null;
+
+      if ($value === null && !in_array($column, $conflictPaths, true) && !in_array($column, $updateColumns, true)) {
+        continue;
+      }
+
+      $filteredColumns[] = $column;
+      $filteredValues[] = $value;
+    }
+
+    return [$filteredColumns, $filteredValues];
+  }
+
+  private function extractReturningIdentifier(array $rows, string $primaryKeyField, string $primaryColumn): mixed
+  {
+    $row = $rows[0] ?? null;
+
+    if (!is_array($row)) {
+      return null;
+    }
+
+    foreach ([$primaryKeyField, $primaryColumn, 'id'] as $key) {
+      if (array_key_exists($key, $row)) {
+        return $row[$key];
+      }
+    }
+
+    return null;
+  }
+
+  private function buildReturningProjection(object $entity): string
+  {
+    $projection = [];
+
+    foreach ($this->entityInspector->getColumns(entity: $entity) as $field => $column) {
+      $columnName = $this->stripTableName($column);
+      $alias = is_string($field) ? $field : $columnName;
+
+      $projection[] = $this->query->quoteIdentifier($columnName) . ' AS ' . $this->query->quoteIdentifier($alias);
+    }
+
+    return implode(', ', $projection);
+  }
+
+  private function hydrateGeneratedMaps(string $entityClass, array $rows): ?object
+  {
+    $row = $rows[0] ?? null;
+
+    if (!is_array($row)) {
+      return null;
+    }
+
+    $row = $this->normalizeReturnedRowForEntity($entityClass, $row);
+
+    return $this->create($entityClass, (object)$row);
+  }
+
+  private function normalizeReturnedRowForEntity(string $entityClass, array $row): array
+  {
+    $reflection = new ReflectionClass($entityClass);
+
+    foreach ($row as $property => $value) {
+      if (!is_string($property) || !property_exists($entityClass, $property)) {
+        continue;
+      }
+
+      if ($value === null) {
+        continue;
+      }
+
+      $propertyReflection = $reflection->getProperty($property);
+      $propertyType = $propertyReflection->getType();
+
+      if ($propertyType instanceof ReflectionUnionType || $propertyType === null) {
+        continue;
+      }
+
+      $targetType = $propertyType->getName();
+
+      if (enum_exists($targetType) && is_string($value) && method_exists($targetType, 'from')) {
+        $row[$property] = $targetType::from($value);
+      }
+    }
+
+    return $row;
+  }
+
+  private function sanitizeGeneratedMaps(?object $entity): ?object
+  {
+    if (!$entity) {
+      return null;
+    }
+
+    foreach ($this->getSecure() as $prop) {
+      if (property_exists($entity, $prop)) {
+        unset($entity->{$prop});
+      }
+    }
+
+    return $entity;
   }
 
   private function stripTableName(string $column): string
@@ -2140,23 +2409,35 @@ class EntityManager implements IEntityStoreOwner
   public function remove(object|array $entityOrEntities, ?RemoveOptions $removeOptions = null): DeleteResult
   {
     if (is_object($entityOrEntities)) {
-      $id = $entityOrEntities->id ?? 0;
+      $primaryKey = $this->getPrimaryKeyMetadata($entityOrEntities);
+      $primaryKeyField = $primaryKey['field'];
+      $primaryColumn = $primaryKey['column'];
+      $identifierValue = $entityOrEntities->{$primaryKeyField} ?? 0;
       $statement = $this->query
         ->deleteFrom(tableName: $this->entityInspector->getTableName(entity: $entityOrEntities));
-      $condition = $this->buildConditionClause(['id' => $id], $this->query, $entityOrEntities);
+      $condition = $this->buildConditionClause([$primaryKeyField => $identifierValue], $this->query, $entityOrEntities);
       $statement = $statement->where($condition);
+
+      if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+        $this->query->appendQueryString('RETURNING ' . $this->query->quoteIdentifier($primaryColumn));
+      }
 
       if ($this->isDebug) {
         $statement->debug();
       }
 
       $result = $statement->execute();
+      $raw = $result->getRaw();
 
       if ($result->isError()) {
         throw new GeneralSQLQueryException($this->query);
       }
 
-      return new DeleteResult(raw: $this->query->queryString(), affected: $result->getTotalAffectedRows());
+      $affected = $this->query->getDialect() === SQLDialect::POSTGRESQL
+        ? count($result->getData())
+        : $result->getTotalAffectedRows();
+
+      return new DeleteResult(raw: $raw, affected: $affected);
     }
 
     $affected = 0;

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -1223,7 +1223,7 @@ class EntityManager implements IEntityStoreOwner
       ->select()
       ->all(columns: $columns)
       ->from(tableReferences: $targetTable)
-      ->join("`$joinTableName`")
+      ->join($joinTableName)
       ->on("$joinTableName.$targetJoinColumn = $targetTable.id");
     $condition = $this->buildInCondition("$joinTableName.$localJoinColumn", $localIds, $query);
     if (!$condition) {
@@ -1484,7 +1484,7 @@ class EntityManager implements IEntityStoreOwner
 
     $query ??= $this->query;
 
-    return SqlIdentifier::quote($qualifiedColumn) . ' IN (' . implode(', ', $query->addParams(array_values($values))) . ')';
+    return SqlIdentifier::quote($qualifiedColumn, $query->getDialect()) . ' IN (' . implode(', ', $query->addParams(array_values($values))) . ')';
   }
 
   private function resolveRelationExcludeColumns(RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
@@ -1745,7 +1745,7 @@ class EntityManager implements IEntityStoreOwner
   private function buildConditionClause(int|object|array $conditions, SQLQuery $query, ?object $entity = null): string
   {
     if (is_int($conditions)) {
-      return SqlIdentifier::quote('id') . '=' . $query->addParam($conditions);
+      return SqlIdentifier::quote('id', $query->getDialect()) . '=' . $query->addParam($conditions);
     }
 
     $parts = [];
@@ -1754,7 +1754,7 @@ class EntityManager implements IEntityStoreOwner
       $columnName = $entity && is_string($key)
         ? $this->getColumnNameFromProperty($entity, $key)
         : (string)$key;
-      $identifier = SqlIdentifier::quote($columnName);
+      $identifier = SqlIdentifier::quote($columnName, $query->getDialect());
 
       if (is_null($value) || $value === 'NULL') {
         $parts[] = "$identifier IS NULL";
@@ -2078,14 +2078,14 @@ class EntityManager implements IEntityStoreOwner
     $columns = $filteredColumns;
     $values = $filteredValues;
 
-    $quotedColumns = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column), $columns));
-    $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column), $conflictPaths));
+    $quotedColumns = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $columns));
+    $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
     $placeholders = array_fill(0, count($values), '?');
     $valueList = implode(', ', $placeholders);
-    $assignmentList = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column) . '=excluded.' . SqlIdentifier::quote($column), $updateColumns));
+    $assignmentList = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()) . '=excluded.' . SqlIdentifier::quote($column, $this->query->getDialect()), $updateColumns));
     $conflictAction = empty($assignmentList) ? 'DO NOTHING' : "DO UPDATE SET $assignmentList";
 
-    $queryString = "INSERT INTO `$tableName` ($quotedColumns) VALUES ($valueList) ON CONFLICT ($quotedConflictPaths) $conflictAction";
+    $queryString = 'INSERT INTO ' . $this->query->quoteIdentifier($tableName) . " ($quotedColumns) VALUES ($valueList) ON CONFLICT ($quotedConflictPaths) $conflictAction";
     $this->query->init();
     $this->query->insertInto(tableName: $tableName);
     $this->query->setQueryString($queryString);

--- a/src/Management/Options/FindWhereOptions.php
+++ b/src/Management/Options/FindWhereOptions.php
@@ -4,6 +4,7 @@ namespace Assegai\Orm\Management\Options;
 
 use Assegai\Orm\Attributes\Columns\Column;
 use Assegai\Orm\Attributes\Entity;
+use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Exceptions\ORMException;
 use Assegai\Orm\Queries\Sql\SQLQuery;
 use Assegai\Orm\Util\SqlIdentifier;
@@ -87,6 +88,7 @@ final readonly class FindWhereOptions
     public function __toString(): string
     {
         return $this->buildConditionString(
+            dialect: SQLDialect::MYSQL,
             renderer: fn(string $identifier, mixed $value): string => match (true) {
                 is_null($value), $value === 'NULL' => "$identifier IS NULL",
                 is_array($value) && array_is_list($value) && !empty($value) => $identifier . ' IN (' . implode(', ', array_map(
@@ -99,16 +101,17 @@ final readonly class FindWhereOptions
     }
 
     /**
+     * @param SQLDialect $dialect
      * @param callable(string, mixed): string $renderer
      * @return string
      */
-    private function buildConditionString(callable $renderer): string
+    private function buildConditionString(SQLDialect $dialect, callable $renderer): string
     {
         $parts = [];
 
         foreach ($this->conditions as $key => $value) {
             $parts[] = $renderer(
-                $this->qualifyColumnName($this->resolveColumnName((string)$key)),
+                $this->qualifyColumnName($this->resolveColumnName((string)$key), $dialect),
                 $value
             );
         }
@@ -118,15 +121,16 @@ final readonly class FindWhereOptions
 
     /**
      * @param string $columnName
+     * @param SQLDialect $dialect
      * @return string
      */
-    private function qualifyColumnName(string $columnName): string
+    private function qualifyColumnName(string $columnName, SQLDialect $dialect = SQLDialect::MYSQL): string
     {
         $qualifiedColumn = $this->tableName
             ? "{$this->tableName}.{$columnName}"
             : $columnName;
 
-        return SqlIdentifier::quote($qualifiedColumn);
+        return SqlIdentifier::quote($qualifiedColumn, $dialect);
     }
 
     /**
@@ -188,6 +192,7 @@ final readonly class FindWhereOptions
     public function compile(SQLQuery $query): string
     {
         return $this->buildConditionString(
+            dialect: $query->getDialect(),
             renderer: function (string $identifier, mixed $value) use ($query): string {
                 if (is_null($value) || $value === 'NULL') {
                     return "$identifier IS NULL";

--- a/src/Queries/Sql/SQLAlterDefinition.php
+++ b/src/Queries/Sql/SQLAlterDefinition.php
@@ -24,7 +24,9 @@ final readonly class SQLAlterDefinition
    */
   public function database(string $databaseName): SQLAlterDatabaseOption
   {
-    $this->query->setQueryString(queryString: "ALTER DATABASE `$databaseName`");
+    $this->query->setQueryString(
+      queryString: 'ALTER DATABASE ' . $this->query->quoteIdentifier($databaseName)
+    );
     return new SQLAlterDatabaseOption( query: $this->query );
   }
 
@@ -36,7 +38,9 @@ final readonly class SQLAlterDefinition
    */
   public function table(string $tableName): SQLAlterTableOption
   {
-    $this->query->setQueryString(queryString: "ALTER TABLE `$tableName`");
+    $this->query->setQueryString(
+      queryString: 'ALTER TABLE ' . $this->query->quoteIdentifier($tableName)
+    );
     return new SQLAlterTableOption( query: $this->query );
   }
 }

--- a/src/Queries/Sql/SQLAlterTableOption.php
+++ b/src/Queries/Sql/SQLAlterTableOption.php
@@ -30,14 +30,14 @@ final class SQLAlterTableOption
    */
   public function addColumn(SQLColumnDefinition $dataType, ?bool $first = false, ?string $afterColumn = null): SQLAlterTableOption
   {
-    $this->query->appendQueryString(tail: "ADD $dataType");
-    if ($first)
+    $this->query->appendQueryString(tail: "ADD COLUMN $dataType");
+    if ($first && in_array($this->query->getDialect(), [\Assegai\Orm\Enumerations\SQLDialect::MYSQL, \Assegai\Orm\Enumerations\SQLDialect::MARIADB], true))
     {
       $this->query->appendQueryString(tail: "FIRST");
     }
-    else if (!is_null($afterColumn))
+    else if (!is_null($afterColumn) && in_array($this->query->getDialect(), [\Assegai\Orm\Enumerations\SQLDialect::MYSQL, \Assegai\Orm\Enumerations\SQLDialect::MARIADB], true))
     {
-      $this->query->appendQueryString(tail: "AFTER `$afterColumn`");
+      $this->query->appendQueryString(tail: "AFTER " . $this->query->quoteIdentifier($afterColumn));
     }
     return $this;
   }
@@ -63,7 +63,9 @@ final class SQLAlterTableOption
    */
   public function renameColumn(string $oldColumnName, string $newColumnName): SQLAlterTableOption
   {
-    $this->query->appendQueryString(tail: "RENAME COLUMN `$oldColumnName` TO `$newColumnName`");
+    $this->query->appendQueryString(
+      tail: "RENAME COLUMN {$this->query->quoteIdentifier($oldColumnName)} TO {$this->query->quoteIdentifier($newColumnName)}"
+    );
     return $this;
   }
 
@@ -75,7 +77,7 @@ final class SQLAlterTableOption
    */
   public function dropColumn(string $columnName): SQLAlterTableOption
   {
-    $this->query->appendQueryString(tail: "DROP COLUMN `$columnName`");
+    $this->query->appendQueryString(tail: "DROP COLUMN " . $this->query->quoteIdentifier($columnName));
     return $this;
   }
 }

--- a/src/Queries/Sql/SQLAssignmentList.php
+++ b/src/Queries/Sql/SQLAssignmentList.php
@@ -23,16 +23,18 @@ final class SQLAssignmentList
     $separator = ', ';
     foreach ($assignmentList as $key => $value)
     {
-      if (in_array($key, $this->query->passwordHashFields()))
+      $identifier = $this->query->quoteIdentifier((string)$key);
+
+      if (in_array($key, $this->query->passwordHashFields(), true))
       {
         $value = password_hash($value, $this->query->passwordHashAlgorithm());
       }
       if (is_string($value) && $value === 'CURRENT_TIMESTAMP') {
-        $queryString .= "`$key`={$value}{$separator}";
+        $queryString .= $identifier . "={$value}{$separator}";
         continue;
       }
 
-      $queryString .= "`$key`=" . $this->query->addParam($value) . $separator;
+      $queryString .= $identifier . '=' . $this->query->addParam($value) . $separator;
     }
     $queryString = trim($queryString, $separator);
     $this->query->appendQueryString( tail: $queryString );

--- a/src/Queries/Sql/SQLColumnDefinition.php
+++ b/src/Queries/Sql/SQLColumnDefinition.php
@@ -65,6 +65,44 @@ class SQLColumnDefinition implements Stringable
     return $this->queryString();
   }
 
+  public function getTypeExpression(): string
+  {
+    return match ($this->dialect) {
+      SQLDialect::POSTGRESQL => $this->getPostgreSqlType(),
+      SQLDialect::SQLITE => $this->getSqliteType(),
+      default => $this->type->value,
+    };
+  }
+
+  public function getDefaultExpression(): ?string
+  {
+    if (is_null($this->defaultValue)) {
+      return null;
+    }
+
+    return $this->normalizeDefaultValue($this->defaultValue);
+  }
+
+  public function isNullable(): bool
+  {
+    return $this->nullable;
+  }
+
+  public function isAutoIncrement(): bool
+  {
+    return $this->autoIncrement;
+  }
+
+  public function isUnique(): bool
+  {
+    return $this->isUnique;
+  }
+
+  public function isPrimaryKey(): bool
+  {
+    return $this->isPrimaryKey;
+  }
+
   private function buildMySqlDefinition(): string
   {
     $queryString = $this->getQuotedColumnName() . ' ';

--- a/src/Queries/Sql/SQLDeleteFromStatement.php
+++ b/src/Queries/Sql/SQLDeleteFromStatement.php
@@ -21,11 +21,11 @@ final class SQLDeleteFromStatement
     private readonly ?string $alias = null
   )
   {
-    $tableName = str_replace('`', '', $tableName);
-    $queryString = "DELETE FROM `$tableName`";
+    $tableName = str_replace(['`', '"'], '', $tableName);
+    $queryString = 'DELETE FROM ' . $this->query->quoteIdentifier($tableName);
     if (!is_null($alias))
     {
-      $queryString .= "AS $alias";
+      $queryString .= ' AS ' . $this->query->quoteIdentifier($alias);
     }
     $this->query->setQueryString(queryString: $queryString);
   }

--- a/src/Queries/Sql/SQLInsertIntoDefinition.php
+++ b/src/Queries/Sql/SQLInsertIntoDefinition.php
@@ -13,7 +13,7 @@ final readonly class SQLInsertIntoDefinition
     private string   $tableName
   )
   {
-    $queryString = "INSERT INTO `$this->tableName` ";
+    $queryString = 'INSERT INTO ' . $this->query->quoteIdentifier($this->tableName) . ' ';
 
     $this->query->setQueryString($queryString);
   }

--- a/src/Queries/Sql/SQLInsertIntoMultipleStatement.php
+++ b/src/Queries/Sql/SQLInsertIntoMultipleStatement.php
@@ -21,17 +21,16 @@ final class SQLInsertIntoMultipleStatement
     private readonly array $columns
   )
   {
-    $queryString = "";
+    $queryString = '';
     $columns = array_map(function(string $column): string {
       $parts = explode('.', $column);
       return end($parts);
     }, array_values($columns));
-    
-    if (!empty($columns))
-    {
-      $quotedColumns = array_map(fn(string $column): string => "`$column`", $columns);
-      $queryString = "(" . implode(', ', $quotedColumns) . ") ";
-      $this->hashableIndexes = array_keys( array_intersect( $columns, $this->query->passwordHashFields() ) );
+
+    if (!empty($columns)) {
+      $quotedColumns = array_map(fn(string $column): string => $this->query->quoteIdentifier($column), $columns);
+      $queryString = '(' . implode(', ', $quotedColumns) . ') ';
+      $this->hashableIndexes = array_keys(array_intersect($columns, $this->query->passwordHashFields()));
     }
 
     $this->query->appendQueryString($queryString);
@@ -43,31 +42,29 @@ final class SQLInsertIntoMultipleStatement
    */
   public function rows(array $rowsList): SQLInsertIntoMultipleStatement
   {
-    $queryString = "VALUES ";
+    $rowGroups = [];
     $separator = ', ';
 
-    foreach ($rowsList as $row)
-    {
-      $queryString .= "ROW(";
-      foreach ($row as $index => $value)
-      {
-        if (in_array($index, $this->hashableIndexes))
-        {
+    foreach ($rowsList as $row) {
+      $rowQuery = '';
+
+      foreach ($row as $index => $value) {
+        if (in_array($index, $this->hashableIndexes, true)) {
           $value = password_hash($value, $this->query->passwordHashAlgorithm());
         }
 
         if (is_string($value) && in_array($value, ['CURRENT_TIMESTAMP', 'NULL'], true)) {
-          $queryString .= "{$value}{$separator}";
+          $rowQuery .= $value . $separator;
           continue;
         }
 
-        $queryString .= $this->query->addParam($value) . $separator;
+        $rowQuery .= $this->query->addParam($value) . $separator;
       }
-      $queryString = trim($queryString, $separator);
-      $queryString .= ")$separator";
+
+      $rowGroups[] = '(' . trim($rowQuery, $separator) . ')';
     }
-    $queryString = trim($queryString, $separator);
-    $this->query->appendQueryString(tail: $queryString);
+
+    $this->query->appendQueryString(tail: 'VALUES ' . implode($separator, $rowGroups));
     return $this;
   }
 }

--- a/src/Queries/Sql/SQLInsertIntoStatement.php
+++ b/src/Queries/Sql/SQLInsertIntoStatement.php
@@ -21,24 +21,24 @@ final class SQLInsertIntoStatement
    */
   public function __construct(private readonly SQLQuery $query, private readonly array $columns = [])
   {
-    $queryString = "";
+    $queryString = '';
     $columns = array_map(function(string $column): string {
       $parts = explode('.', $column);
       return end($parts);
     }, array_values($columns));
 
     if (!empty($columns)) {
-      $quotedColumns = array_map(fn(string $column): string => "`$column`", $columns);
-      $queryString = "(" . implode(', ', $quotedColumns) . ") ";
+      $quotedColumns = array_map(fn(string $column): string => $this->query->quoteIdentifier($column), $columns);
+      $queryString = '(' . implode(', ', $quotedColumns) . ') ';
 
       $columnIndex = 0;
       foreach ($columns as $index => $column) {
         if (is_numeric($index)) {
-          if (in_array($column, $this->query->passwordHashFields())) {
+          if (in_array($column, $this->query->passwordHashFields(), true)) {
             $this->hashableIndexes[] = $index;
           }
         } else {
-          if (in_array($index, $this->query->passwordHashFields())) {
+          if (in_array($index, $this->query->passwordHashFields(), true)) {
             $this->hashableIndexes[] = $columnIndex;
           }
         }
@@ -55,11 +55,11 @@ final class SQLInsertIntoStatement
    */
   public function values(array $valuesList): SQLInsertIntoStatement
   {
-    $queryString = "VALUES(";
+    $queryString = 'VALUES(';
     $separator = ', ';
 
     foreach ($valuesList as $index => $value) {
-      if (in_array($index, $this->hashableIndexes)) {
+      if (in_array($index, $this->hashableIndexes, true)) {
         $value = password_hash($value, $this->query->passwordHashAlgorithm());
       }
 
@@ -71,7 +71,7 @@ final class SQLInsertIntoStatement
       $queryString .= $this->query->addParam($value) . $separator;
     }
 
-    $queryString = trim(string: $queryString, characters: $separator) . ") ";
+    $queryString = trim(string: $queryString, characters: $separator) . ') ';
     $this->query->appendQueryString($queryString);
     return $this;
   }

--- a/src/Queries/Sql/SQLJoinExpression.php
+++ b/src/Queries/Sql/SQLJoinExpression.php
@@ -21,12 +21,13 @@ final class SQLJoinExpression
       $this->joinType = JoinType::JOIN;
     }
 
+    $joinReferences = $this->formatJoinTableReferences($this->joinTableReferences);
     $queryString = match($this->joinType) {
-      JoinType::LEFT_JOIN => "LEFT JOIN $this->joinTableReferences",
-      JoinType::RIGHT_JOIN => "RIGHT JOIN $this->joinTableReferences",
-      JoinType::INNER_JOIN => "INNER JOIN $this->joinTableReferences",
-      JoinType::OUTER_JOIN => "OUTER JOIN $this->joinTableReferences",
-      default => "JOIN $this->joinTableReferences"
+      JoinType::LEFT_JOIN => "LEFT JOIN $joinReferences",
+      JoinType::RIGHT_JOIN => "RIGHT JOIN $joinReferences",
+      JoinType::INNER_JOIN => "INNER JOIN $joinReferences",
+      JoinType::OUTER_JOIN => "OUTER JOIN $joinReferences",
+      default => "JOIN $joinReferences"
     };
 
     $this->query->appendQueryString(tail: $queryString);
@@ -48,5 +49,25 @@ final class SQLJoinExpression
   public function using(array $joinColumnList): SQLJoinSpecification
   {
     return new SQLJoinSpecification(query: $this->query, conditionOrList: $joinColumnList, isUsing: true);
+  }
+
+  private function formatJoinTableReferences(array|string $tableReferences): string
+  {
+    if (is_string($tableReferences)) {
+      return $this->query->quoteIdentifier($tableReferences);
+    }
+
+    $parts = [];
+
+    foreach ($tableReferences as $alias => $reference) {
+      if (is_numeric($alias)) {
+        $parts[] = $this->query->quoteIdentifier((string)$reference);
+        continue;
+      }
+
+      $parts[] = $this->query->quoteIdentifier((string)$reference) . ' AS ' . $this->query->quoteIdentifier((string)$alias);
+    }
+
+    return implode(', ', $parts);
   }
 }

--- a/src/Queries/Sql/SQLJoinSpecification.php
+++ b/src/Queries/Sql/SQLJoinSpecification.php
@@ -22,7 +22,7 @@ final class SQLJoinSpecification
   ) {
     $specification =
       is_array($conditionOrList)
-      ? '(' . implode(',', $conditionOrList) . ')'
+      ? '(' . implode(', ', array_map(fn(string $identifier): string => $this->query->quoteIdentifier($identifier), $conditionOrList)) . ')'
       : $conditionOrList;
 
     $queryString = $isUsing ? "USING $specification" : "ON $specification";

--- a/src/Queries/Sql/SQLKeyPart.php
+++ b/src/Queries/Sql/SQLKeyPart.php
@@ -2,6 +2,7 @@
 
 namespace Assegai\Orm\Queries\Sql;
 
+use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Util\SqlIdentifier;
 use JsonSerializable;
 
@@ -27,13 +28,15 @@ final class SQLKeyPart implements JsonSerializable
    * @param bool|null $ascending Sort specifier. If set to `true`, appends 
    * `ASC` to resulting Sql. If set to `false`, appends `DESC` to
    * resulting Sql. If set to `null` then omits sorting string.
+   * @param SQLDialect $dialect The SQL dialect to render identifiers for.
    */
   public function __construct(
     private readonly string $key,
-    private readonly ?bool $ascending = null
+    private readonly ?bool $ascending = null,
+    private readonly SQLDialect $dialect = SQLDialect::MYSQL
   )
   {
-    $this->queryString = SqlIdentifier::quote($this->key);
+    $this->queryString = SqlIdentifier::quote($this->key, $this->dialect);
 
     if (!is_null($this->ascending)) {
       $this->queryString .= $this->ascending ? ' ASC' : ' DESC';

--- a/src/Queries/Sql/SQLLimitClause.php
+++ b/src/Queries/Sql/SQLLimitClause.php
@@ -2,6 +2,7 @@
 
 namespace Assegai\Orm\Queries\Sql;
 
+use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Traits\ExecutableTrait;
 
 final class SQLLimitClause
@@ -19,7 +20,12 @@ final class SQLLimitClause
     private readonly ?int     $offset = null,
   )
   {
-    $queryString = "LIMIT " . (!is_null($offset) ? "$offset,$limit" : "$limit");
+    $queryString = match (true) {
+      is_null($offset) => "LIMIT $limit",
+      $this->query->getDialect() === SQLDialect::POSTGRESQL => "LIMIT $limit OFFSET $offset",
+      default => "LIMIT $offset,$limit",
+    };
+
     $this->query->appendQueryString($queryString);
   }
 }

--- a/src/Queries/Sql/SQLQuery.php
+++ b/src/Queries/Sql/SQLQuery.php
@@ -89,6 +89,9 @@ final class SQLQuery
         $this->queryString = '';
         $this->type = '';
         $this->params = [];
+        $this->lastInsertId = null;
+        $this->rowCount = null;
+        $this->columnCount = null;
     }
 
     /**
@@ -382,17 +385,17 @@ final class SQLQuery
 
                 $data = match ($this->type()) {
                     SQLQueryType::SELECT => $statement->fetchAll(mode: $this->fetchMode),
-                    default => []
+                    default => $this->queryReturnsRows()
+                        ? $statement->fetchAll(mode: PDO::FETCH_ASSOC)
+                        : []
                 };
 
                 if ($this->type() === SQLQueryType::INSERT) {
-                    $this->lastInsertId = $this->db->lastInsertId();
-                    if ($this->lastInsertId && isset($data['id'])) {
-                        $data['id'] = $this->lastInsertId;
-                    }
+                    $this->lastInsertId = $this->resolveLastInsertId($data);
                 }
 
                 $this->rowCount = $statement->rowCount();
+                $this->columnCount = $statement->columnCount();
 
                 return new SQLQueryResult(data: $data, errors: [], raw: $this->queryString, affected: $statement->rowCount());
             }
@@ -460,5 +463,61 @@ final class SQLQuery
     public function debug(): never
     {
         exit($this . PHP_EOL);
+    }
+
+    private function queryReturnsRows(): bool
+    {
+        return str_contains(strtoupper($this->queryString), 'RETURNING ');
+    }
+
+    private function resolveLastInsertId(array $data): ?int
+    {
+        $lastInsertId = $this->safeLastInsertId();
+
+        if ($lastInsertId !== null && $lastInsertId > 0) {
+            return $lastInsertId;
+        }
+
+        return $this->resolveLastInsertIdFromReturningData($data);
+    }
+
+    private function safeLastInsertId(): ?int
+    {
+        try {
+            $lastInsertId = $this->db->lastInsertId();
+        } catch (PDOException) {
+            return null;
+        }
+
+        if (!is_numeric($lastInsertId)) {
+            return null;
+        }
+
+        $lastInsertId = (int) $lastInsertId;
+
+        return $lastInsertId > 0 ? $lastInsertId : null;
+    }
+
+    private function resolveLastInsertIdFromReturningData(array $data): ?int
+    {
+        $firstRow = $data[0] ?? null;
+
+        if (!is_array($firstRow)) {
+            return null;
+        }
+
+        foreach (['id', 'Id'] as $key) {
+            if (isset($firstRow[$key]) && is_numeric($firstRow[$key])) {
+                return (int) $firstRow[$key];
+            }
+        }
+
+        foreach ($firstRow as $value) {
+            if (is_numeric($value)) {
+                return (int) $value;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Queries/Sql/SQLQuery.php
+++ b/src/Queries/Sql/SQLQuery.php
@@ -2,8 +2,11 @@
 
 namespace Assegai\Orm\Queries\Sql;
 
+use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Exceptions\ORMException;
 use Assegai\Orm\Support\OrmRuntime;
+use Assegai\Orm\Util\SqlIdentifier;
+use Assegai\Orm\Util\SqlDialectHelper;
 use DateTimeInterface;
 use PDO;
 use PDOException;
@@ -39,6 +42,10 @@ final class SQLQuery
      * @var int|null The number of columns affected by the query.
      */
     private ?int $columnCount = null;
+    /**
+     * @var SQLDialect The SQL dialect used for rendering queries.
+     */
+    private readonly SQLDialect $dialect;
 
     /**
      * Constructs a new SQLQuery instance.
@@ -49,6 +56,7 @@ final class SQLQuery
      * @param array $fetchClassParams The parameters to pass to the fetch class.
      * @param array $passwordHashFields The fields to hash.
      * @param string $passwordHashAlgorithm The algorithm to use for hashing.
+     * @param SQLDialect|null $dialect The SQL dialect to render queries for.
      */
     public function __construct(
         private readonly PDO    $db,
@@ -56,9 +64,11 @@ final class SQLQuery
         private readonly int    $fetchMode = PDO::FETCH_ASSOC,
         private readonly array  $fetchClassParams = [],
         private readonly array  $passwordHashFields = ['password'],
-        private string          $passwordHashAlgorithm = ''
+        private string          $passwordHashAlgorithm = '',
+        ?SQLDialect             $dialect = null
     )
     {
+        $this->dialect = $dialect ?? SqlDialectHelper::fromPdo($db);
         if (empty($this->passwordHashAlgorithm)) {
             $this->passwordHashAlgorithm = OrmRuntime::defaultPasswordHashAlgorithm();
 
@@ -129,6 +139,27 @@ final class SQLQuery
     public function queryString(): string
     {
         return $this->queryString;
+    }
+
+    /**
+     * Returns the SQL dialect used for query rendering.
+     *
+     * @return SQLDialect
+     */
+    public function getDialect(): SQLDialect
+    {
+        return $this->dialect;
+    }
+
+    /**
+     * Quotes an SQL identifier for the current query dialect.
+     *
+     * @param string $identifier
+     * @return string
+     */
+    public function quoteIdentifier(string $identifier): string
+    {
+        return SqlIdentifier::quote($identifier, $this->dialect);
     }
 
     /**

--- a/src/Queries/Sql/SQLRenameTableStatement.php
+++ b/src/Queries/Sql/SQLRenameTableStatement.php
@@ -2,6 +2,8 @@
 
 namespace Assegai\Orm\Queries\Sql;
 
+use Assegai\Orm\Enumerations\SQLDialect;
+
 final class SQLRenameTableStatement
 {
   private string $queryString = '';
@@ -17,7 +19,14 @@ final class SQLRenameTableStatement
     private readonly string   $newTableName,
   )
   {
-    $this->queryString = "RENAME TABLE `$oldTableName` TO `$newTableName`";
+    $quotedOldTableName = $this->query->quoteIdentifier($oldTableName);
+    $quotedNewTableName = $this->query->quoteIdentifier($newTableName);
+
+    $this->queryString = match ($this->query->getDialect()) {
+      SQLDialect::POSTGRESQL,
+      SQLDialect::SQLITE => "ALTER TABLE $quotedOldTableName RENAME TO $quotedNewTableName",
+      default => "RENAME TABLE $quotedOldTableName TO $quotedNewTableName",
+    };
     $this->query->setQueryString($this->queryString);
   }
 

--- a/src/Queries/Sql/SQLSelectDefinition.php
+++ b/src/Queries/Sql/SQLSelectDefinition.php
@@ -2,6 +2,9 @@
 
 namespace Assegai\Orm\Queries\Sql;
 
+use Assegai\Orm\Util\SqlIdentifier;
+use InvalidArgumentException;
+
 final class SQLSelectDefinition
 {
   /**
@@ -9,7 +12,7 @@ final class SQLSelectDefinition
    */
   public function __construct(private readonly SQLQuery $query)
   {
-    $queryString = "SELECT ";
+    $queryString = 'SELECT ';
     $this->query->setQueryString(queryString: $queryString);
   }
 
@@ -32,7 +35,7 @@ final class SQLSelectDefinition
    */
   public function count(array $columns = []): SQLSelectExpression
   {
-    $queryString = "COUNT(" . $this->getColumnListString(columns: $columns) . ') as total';
+    $queryString = 'COUNT(' . $this->getColumnListString(columns: $columns) . ') as total';
 
     $this->query->appendQueryString($queryString);
 
@@ -45,7 +48,7 @@ final class SQLSelectDefinition
    */
   public function avg(array $columns = []): SQLSelectExpression
   {
-    $queryString = "AVG(" . $this->getColumnListString(columns: $columns) . ')';
+    $queryString = 'AVG(' . $this->getColumnListString(columns: $columns) . ')';
 
     $this->query->appendQueryString($queryString);
 
@@ -58,7 +61,7 @@ final class SQLSelectDefinition
    */
   public function sum(array $columns = []): SQLSelectExpression
   {
-    $queryString = "SUM(" . $this->getColumnListString(columns: $columns) . ')';
+    $queryString = 'SUM(' . $this->getColumnListString(columns: $columns) . ')';
 
     $this->query->appendQueryString($queryString);
 
@@ -80,13 +83,29 @@ final class SQLSelectDefinition
     $separator = ', ';
 
     if (empty($columns)) {
-      $columnListString .= "*";
+      $columnListString .= '*';
     } else {
       foreach ($columns as $key => $value) {
-        $columnListString .= is_numeric($key) ? "{$value}{$separator}" : "$value as `{$key}`{$separator}";
+        $expression = $this->formatColumnExpression((string)$value);
+        $columnListString .= is_numeric($key)
+          ? "{$expression}{$separator}"
+          : $expression . ' AS ' . $this->query->quoteIdentifier((string)$key) . $separator;
       }
     }
 
     return trim($columnListString, $separator);
+  }
+
+  private function formatColumnExpression(string $expression): string
+  {
+    if ($expression === '*') {
+      return '*';
+    }
+
+    try {
+      return SqlIdentifier::quote($expression, $this->query->getDialect());
+    } catch (InvalidArgumentException) {
+      return $expression;
+    }
   }
 }

--- a/src/Queries/Sql/SQLTableReference.php
+++ b/src/Queries/Sql/SQLTableReference.php
@@ -22,12 +22,12 @@ final class SQLTableReference
     private readonly SQLQuery $query,
     private readonly array|string $tableReferences
   ) {
-    $queryString = "FROM ";
+    $queryString = 'FROM ';
     $separate = ', ';
 
     if (is_string($tableReferences))
     {
-      $queryString .= "`$tableReferences`";
+      $queryString .= $this->query->quoteIdentifier($tableReferences);
     }
     else
     {
@@ -35,12 +35,11 @@ final class SQLTableReference
       {
         if (is_numeric($alias))
         {
-          # We don't have an alias
-          $queryString .= "`{$reference}`{$separate}";
+          $queryString .= $this->query->quoteIdentifier((string)$reference) . $separate;
         }
         else
         {
-          $queryString .= "`{$reference}` AS {$alias}{$separate}";
+          $queryString .= $this->query->quoteIdentifier((string)$reference) . ' AS ' . $this->query->quoteIdentifier((string)$alias) . $separate;
         }
       }
       $queryString = trim($queryString, $separate);

--- a/src/Queries/Sql/SQLUpdateDefinition.php
+++ b/src/Queries/Sql/SQLUpdateDefinition.php
@@ -23,18 +23,18 @@ final readonly class SQLUpdateDefinition
     private bool     $ignore =  false
   )
   {
-    $queryString = "UPDATE ";
+    $queryString = 'UPDATE ';
 
     if ($this->lowPriority) {
-      $queryString .= "LOW_PRIORITY ";
+      $queryString .= 'LOW_PRIORITY ';
     }
 
     if ($this->ignore) {
-      $queryString .= "IGNORE ";
+      $queryString .= 'IGNORE ';
     }
 
     $queryString = trim($queryString);
-    $this->query->setQueryString(queryString: "$queryString `$this->tableName`");
+    $this->query->setQueryString(queryString: $queryString . ' ' . $this->query->quoteIdentifier($this->tableName));
   }
 
   /**

--- a/src/Queries/Sql/SQLUpdateDefinition.php
+++ b/src/Queries/Sql/SQLUpdateDefinition.php
@@ -2,6 +2,8 @@
 
 namespace Assegai\Orm\Queries\Sql;
 
+use Assegai\Orm\Enumerations\SQLDialect;
+
 /**
  * Class SQLUpdateDefinition
  *
@@ -25,11 +27,11 @@ final readonly class SQLUpdateDefinition
   {
     $queryString = 'UPDATE ';
 
-    if ($this->lowPriority) {
+    if ($this->lowPriority && in_array($this->query->getDialect(), [SQLDialect::MYSQL, SQLDialect::MARIADB], true)) {
       $queryString .= 'LOW_PRIORITY ';
     }
 
-    if ($this->ignore) {
+    if ($this->ignore && in_array($this->query->getDialect(), [SQLDialect::MYSQL, SQLDialect::MARIADB], true)) {
       $queryString .= 'IGNORE ';
     }
 

--- a/src/Traits/SQLAggregatorTrait.php
+++ b/src/Traits/SQLAggregatorTrait.php
@@ -37,12 +37,16 @@ trait SQLAggregatorTrait
    */
   public function orderBy(array $keyParts): static
   {
-    $bufferKeyPart = [];
+    $bufferKeyPart = $keyParts;
 
     if (property_exists($this, 'query')) {
       if (array_is_associative($keyParts)) {
         $callback = function ($key, $value) {
-          return new SQLKeyPart($key, $value === 'ASC');
+          return new SQLKeyPart(
+            key: $key,
+            ascending: strtoupper((string) $value) === 'ASC',
+            dialect: $this->query->getDialect()
+          );
         };
         $bufferKeyPart = array_map($callback, array_keys($keyParts), $keyParts);
       }
@@ -64,7 +68,7 @@ trait SQLAggregatorTrait
   {
     if (property_exists($this, 'query')) {
       $queryString = "GROUP BY " . implode(', ', array_map(
-        fn(string $columnName): string => SqlIdentifier::quote($columnName),
+        fn(string $columnName): string => SqlIdentifier::quote($columnName, $this->query->getDialect()),
         $columnNames
       ));
       $this->query->appendQueryString($queryString);

--- a/src/Util/SqlIdentifier.php
+++ b/src/Util/SqlIdentifier.php
@@ -2,6 +2,7 @@
 
 namespace Assegai\Orm\Util;
 
+use Assegai\Orm\Enumerations\SQLDialect;
 use InvalidArgumentException;
 
 final class SqlIdentifier
@@ -10,9 +11,10 @@ final class SqlIdentifier
    * Quotes a column or table identifier after validating each segment.
    *
    * @param string $identifier
+   * @param SQLDialect $dialect
    * @return string
    */
-  public static function quote(string $identifier): string
+  public static function quote(string $identifier, SQLDialect $dialect = SQLDialect::MYSQL): string
   {
     $identifier = trim($identifier);
 
@@ -20,7 +22,7 @@ final class SqlIdentifier
       return '*';
     }
 
-    $segments = explode('.', str_replace('`', '', $identifier));
+    $segments = explode('.', str_replace(['`', '"'], '', $identifier));
     $quotedSegments = [];
 
     foreach ($segments as $index => $segment) {
@@ -39,7 +41,7 @@ final class SqlIdentifier
         throw new InvalidArgumentException("Unsafe SQL identifier: $identifier");
       }
 
-      $quotedSegments[] = "`$segment`";
+      $quotedSegments[] = SqlDialectHelper::quoteIdentifier($segment, $dialect);
     }
 
     return implode('.', $quotedSegments);

--- a/tests/PHPUnit/PostgreSQLIntegration/DatabaseManagerPostgreSqlIntegrationTest.php
+++ b/tests/PHPUnit/PostgreSQLIntegration/DatabaseManagerPostgreSqlIntegrationTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\PHPUnit\PostgreSQLIntegration;
+
+use Assegai\Orm\Management\DatabaseManager;
+use Tests\PHPUnit\Support\PostgreSqlIntegrationTestCase;
+use Throwable;
+
+final class DatabaseManagerPostgreSqlIntegrationTest extends PostgreSqlIntegrationTestCase
+{
+    private DatabaseManager $databaseManager;
+
+    /** @var string[] */
+    private array $createdDatabaseNames = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->databaseManager = DatabaseManager::getInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->createdDatabaseNames) as $databaseName) {
+            try {
+                if ($this->databaseManager->exists($this->dataSource, $databaseName, false)) {
+                    $this->databaseManager->drop($this->dataSource, $databaseName);
+                }
+            } catch (Throwable) {
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testExistsRecognizesCurrentAndMissingDatabases(): void
+    {
+        self::assertTrue($this->databaseManager->exists($this->dataSource, $this->databaseName));
+        self::assertFalse($this->databaseManager->exists($this->dataSource, $this->tempDatabaseName('missing')));
+    }
+
+    public function testSetupCreatesDatabaseWhenMissing(): void
+    {
+        $databaseName = $this->tempDatabaseName('setup');
+
+        self::assertFalse($this->databaseManager->exists($this->dataSource, $databaseName));
+
+        $this->databaseManager->setup($this->dataSource, $databaseName);
+        $this->createdDatabaseNames[] = $databaseName;
+
+        self::assertTrue($this->databaseManager->exists($this->dataSource, $databaseName));
+    }
+
+    public function testDropRemovesDatabase(): void
+    {
+        $databaseName = $this->tempDatabaseName('drop');
+
+        $this->databaseManager->setup($this->dataSource, $databaseName);
+        self::assertTrue($this->databaseManager->exists($this->dataSource, $databaseName));
+
+        $this->databaseManager->drop($this->dataSource, $databaseName);
+
+        self::assertFalse($this->databaseManager->exists($this->dataSource, $databaseName));
+    }
+
+    public function testResetRecreatesDatabaseWithoutKeepingOldTables(): void
+    {
+        $databaseName = $this->tempDatabaseName('reset');
+        $tableName = 'transient_records';
+
+        $this->databaseManager->setup($this->dataSource, $databaseName);
+        $this->createdDatabaseNames[] = $databaseName;
+
+        $temporaryDataSource = $this->createPostgreSqlDataSource($databaseName);
+        try {
+            $temporaryDataSource->getClient()->exec(
+                'CREATE TABLE IF NOT EXISTS "transient_records" ("id" BIGSERIAL PRIMARY KEY)'
+            );
+        } finally {
+            $temporaryDataSource->disconnect();
+        }
+
+        self::assertTrue($this->hasTable($databaseName, $tableName));
+
+        $this->databaseManager->reset($this->dataSource, $databaseName);
+
+        self::assertTrue($this->databaseManager->exists($this->dataSource, $databaseName));
+        self::assertFalse($this->hasTable($databaseName, $tableName));
+    }
+
+    private function hasTable(string $databaseName, string $tableName): bool
+    {
+        $temporaryDataSource = $this->createPostgreSqlDataSource($databaseName);
+
+        try {
+            $statement = $temporaryDataSource->getClient()->prepare(
+                'SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = :table LIMIT 1'
+            );
+            $statement->execute(['table' => $tableName]);
+
+            return $statement->fetchColumn() !== false;
+        } finally {
+            $temporaryDataSource->disconnect();
+        }
+    }
+}

--- a/tests/PHPUnit/PostgreSQLIntegration/EntityManagerPostgreSqlIntegrationTest.php
+++ b/tests/PHPUnit/PostgreSQLIntegration/EntityManagerPostgreSqlIntegrationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\PHPUnit\PostgreSQLIntegration;
+
+use Assegai\Orm\Management\Options\UpsertOptions;
+use Assegai\Orm\Queries\QueryBuilder\Results\InsertResult;
+use Tests\PHPUnit\Support\PostgreSqlIntegrationTestCase;
+use Unit\mocks\MockColorType;
+use Unit\mocks\MockEntity;
+
+final class EntityManagerPostgreSqlIntegrationTest extends PostgreSqlIntegrationTestCase
+{
+    public function testInsertReturnsHydratedGeneratedMaps(): void
+    {
+        $entity = new MockEntity();
+        $entity->name = 'pgsql insert valid';
+        $entity->description = 'Inserted through insert()';
+        $entity->colorType = MockColorType::BLUE;
+
+        $result = $this->manager->insert(MockEntity::class, $entity);
+
+        self::assertInstanceOf(InsertResult::class, $result);
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('RETURNING "id" AS "id"', (string) $result->getRaw());
+        self::assertInstanceOf(MockEntity::class, $result->getGeneratedMaps());
+
+        $entityId = (int) ($result->generatedMaps?->id ?? $result->identifiers?->id);
+        $row = $this->fetchMocksRowById($entityId);
+
+        self::assertSame('pgsql insert valid', $row['name']);
+        self::assertSame('Inserted through insert()', $row['description']);
+        self::assertSame(MockColorType::BLUE->value, $row['color_type']);
+        self::assertSame(MockColorType::BLUE, $result->getGeneratedMaps()?->colorType);
+    }
+
+    public function testUpdateReturnsHydratedGeneratedMaps(): void
+    {
+        $entity = new MockEntity();
+        $entity->name = 'pgsql update target';
+        $entity->description = 'Before update';
+        $entity->colorType = MockColorType::GREEN;
+
+        $insertResult = $this->manager->insert(MockEntity::class, $entity);
+        $entityId = (int) ($insertResult->generatedMaps?->id ?? $insertResult->identifiers?->id);
+
+        $result = $this->manager->update(
+            MockEntity::class,
+            ['description' => 'After update', 'colorType' => MockColorType::VIOLET],
+            ['id' => $entityId],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('RETURNING "id" AS "id"', (string) $result->getRaw());
+        self::assertSame($entityId, (int) ($result->identifiers?->id ?? 0));
+        self::assertInstanceOf(MockEntity::class, $result->generatedMaps);
+        self::assertSame('After update', $result->generatedMaps?->description);
+        self::assertSame(MockColorType::VIOLET, $result->generatedMaps?->colorType);
+    }
+
+    public function testUpsertPreservesIdentifierOnConflict(): void
+    {
+        $entity = new MockEntity();
+        $entity->name = 'pgsql upsert subject';
+        $entity->description = 'Initial insert';
+        $entity->colorType = MockColorType::ORANGE;
+
+        $insertResult = $this->manager->insert(MockEntity::class, $entity);
+        $entityId = (int) ($insertResult->generatedMaps?->id ?? $insertResult->identifiers?->id);
+
+        $entity->id = $entityId;
+        $entity->description = 'Updated through pgsql upsert';
+
+        $upsertResult = $this->manager->upsert(
+            MockEntity::class,
+            $entity,
+            ['id'],
+            new UpsertOptions(skipUpdateIfNoValuesChanged: false),
+        );
+
+        self::assertTrue($upsertResult->isOk());
+        self::assertStringContainsString('ON CONFLICT ("id") DO UPDATE SET', (string) $upsertResult->getRaw());
+        self::assertStringContainsString('RETURNING "id" AS "id"', (string) $upsertResult->getRaw());
+        self::assertSame($entityId, (int) ($upsertResult->identifiers?->id ?? 0));
+
+        $row = $this->fetchMocksRowById($entityId);
+
+        self::assertSame('Updated through pgsql upsert', $row['description']);
+    }
+
+    public function testRemoveUsesPrimaryKeyMetadataAndDeletesRow(): void
+    {
+        $entity = new MockEntity();
+        $entity->name = 'pgsql remove target';
+        $entity->description = 'Delete through remove()';
+        $entity->colorType = MockColorType::YELLOW;
+
+        $insertResult = $this->manager->insert(MockEntity::class, $entity);
+        $entity->id = (int) ($insertResult->generatedMaps?->id ?? $insertResult->identifiers?->id);
+
+        $result = $this->manager->remove($entity);
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('RETURNING "id"', (string) $result->getRaw());
+        self::assertSame(1, $result->getTotalAffectedRows());
+        self::assertSame(0, $this->rowCount('mocks'));
+    }
+}

--- a/tests/PHPUnit/PostgreSQLIntegration/EntityManagerPostgreSqlIntegrationTest.php
+++ b/tests/PHPUnit/PostgreSQLIntegration/EntityManagerPostgreSqlIntegrationTest.php
@@ -73,8 +73,10 @@ final class EntityManagerPostgreSqlIntegrationTest extends PostgreSqlIntegration
         $upsertResult = $this->manager->upsert(
             MockEntity::class,
             $entity,
-            ['id'],
-            new UpsertOptions(skipUpdateIfNoValuesChanged: false),
+            new UpsertOptions(
+                conflictPaths: ['id'],
+                skipUpdateIfNoValuesChanged: false,
+            ),
         );
 
         self::assertTrue($upsertResult->isOk());

--- a/tests/PHPUnit/PostgreSQLIntegration/SchemaPostgreSqlIntegrationTest.php
+++ b/tests/PHPUnit/PostgreSQLIntegration/SchemaPostgreSqlIntegrationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\PHPUnit\PostgreSQLIntegration;
+
+use Assegai\Orm\DataSource\Schema;
+use Tests\PHPUnit\Support\PostgreSqlIntegrationTestCase;
+use Unit\mocks\AlteredMockEntity;
+use Unit\mocks\MockColorType;
+use Unit\mocks\MockEntity;
+
+final class SchemaPostgreSqlIntegrationTest extends PostgreSqlIntegrationTestCase
+{
+    public function testCreateIfNotExistsCreatesMocksTableWithExpectedColumns(): void
+    {
+        Schema::dropIfExists(MockEntity::class, $this->schemaOptions);
+
+        self::assertTrue(Schema::createIfNotExists(MockEntity::class, $this->schemaOptions));
+        self::assertTrue(Schema::exists('mocks', $this->dataSource));
+        self::assertTrue(Schema::hasColumns('mocks', ['id', 'name', 'description', 'color_type'], $this->dataSource));
+    }
+
+    public function testInfoReturnsPostgreSqlTableDefinition(): void
+    {
+        $info = Schema::info(MockEntity::class, $this->schemaOptions);
+
+        self::assertNotNull($info);
+        self::assertStringContainsString('CREATE TABLE "mocks"', $info->ddlStatement);
+        self::assertStringContainsString('"id" bigint NOT NULL', $info->ddlStatement);
+        self::assertStringContainsString('"name" character varying(255) NOT NULL UNIQUE', $info->ddlStatement);
+        self::assertNotEmpty($info->tableFields);
+    }
+
+    public function testRenameChangesTableName(): void
+    {
+        self::assertTrue(Schema::exists('mocks', $this->dataSource));
+
+        try {
+            self::assertTrue(Schema::rename('mocks', 'socks', $this->schemaOptions));
+            self::assertTrue(Schema::exists('socks', $this->dataSource));
+            self::assertFalse(Schema::exists('mocks', $this->dataSource));
+        } finally {
+            $this->dataSource->getClient()->exec('DROP TABLE IF EXISTS "socks"');
+            Schema::createIfNotExists(MockEntity::class, $this->schemaOptions);
+        }
+    }
+
+    public function testAlterRebuildsTableWithAlteredEntityShape(): void
+    {
+        self::assertTrue(Schema::alter(AlteredMockEntity::class, $this->schemaOptions));
+        self::assertTrue(Schema::hasColumns('mocks', ['id', 'name', 'email'], $this->dataSource));
+        self::assertFalse(Schema::hasColumns('mocks', ['description', 'color_type'], $this->dataSource));
+
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO "mocks" ("name", "email") VALUES (:name, :email)'
+        );
+        $statement->execute([
+            'name' => 'Altered pgsql row',
+            'email' => 'altered@example.com',
+        ]);
+
+        $row = $this->dataSource->getClient()
+            ->query('SELECT "name", "email" FROM "mocks" ORDER BY "id" DESC LIMIT 1')
+            ->fetch();
+
+        self::assertSame('Altered pgsql row', $row['name']);
+        self::assertSame('altered@example.com', $row['email']);
+    }
+
+    public function testAlterResetsIdentitySequenceAfterCopyingExistingRows(): void
+    {
+        $this->dataSource->getClient()->exec(
+            <<<SQL
+INSERT INTO "mocks" ("name", "description", "color_type")
+VALUES
+  ('pgsql alter existing row 1', 'before alter 1', 'violet'),
+  ('pgsql alter existing row 2', 'before alter 2', 'green')
+SQL
+        );
+
+        self::assertTrue(Schema::alter(AlteredMockEntity::class, $this->schemaOptions));
+
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO "mocks" ("name", "email") VALUES (:name, :email) RETURNING "id"'
+        );
+        $statement->execute([
+            'name' => 'pgsql alter new row',
+            'email' => 'after-alter@example.com',
+        ]);
+
+        $newId = (int) $statement->fetchColumn();
+
+        self::assertGreaterThan(2, $newId);
+    }
+
+    public function testTruncateRemovesPersistedRows(): void
+    {
+        $entity = new MockEntity();
+        $entity->name = 'pgsql schema truncate';
+        $entity->description = 'Inserted before truncate';
+        $entity->colorType = MockColorType::VIOLET;
+
+        $insertResult = $this->manager->insert(MockEntity::class, $entity);
+
+        self::assertTrue($insertResult->isOk());
+        self::assertSame(1, $this->rowCount('mocks'));
+        self::assertTrue(Schema::truncate(MockEntity::class, $this->schemaOptions));
+        self::assertSame(0, $this->rowCount('mocks'));
+    }
+
+    public function testDropIfExistsRemovesMocksTable(): void
+    {
+        self::assertTrue(Schema::exists('mocks', $this->dataSource));
+        self::assertTrue(Schema::dropIfExists(MockEntity::class, $this->schemaOptions));
+        self::assertFalse(Schema::exists('mocks', $this->dataSource));
+    }
+}

--- a/tests/PHPUnit/Support/PostgreSqlIntegrationTestCase.php
+++ b/tests/PHPUnit/Support/PostgreSqlIntegrationTestCase.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\PHPUnit\Support;
+
+use Assegai\Orm\DataSource\DataSource;
+use Assegai\Orm\DataSource\DataSourceOptions;
+use Assegai\Orm\DataSource\SchemaOptions;
+use Assegai\Orm\Enumerations\DataSourceType;
+use Assegai\Orm\Enumerations\SQLDialect;
+use Assegai\Orm\Exceptions\DataSourceConnectionException;
+use Assegai\Orm\Management\EntityManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Unit\mocks\AlteredMockEntity;
+use Unit\mocks\MockEntity;
+
+abstract class PostgreSqlIntegrationTestCase extends TestCase
+{
+    /** @var array{PG_DB_HOST:string,PG_DB_NAME:string,PG_DB_PORT:string,PG_DB_USER:string,PG_DB_PASS:string} */
+    protected array $config;
+    protected DataSource $dataSource;
+    protected EntityManager $manager;
+    protected SchemaOptions $schemaOptions;
+    protected string $databaseName;
+
+    protected function setUp(): void
+    {
+        $config = $this->loadEnvironment();
+        $this->config = $config;
+        $this->databaseName = $config['PG_DB_NAME'];
+        $this->schemaOptions = new SchemaOptions(
+            dbName: $this->databaseName,
+            dialect: SQLDialect::POSTGRESQL,
+            checkIfExists: true,
+        );
+
+        try {
+            $this->dataSource = new DataSource(new DataSourceOptions(
+                entities: [MockEntity::class, AlteredMockEntity::class],
+                name: $this->databaseName,
+                type: DataSourceType::POSTGRESQL,
+                host: $config['PG_DB_HOST'],
+                port: (int) $config['PG_DB_PORT'],
+                username: $config['PG_DB_USER'],
+                password: $config['PG_DB_PASS'],
+            ));
+        } catch (DataSourceConnectionException $exception) {
+            throw new RuntimeException(
+                sprintf(
+                    'Unable to connect to the ORM PostgreSQL integration database using %s (host=%s port=%s db=%s user=%s).',
+                    dirname(__DIR__, 3) . '/.env.pgsql',
+                    $config['PG_DB_HOST'],
+                    $config['PG_DB_PORT'],
+                    $config['PG_DB_NAME'],
+                    $config['PG_DB_USER'],
+                ),
+                previous: $exception,
+            );
+        }
+
+        $this->manager = $this->dataSource->manager;
+        $this->resetMocksTable();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->dataSource)) {
+            $this->dataSource->getClient()->exec('DROP TABLE IF EXISTS "mocks"');
+            $this->dataSource->disconnect();
+        }
+
+        unset($this->manager, $this->dataSource, $this->schemaOptions, $this->databaseName, $this->config);
+    }
+
+    protected function resetMocksTable(): void
+    {
+        $this->dataSource->getClient()->exec('DROP TABLE IF EXISTS "mocks"');
+        $this->dataSource->getClient()->exec(
+            'CREATE TABLE "mocks" (
+                "id" BIGSERIAL PRIMARY KEY,
+                "name" VARCHAR(255) NOT NULL UNIQUE,
+                "description" TEXT NOT NULL,
+                "color_type" VARCHAR(32) NOT NULL,
+                "created_at" TIMESTAMP NULL,
+                "updated_at" TIMESTAMP NULL,
+                "deleted_at" TIMESTAMP NULL
+            )'
+        );
+    }
+
+    protected function rowCount(string $tableName): int
+    {
+        $statement = $this->dataSource->getClient()->query(
+            sprintf('SELECT COUNT(*) FROM "%s"', str_replace('"', '""', $tableName))
+        );
+
+        return (int) $statement->fetchColumn();
+    }
+
+    protected function fetchMocksRowById(int $id): array
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT "id", "name", "description", "color_type" FROM "mocks" WHERE "id" = :id'
+        );
+        $statement->execute(['id' => $id]);
+
+        $row = $statement->fetch();
+
+        if (!is_array($row)) {
+            throw new RuntimeException("Expected to find mocks row for id {$id}");
+        }
+
+        return $row;
+    }
+
+    protected function createPostgreSqlDataSource(string $databaseName, array $entities = []): DataSource
+    {
+        return new DataSource(new DataSourceOptions(
+            entities: $entities,
+            name: $databaseName,
+            type: DataSourceType::POSTGRESQL,
+            host: $this->config['PG_DB_HOST'],
+            port: (int) $this->config['PG_DB_PORT'],
+            username: $this->config['PG_DB_USER'],
+            password: $this->config['PG_DB_PASS'],
+        ));
+    }
+
+    protected function tempDatabaseName(string $suffix): string
+    {
+        return 'assegai_' . $suffix . '_' . substr(str_replace('.', '', uniqid('', true)), -12);
+    }
+
+    /**
+     * @return array{PG_DB_HOST:string,PG_DB_NAME:string,PG_DB_PORT:string,PG_DB_USER:string,PG_DB_PASS:string}
+     */
+    private function loadEnvironment(): array
+    {
+        $env = [];
+        $envFile = dirname(__DIR__, 3) . '/.env.pgsql';
+
+        if (is_file($envFile)) {
+            $env = parse_ini_file($envFile, false, INI_SCANNER_RAW) ?: [];
+        } else {
+            foreach (['PG_DB_HOST', 'PG_DB_NAME', 'PG_DB_PORT', 'PG_DB_USER', 'PG_DB_PASS'] as $key) {
+                $value = getenv($key);
+
+                if ($value !== false) {
+                    $env[$key] = $value;
+                }
+            }
+        }
+
+        foreach (['PG_DB_HOST', 'PG_DB_NAME', 'PG_DB_PORT', 'PG_DB_USER', 'PG_DB_PASS'] as $requiredKey) {
+            if (!array_key_exists($requiredKey, $env) || $env[$requiredKey] === '') {
+                self::markTestSkipped(
+                    sprintf(
+                        'PostgreSQL integration environment not configured. Create %s or set %s.',
+                        $envFile,
+                        $requiredKey,
+                    )
+                );
+            }
+        }
+
+        return $env;
+    }
+}

--- a/tests/PHPUnit/Support/PostgreSqlIntegrationTestCase.php
+++ b/tests/PHPUnit/Support/PostgreSqlIntegrationTestCase.php
@@ -9,6 +9,7 @@ use Assegai\Orm\Enumerations\DataSourceType;
 use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Exceptions\DataSourceConnectionException;
 use Assegai\Orm\Management\EntityManager;
+use Assegai\Orm\Support\OrmRuntime;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Unit\mocks\AlteredMockEntity;
@@ -33,6 +34,20 @@ abstract class PostgreSqlIntegrationTestCase extends TestCase
             dialect: SQLDialect::POSTGRESQL,
             checkIfExists: true,
         );
+        OrmRuntime::mergeConfig([
+            'databases' => [
+                'pgsql' => [
+                    $this->databaseName => [
+                        'host' => $config['PG_DB_HOST'],
+                        'port' => (int) $config['PG_DB_PORT'],
+                        'username' => $config['PG_DB_USER'],
+                        'password' => $config['PG_DB_PASS'],
+                        'database' => $this->databaseName,
+                        'name' => $this->databaseName,
+                    ],
+                ],
+            ],
+        ]);
 
         try {
             $this->dataSource = new DataSource(new DataSourceOptions(

--- a/tests/PHPUnit/Unit/ConnectionConfigTest.php
+++ b/tests/PHPUnit/Unit/ConnectionConfigTest.php
@@ -44,6 +44,16 @@ final class ConnectionConfigTest extends TestCase
         self::assertSame(SQLCharacterSet::UTF8MB4, $options->charSet);
     }
 
+    public function testReportsRequiredDriverMetadataPerDialect(): void
+    {
+        self::assertSame('pdo_mysql', DBFactory::getRequiredPdoExtension(SQLDialect::MYSQL));
+        self::assertSame('mysql', DBFactory::getRequiredPdoDriverName(SQLDialect::MYSQL));
+        self::assertSame('pdo_pgsql', DBFactory::getRequiredPdoExtension(SQLDialect::POSTGRESQL));
+        self::assertSame('pgsql', DBFactory::getRequiredPdoDriverName(SQLDialect::POSTGRESQL));
+        self::assertSame('pdo_sqlite', DBFactory::getRequiredPdoExtension(SQLDialect::SQLITE));
+        self::assertSame('sqlite', DBFactory::getRequiredPdoDriverName(SQLDialect::SQLITE));
+    }
+
     public function testCachesSqliteConnectionsAcrossFactoryCalls(): void
     {
         $path = sys_get_temp_dir() . '/assegai-sqlite-factory-' . uniqid('', true) . '.sqlite';

--- a/tests/PHPUnit/Unit/DatabaseManagerSqlTest.php
+++ b/tests/PHPUnit/Unit/DatabaseManagerSqlTest.php
@@ -33,6 +33,15 @@ final class DatabaseManagerSqlTest extends TestCase
         self::assertSame('DROP DATABASE IF EXISTS `assegai_blog`', $sql);
     }
 
+    public function testBuildsPostgreSqlDatabaseStatementsSafely(): void
+    {
+        $createSql = DatabaseManager::buildCreateDatabaseStatement(DataSourceType::POSTGRESQL, 'assegai_blog');
+        $dropSql = DatabaseManager::buildDropDatabaseStatement(DataSourceType::POSTGRESQL, 'assegai_blog');
+
+        self::assertSame('CREATE DATABASE "assegai_blog"', $createSql);
+        self::assertSame('DROP DATABASE IF EXISTS "assegai_blog"', $dropSql);
+    }
+
     public function testRejectsUnsafeDatabaseNames(): void
     {
         $this->expectException(DataSourceException::class);

--- a/tests/PHPUnit/Unit/DatabaseManagerSqlTest.php
+++ b/tests/PHPUnit/Unit/DatabaseManagerSqlTest.php
@@ -9,6 +9,8 @@ use Assegai\Orm\Enumerations\DataSourceType;
 use Assegai\Orm\Exceptions\DataSourceException;
 use Assegai\Orm\Management\DatabaseManager;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
 
 final class DatabaseManagerSqlTest extends TestCase
 {
@@ -82,5 +84,70 @@ final class DatabaseManagerSqlTest extends TestCase
         } finally {
             @unlink($path);
         }
+    }
+
+    public function testPostgreSqlSetupWrapsManagementConnectionFailures(): void
+    {
+        if (!extension_loaded('pdo_pgsql')) {
+            self::markTestSkipped('pdo_pgsql is required for PostgreSQL management tests.');
+        }
+
+        $manager = DatabaseManager::getInstance();
+        $dataSource = $this->createDetachedDataSource(new DataSourceOptions(
+            entities: [],
+            name: 'assegai_blog',
+            type: DataSourceType::POSTGRESQL,
+            host: '127.0.0.1',
+            port: 1,
+            username: 'postgres',
+            password: 'postgres',
+        ));
+
+        $this->expectException(DataSourceException::class);
+        $this->expectExceptionMessage('Data Source error:');
+
+        $manager->setup($dataSource, 'assegai_blog');
+    }
+
+    public function testPostgreSqlDropWrapsManagementConnectionFailures(): void
+    {
+        if (!extension_loaded('pdo_pgsql')) {
+            self::markTestSkipped('pdo_pgsql is required for PostgreSQL management tests.');
+        }
+
+        $manager = DatabaseManager::getInstance();
+        $dataSource = $this->createDetachedDataSource(new DataSourceOptions(
+            entities: [],
+            name: 'assegai_blog',
+            type: DataSourceType::POSTGRESQL,
+            host: '127.0.0.1',
+            port: 1,
+            username: 'postgres',
+            password: 'postgres',
+        ));
+
+        $this->expectException(DataSourceException::class);
+        $this->expectExceptionMessage('Data Source error:');
+
+        $manager->drop($dataSource, 'assegai_blog');
+    }
+
+    private function createDetachedDataSource(DataSourceOptions $options): DataSource
+    {
+        $reflection = new ReflectionClass(DataSource::class);
+        /** @var DataSource $dataSource */
+        $dataSource = $reflection->newInstanceWithoutConstructor();
+
+        $this->setProperty($dataSource, 'options', $options);
+        $this->setProperty($dataSource, 'type', $options->type);
+        $this->setProperty($dataSource, 'entities', $options->entities);
+
+        return $dataSource;
+    }
+
+    private function setProperty(object $object, string $propertyName, mixed $value): void
+    {
+        $property = new ReflectionProperty($object, $propertyName);
+        $property->setValue($object, $value);
     }
 }

--- a/tests/PHPUnit/Unit/PostgreSqlUpsertTest.php
+++ b/tests/PHPUnit/Unit/PostgreSqlUpsertTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\PHPUnit\Unit;
+
+use Assegai\Orm\DataSource\DataSource;
+use Assegai\Orm\DataSource\DataSourceOptions;
+use Assegai\Orm\Enumerations\DataSourceType;
+use Assegai\Orm\Enumerations\SQLDialect;
+use Assegai\Orm\Management\EntityManager;
+use Assegai\Orm\Queries\Sql\SQLQuery;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Unit\mocks\MockColorType;
+use Unit\mocks\MockEntity;
+
+final class PostgreSqlUpsertTest extends TestCase
+{
+    private ?DataSource $dataSource = null;
+    private string $databasePath;
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/assegai-postgresql-upsert-' . uniqid('', true) . '.sqlite';
+        $this->cleanupSqliteFiles($this->databasePath);
+        $this->dataSource = new DataSource(new DataSourceOptions(
+            entities: [MockEntity::class],
+            name: $this->databasePath,
+            type: DataSourceType::SQLITE,
+        ));
+
+        $this->dataSource->getClient()->exec(
+            'CREATE TABLE mocks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                color_type TEXT NOT NULL,
+                created_at TEXT NULL,
+                updated_at TEXT NULL,
+                deleted_at TEXT NULL
+            )'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dataSource?->disconnect();
+        $this->cleanupSqliteFiles($this->databasePath);
+    }
+
+    public function testInsertUsesReturningToHydrateGeneratedMaps(): void
+    {
+        $manager = $this->createPostgreSqlManager();
+
+        $entity = new MockEntity();
+        $entity->name = 'Insert returning';
+        $entity->description = 'Inserted through PostgreSQL path';
+        $entity->colorType = MockColorType::BLUE;
+
+        $result = $manager->insert(MockEntity::class, $entity);
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('RETURNING "id" AS "id"', $result->getRaw());
+        self::assertSame(1, $result->getIdentifiers()?->id);
+        self::assertInstanceOf(MockEntity::class, $result->getGeneratedMaps());
+        self::assertSame('Insert returning', $result->getGeneratedMaps()?->name);
+        self::assertSame(MockColorType::BLUE, $result->getGeneratedMaps()?->colorType);
+    }
+
+    public function testUpdateUsesReturningToHydrateUpdatedRow(): void
+    {
+        $manager = $this->createPostgreSqlManager();
+
+        $entity = new MockEntity();
+        $entity->name = 'Update returning';
+        $entity->description = 'Before update';
+        $entity->colorType = MockColorType::ORANGE;
+
+        $insertResult = $manager->insert(MockEntity::class, $entity);
+        $entityId = $insertResult->getIdentifiers()?->id;
+
+        $result = $manager->update(
+            MockEntity::class,
+            ['description' => 'After update', 'colorType' => MockColorType::VIOLET],
+            ['id' => $entityId],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('RETURNING "id" AS "id"', $result->getRaw());
+        self::assertSame($entityId, $result->getIdentifiers()?->id);
+        self::assertInstanceOf(MockEntity::class, $result->getGeneratedMaps());
+        self::assertSame('After update', $result->getGeneratedMaps()?->description);
+        self::assertSame(MockColorType::VIOLET, $result->getGeneratedMaps()?->colorType);
+    }
+
+    public function testRemoveUsesReturningOnPostgreSqlPath(): void
+    {
+        $manager = $this->createPostgreSqlManager();
+
+        $entity = new MockEntity();
+        $entity->name = 'Delete returning';
+        $entity->description = 'Delete me';
+        $entity->colorType = MockColorType::YELLOW;
+
+        $insertResult = $manager->insert(MockEntity::class, $entity);
+        $entity->id = $insertResult->getIdentifiers()?->id;
+
+        $result = $manager->remove($entity);
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('RETURNING "id"', $result->getRaw());
+        self::assertSame(1, $result->getTotalAffectedRows());
+    }
+
+    public function testUpsertUsesPostgreSqlConflictSyntaxAndPreservesIdentifiers(): void
+    {
+        $manager = $this->createPostgreSqlManager();
+
+        $first = new MockEntity();
+        $first->name = 'Ada';
+        $first->description = 'Initial record';
+        $first->colorType = MockColorType::RED;
+
+        $insertResult = $manager->upsert(MockEntity::class, $first, ['name']);
+
+        self::assertTrue($insertResult->isOk());
+        self::assertStringContainsString('ON CONFLICT ("name") DO UPDATE SET', $insertResult->getRaw());
+        self::assertStringContainsString('RETURNING "id" AS "id"', $insertResult->getRaw());
+        self::assertSame(1, $insertResult->getIdentifiers()?->id);
+
+        $second = new MockEntity();
+        $second->name = 'Ada';
+        $second->description = 'Updated record';
+        $second->colorType = MockColorType::GREEN;
+
+        $updateResult = $manager->upsert(MockEntity::class, $second, ['name']);
+
+        self::assertTrue($updateResult->isOk());
+        self::assertSame($insertResult->getIdentifiers()?->id, $updateResult->getIdentifiers()?->id);
+        self::assertIsObject($updateResult->getGeneratedMaps());
+        self::assertSame('Updated record', $updateResult->getGeneratedMaps()?->description);
+        self::assertContains($updateResult->getGeneratedMaps()?->colorType, [MockColorType::GREEN, MockColorType::GREEN->value]);
+    }
+
+    private function createPostgreSqlManager(): EntityManager
+    {
+        return new EntityManager(
+            connection: $this->dataSource,
+            query: new SQLQuery(
+                db: $this->dataSource->getClient(),
+                fetchClass: MockEntity::class,
+                fetchMode: PDO::FETCH_CLASS,
+                dialect: SQLDialect::POSTGRESQL,
+            ),
+        );
+    }
+
+    private function cleanupSqliteFiles(string $path): void
+    {
+        foreach ([$path, $path . '-wal', $path . '-shm'] as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+}

--- a/tests/PHPUnit/Unit/SQLKeyPartTest.php
+++ b/tests/PHPUnit/Unit/SQLKeyPartTest.php
@@ -2,17 +2,25 @@
 
 namespace Tests\PHPUnit\Unit;
 
+use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Queries\Sql\SQLKeyPart;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 final class SQLKeyPartTest extends TestCase
 {
-    public function testQuotesSafeIdentifiers(): void
+    public function testQuotesSafeIdentifiersForMySql(): void
     {
         $keyPart = new SQLKeyPart('users.created_at', ascending: false);
 
         self::assertSame('`users`.`created_at` DESC', (string) $keyPart);
+    }
+
+    public function testQuotesSafeIdentifiersForPostgreSql(): void
+    {
+        $keyPart = new SQLKeyPart('users.created_at', ascending: false, dialect: SQLDialect::POSTGRESQL);
+
+        self::assertSame('"users"."created_at" DESC', (string) $keyPart);
     }
 
     public function testRejectsUnsafeIdentifiers(): void

--- a/tests/PHPUnit/Unit/SqlDialectRenderingTest.php
+++ b/tests/PHPUnit/Unit/SqlDialectRenderingTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\PHPUnit\Unit;
+
+use Assegai\Orm\Enumerations\SQLDialect;
+use Assegai\Orm\Management\Options\FindWhereOptions;
+use Assegai\Orm\Queries\Sql\SQLQuery;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class SqlDialectRenderingTest extends TestCase
+{
+    public function testPostgreSqlLimitClauseUsesOffsetSyntax(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+
+        $query
+            ->select()
+            ->all(['users.name'])
+            ->from('users')
+            ->limit(10, 20);
+
+        self::assertSame('SELECT "users"."name" FROM "users" LIMIT 10 OFFSET 20', $query->queryString());
+    }
+
+    public function testMySqlLimitClauseKeepsOffsetCommaSyntax(): void
+    {
+        $query = $this->createQuery(SQLDialect::MYSQL);
+
+        $query
+            ->select()
+            ->all(['users.name'])
+            ->from('users')
+            ->limit(10, 20);
+
+        self::assertSame('SELECT `users`.`name` FROM `users` LIMIT 20,10', $query->queryString());
+    }
+
+    public function testFindWhereOptionsCompileUsesQueryDialect(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+        $where = new FindWhereOptions(conditions: ['status' => 'active']);
+
+        self::assertSame('"status"=?', $where->compile($query));
+    }
+
+    public function testPostgreSqlUpdateBuilderQuotesIdentifiers(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+
+        $query
+            ->update('users')
+            ->set(['name' => 'Ada']);
+
+        self::assertSame('UPDATE "users" SET "name"=?', $query->queryString());
+    }
+
+    public function testPostgreSqlMultipleInsertUsesPortableValuesSyntax(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+
+        $query
+            ->insertInto('users')
+            ->multipleRows(['name', 'email'])
+            ->rows([
+                ['Ada', 'ada@example.com'],
+                ['Bob', 'bob@example.com'],
+            ]);
+
+        self::assertSame(
+            'INSERT INTO "users" ("name", "email") VALUES (?, ?), (?, ?)',
+            $query->queryString()
+        );
+    }
+
+    public function testPostgreSqlSelectAndFromQuoteAliases(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+
+        $query
+            ->select()
+            ->all(['user_name' => 'users.name'])
+            ->from(['u' => 'users']);
+
+        self::assertSame(
+            'SELECT "users"."name" AS "user_name" FROM "users" AS "u"',
+            $query->queryString()
+        );
+    }
+
+    private function createQuery(SQLDialect $dialect): SQLQuery
+    {
+        return new SQLQuery(new PDO('sqlite::memory:'), dialect: $dialect);
+    }
+}

--- a/tests/PHPUnit/Unit/SqlDialectRenderingTest.php
+++ b/tests/PHPUnit/Unit/SqlDialectRenderingTest.php
@@ -55,6 +55,17 @@ final class SqlDialectRenderingTest extends TestCase
         self::assertSame('UPDATE "users" SET "name"=?', $query->queryString());
     }
 
+    public function testPostgreSqlUpdateBuilderIgnoresMysqlOnlyModifiers(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+
+        $query
+            ->update('users', lowPriority: true, ignore: true)
+            ->set(['name' => 'Ada']);
+
+        self::assertSame('UPDATE "users" SET "name"=?', $query->queryString());
+    }
+
     public function testPostgreSqlMultipleInsertUsesPortableValuesSyntax(): void
     {
         $query = $this->createQuery(SQLDialect::POSTGRESQL);
@@ -86,6 +97,41 @@ final class SqlDialectRenderingTest extends TestCase
             'SELECT "users"."name" AS "user_name" FROM "users" AS "u"',
             $query->queryString()
         );
+    }
+
+    public function testPostgreSqlRenameTableUsesAlterTableSyntax(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+
+        $query->rename()->table('users', 'customers');
+
+        self::assertSame('ALTER TABLE "users" RENAME TO "customers"', $query->queryString());
+    }
+
+    public function testPostgreSqlAlterBuilderQuotesIdentifiers(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+
+        $query->alter()->table('users');
+
+        self::assertSame('ALTER TABLE "users"', $query->queryString());
+    }
+
+    public function testInsertReturningRowsAreAvailableToPostgreSqlQueries(): void
+    {
+        $query = $this->createQuery(SQLDialect::POSTGRESQL);
+        $query->getConnection()->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)');
+
+        $result = $query
+            ->insertInto('users')
+            ->singleRow(['name'])
+            ->values(['Ada']);
+        $query->appendQueryString('RETURNING "id", "name"');
+        $executed = $query->execute();
+
+        self::assertTrue($executed->isOK());
+        self::assertSame([['id' => 1, 'name' => 'Ada']], $executed->getData());
+        self::assertSame(1, $query->lastInsertId());
     }
 
     private function createQuery(SQLDialect $dialect): SQLQuery


### PR DESCRIPTION
This pull request introduces PostgreSQL integration support to the Assegai ORM, improves database driver handling, and formalizes contribution guidelines and workflow documentation. The most significant changes include adding PostgreSQL test coverage, refactoring driver extension checks, and updating documentation to clarify commit/PR conventions and installation steps.

**PostgreSQL Integration and Testing**
* Added a PostgreSQL integration job to the GitHub Actions workflow (`.github/workflows/php.yml`) and a dedicated PHPUnit config for PostgreSQL integration tests (`phpunit.pgsql.xml`). Environment variables for PostgreSQL testing were also added (`.env.pgsql.example`). [[1]](diffhunk://#diff-a73bb6555480a5ee79ae276a3f5d71a08fa316e09a4a8da7b643cf1e92c97df9R54-R108) [[2]](diffhunk://#diff-8cc0cdd2356caa204942e79c2667b39f60e0f3a0922775674eb2d39457d38876R1-R18) [[3]](diffhunk://#diff-e3a4c034f81b85114ed9aa95fbb45dec33bea25a6ec84a44b2bd1be3316c8b9eR1-R5)
* Introduced a new Composer script for running PostgreSQL tests: `test:pgsql` (`composer.json`).

**Database Driver Handling and Error Reporting**
* Refactored `DBFactory` to check for the required PDO extension and driver before creating a connection, throwing a clear exception if the extension is missing. This affects MySQL, PostgreSQL, and SQLite connection methods, and adds helper methods for driver/extension detection. [[1]](diffhunk://#diff-55dcbb06d7e6bffe0a0fd79a3c03af857386b28f45948085c56c01a02ae4d043R75) [[2]](diffhunk://#diff-55dcbb06d7e6bffe0a0fd79a3c03af857386b28f45948085c56c01a02ae4d043R221) [[3]](diffhunk://#diff-55dcbb06d7e6bffe0a0fd79a3c03af857386b28f45948085c56c01a02ae4d043R268) [[4]](diffhunk://#diff-55dcbb06d7e6bffe0a0fd79a3c03af857386b28f45948085c56c01a02ae4d043R382-R425)
* Updated `composer.json` to make PDO driver extensions (`ext-pdo_mysql`, `ext-pdo_pgsql`, `ext-pdo_sqlite`) optional, moving them to the `suggest` section with clear descriptions.
* Updated installation instructions in `README.md` to clarify that users must enable only the PDO extension for their chosen database.

**Schema Migration Improvements**
* Generalized the schema rebuild logic so that both SQLite and PostgreSQL use the same table-rebuild path for schema-altering operations, with dialect-aware quoting and DDL handling. [[1]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL182-R184) [[2]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL607-R613) [[3]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL627-R669) [[4]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL668-R683) [[5]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL686-R704)

**Documentation and Contribution Workflow**
* Added detailed commit and pull request guidelines in `docs/commit-and-pr-guidelines.md`, and referenced these from the `README.md` for contributor clarity. [[1]](diffhunk://#diff-bbce47aee4a1d5db1813fb8b92c1197903d91f3fad23c29d0dab74f6a7ee903eR1-R170) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20-R26)
* Added repository-wide Copilot instructions (`.github/copilot-instructions.md`) and a standardized pull request template (`.github/pull_request_template.md`) to enforce consistent contribution practices. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R70) [[2]](diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR1-R28)

**Summary of Most Important Changes**

**PostgreSQL Integration**
- Added PostgreSQL integration test job to GitHub Actions and a dedicated PHPUnit configuration for PostgreSQL, along with example environment variables for local testing. [[1]](diffhunk://#diff-a73bb6555480a5ee79ae276a3f5d71a08fa316e09a4a8da7b643cf1e92c97df9R54-R108) [[2]](diffhunk://#diff-8cc0cdd2356caa204942e79c2667b39f60e0f3a0922775674eb2d39457d38876R1-R18) [[3]](diffhunk://#diff-e3a4c034f81b85114ed9aa95fbb45dec33bea25a6ec84a44b2bd1be3316c8b9eR1-R5)
- Added `test:pgsql` Composer script for running PostgreSQL tests.

**Database Driver Handling**
- Refactored `DBFactory` to check for required PDO extensions and drivers before connecting, with clear error messages if missing. [[1]](diffhunk://#diff-55dcbb06d7e6bffe0a0fd79a3c03af857386b28f45948085c56c01a02ae4d043R75) [[2]](diffhunk://#diff-55dcbb06d7e6bffe0a0fd79a3c03af857386b28f45948085c56c01a02ae4d043R221) [[3]](diffhunk://#diff-55dcbb06d7e6bffe0a0fd79a3c03af857386b28f45948085c56c01a02ae4d043R268) [[4]](diffhunk://#diff-55dcbb06d7e6bffe0a0fd79a3c03af857386b28f45948085c56c01a02ae4d043R382-R425)
- Made PDO driver extensions optional in `composer.json` and clarified their purpose in the `suggest` section.
- Updated installation instructions in `README.md` to explain the need to enable the correct PDO extension for the chosen database.

**Schema Migration**
- Generalized schema rebuild logic for both SQLite and PostgreSQL, ensuring dialect-aware quoting, DDL, and transactional safety during schema changes. [[1]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL182-R184) [[2]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL607-R613) [[3]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL627-R669) [[4]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL668-R683) [[5]](diffhunk://#diff-76d5f78c8b0ccbb4f5bded2adae7b45d080386d865234c43a05f5443f91a1d3fL686-R704)

**Contribution Workflow**
- Added and referenced detailed commit and PR guidelines; included Copilot instructions and a PR template for consistent contribution practices. [[1]](diffhunk://#diff-bbce47aee4a1d5db1813fb8b92c1197903d91f3fad23c29d0dab74f6a7ee903eR1-R170) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20-R26) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R70) [[4]](diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR1-R28)