### PR TITLE
Fix regex replacements in ORM to avoid interpolation issues

### DIFF
--- a/src/Util/TypeConversion/BasicTypeConverter.php
+++ b/src/Util/TypeConversion/BasicTypeConverter.php
@@ -32,7 +32,7 @@ class BasicTypeConverter
   #[TypeConverter]
   public function fromStringToDateTime(string $dateTime): DateTime
   {
-    $dateTime = preg_replace('/(.*)\(.*\)/', "$1", $dateTime);
+    $dateTime = preg_replace('/(.*)\(.*\)/', '$1', $dateTime);
     return new DateTime($dateTime);
   }
 


### PR DESCRIPTION
This pull request makes a minor change to the `fromStringToDateTime` function in `BasicTypeConverter.php`, updating the regular expression replacement to use single quotes for the replacement string instead of double quotes. This change clarifies the intent and avoids unnecessary variable interpolation.

* Changed the replacement string in the `preg_replace` call in `fromStringToDateTime` from double quotes to single quotes for improved clarity and correctness.