### PR TITLE
Improve error reporting in EntityManager

### DIFF
--- a/src/Attributes/Columns/Column.php
+++ b/src/Attributes/Columns/Column.php
@@ -2,10 +2,10 @@
 
 namespace Assegai\Orm\Attributes\Columns;
 
-use Assegai\Orm\Exceptions\ORMException;
-use Assegai\Orm\Queries\Sql\SQLColumnDefinition;
-use Assegai\Orm\Queries\Sql\ColumnType;
 use Assegai\Orm\Enumerations\SQLDialect;
+use Assegai\Orm\Exceptions\ORMException;
+use Assegai\Orm\Queries\Sql\ColumnType;
+use Assegai\Orm\Queries\Sql\SQLColumnDefinition;
 use Attribute;
 use UnitEnum;
 
@@ -16,288 +16,284 @@ use UnitEnum;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class Column
 {
-  // TODO: Move these constants to an appropriate class/enum
-  const SIGNED = 'SIGNED';
-  const UNSIGNED = 'UNSIGNED';
-  const ZEROFILL = 'ZEROFILL';
-  const NOW = 'NOW';
-  const CURRENT_DATE = 'CURRENT_DATE()';
-  const CURRENT_TIME = 'CURRENT_TIME()';
-  const CURRENT_TIMESTAMP = 'CURRENT_TIMESTAMP';
-  const DEFAULT_LENGTH_CHAR = 30;
-  const DEFAULT_LENGTH_VARCHAR = 255;
-  const DEFAULT_LENGTH_BINARY = 1;
-  const DEFAULT_LENGTH_VARBINARY = 255;
-  const DEFAULT_LENGTH_TINYBLOB = 255;
-  const DEFAULT_LENGTH_BLOB = 65535;
-  const DEFAULT_LENGTH_TEXT = 65535;
-  const DEFAULT_LENGTH_MEDIUMBLOB = 16777215;
-  const DEFAULT_LENGTH_MEDIUMTEXT = 16777215;
-  const DEFAULT_LENGTH_LONGBLOB = 4294967295;
-  const DEFAULT_LENGTH_LONGTEXT = 4294967295;
+    // TODO: Move these constants to an appropriate class/enum
+    const string SIGNED = 'SIGNED';
+    const string UNSIGNED = 'UNSIGNED';
+    const string ZEROFILL = 'ZEROFILL';
+    const string NOW = 'NOW';
+    const string CURRENT_DATE = 'CURRENT_DATE()';
+    const string CURRENT_TIME = 'CURRENT_TIME()';
+    const string CURRENT_TIMESTAMP = 'CURRENT_TIMESTAMP';
+    const int DEFAULT_LENGTH_CHAR = 30;
+    const int DEFAULT_LENGTH_VARCHAR = 255;
+    const int DEFAULT_LENGTH_BINARY = 1;
+    const int DEFAULT_LENGTH_VARBINARY = 255;
+    const int DEFAULT_LENGTH_TINYBLOB = 255;
+    const int DEFAULT_LENGTH_BLOB = 65535;
+    const int DEFAULT_LENGTH_TEXT = 65535;
+    const int DEFAULT_LENGTH_MEDIUMBLOB = 16777215;
+    const int DEFAULT_LENGTH_MEDIUMTEXT = 16777215;
+    const int DEFAULT_LENGTH_LONGBLOB = 4294967295;
+    const int DEFAULT_LENGTH_LONGTEXT = 4294967295;
 
-  public string $value;
-  public SQLColumnDefinition|string $sqlDefinition = '';
+    public string $value;
+    public SQLColumnDefinition|string $sqlDefinition = '';
 
-  /**
-   * @param string $name Column name in the database table. By default, the column name is generated from the name of
-   * the property. You can change it by specifying your own name.
-   * @param string $alias
-   * @param string $type Column type.
-   * @param string|array|int|null $lengthOrValues Column type's length. For example if you want to create varchar(150)
-   * type you specify column type and length options.
-   * @param bool $nullable Makes column NULL or NOT NULL in the database. By default, column is nullable: false.
-   * @param bool $unsigned Puts UNSIGNED attribute on to a numeric column. Used only in MySQL.
-   * @param bool $zeroFilled Puts ZEROFILL attribute on to a numeric column. Used only in MySQL. If true, MySQL
-   * automatically adds the UNSIGNED attribute to this column.
-   * @param mixed|null $default
-   * @param bool $autoIncrement
-   * @param string $onUpdate
-   * @param bool $isUnique
-   * @param string $uniqueKey
-   * @param bool $isPrimaryKey
-   * @param string $comment
-   * @param bool $canUpdate
-   * @param string $enum
-   * @throws ORMException
-   */
-  public function __construct(
-    public string                $name = '',
-    public string                $alias = '',
-    public ColumnType            $type = ColumnType::INT,
-    public null|string|array|int $lengthOrValues = null,
-    public bool                  $nullable = true,
-    public bool                  $unsigned = false,
-    public bool                  $zeroFilled = false,
-    public mixed                 $default = null,
-    public bool                  $autoIncrement = false,
-    public string                $onUpdate = '',
-    public bool                  $isUnique = false,
-    public string                $uniqueKey = '',
-    public bool                  $isPrimaryKey = false,
-    public string                $comment = '',
-    public bool                  $canUpdate = true,
-    public string|UnitEnum       $enum = ''
-  )
-  {
-    # Build definition string
-    if ($this->type === ColumnType::ENUM && !empty($this->enum))
+    /**
+     * @param string $name Column name in the database table. By default, the column name is generated from the name of
+     * the property. You can change it by specifying your own name.
+     * @param string $alias
+     * @param ColumnType $type Column type.
+     * @param string|array|int|null $lengthOrValues Column type's length. For example if you want to create varchar(150)
+     * type you specify column type and length options.
+     * @param bool $nullable Makes column NULL or NOT NULL in the database. By default, column is nullable: false.
+     * @param bool $unsigned Puts UNSIGNED attribute on to a numeric column. Used only in MySQL.
+     * @param bool $zeroFilled Puts ZEROFILL attribute on to a numeric column. Used only in MySQL. If true, MySQL
+     * automatically adds the UNSIGNED attribute to this column.
+     * @param mixed|null $default
+     * @param bool $autoIncrement
+     * @param string $onUpdate
+     * @param bool $isUnique
+     * @param string $uniqueKey
+     * @param bool $isPrimaryKey
+     * @param string $comment
+     * @param bool $canUpdate
+     * @param string|UnitEnum $enum
+     * @throws ORMException
+     */
+    public function __construct(
+        public string                $name = '',
+        public string                $alias = '',
+        public ColumnType            $type = ColumnType::INT,
+        public null|string|array|int $lengthOrValues = null,
+        public bool                  $nullable = true,
+        public bool                  $unsigned = false,
+        public bool                  $zeroFilled = false,
+        public mixed                 $default = null,
+        public bool                  $autoIncrement = false,
+        public string                $onUpdate = '',
+        public bool                  $isUnique = false,
+        public string                $uniqueKey = '',
+        public bool                  $isPrimaryKey = false,
+        public string                $comment = '',
+        public bool                  $canUpdate = true,
+        public string|UnitEnum       $enum = ''
+    )
     {
-      if (enum_exists($this->enum))
-      {
-        $this->lengthOrValues = [];
-        /** @var UnitEnum $enum */
-        $cases = $this->enum::cases();
+        # Build definition string
+        if ($this->type === ColumnType::ENUM && !empty($this->enum)) {
+            if (enum_exists($this->enum)) {
+                $this->lengthOrValues = [];
+                /** @var UnitEnum $enum */
+                $cases = $this->enum::cases();
 
-        foreach ($cases as $case)
-        {
-          if (!isset($case->value))
-          {
-            throw new ORMException('Enum ' . $this->enum . ' is NOT backed.');
-          }
-          $this->lengthOrValues[] = $case->value;
+                foreach ($cases as $case) {
+                    if (!isset($case->value)) {
+                        throw new ORMException('Enum ' . $this->enum . ' is NOT backed.');
+                    }
+                    $this->lengthOrValues[] = $case->value;
+                }
+            }
         }
-      }
+
+        $sqlLengthOrValues = $this->lengthOrValues;
+        if (is_null($sqlLengthOrValues)) {
+            $sqlLengthOrValues = match ($this->type) {
+                ColumnType::VARCHAR => strval(self::DEFAULT_LENGTH_VARCHAR),
+                ColumnType::DECIMAL => '16,2',
+                default => null
+            };
+        }
+
+        $this->sqlDefinition = new SQLColumnDefinition(
+            name: $this->name,
+            type: $this->type,
+            lengthOrValues: $sqlLengthOrValues,
+            defaultValue: $this->default,
+            nullable: $this->nullable,
+            autoIncrement: $this->autoIncrement,
+            onUpdate: $this->onUpdate,
+            isUnique: $this->isUnique,
+            uniqueKey: $this->uniqueKey,
+            isPrimaryKey: $this->isPrimaryKey,
+            comment: $this->comment
+        );
+
+        $this->lengthOrValues = match (gettype($this->lengthOrValues)) {
+            'array' => empty($this->lengthOrValues) ? '' : '(' . implode(',', $this->lengthOrValues) . ')',
+            'NULL' => '',
+            default => empty($this->lengthOrValues) ? '' : '(' . $this->lengthOrValues . ')'
+        };
+
+        $this->value = "$type->value$this->lengthOrValues ";
+
+        if ($unsigned) {
+            $this->value .= Column::UNSIGNED . ' ';
+        }
+        if (!$nullable) {
+            $this->value .= 'NOT ';
+        }
+
+        $this->value .= 'NULL ';
+
+        if ($zeroFilled && $unsigned) {
+            $this->value .= Column::ZEROFILL . ' ';
+        }
+        if (isset($this->default)) {
+            if (is_object($this->default) && property_exists($this->default, 'value')) {
+                $this->default = $this->default->value;
+            } else if (is_callable($this->default)) {
+                $this->default = call_user_func($this->default);
+            }
+
+            $this->value .= "DEFAULT $this->default ";
+        }
+
+        if ($autoIncrement) {
+            $this->value .= "AUTO_INCREMENT ";
+        }
+        if ($isUnique) {
+            $this->value .= "UNIQUE $uniqueKey";
+        }
+
+        if (isset($alias)) {
+            $this->value .= "AS $alias";
+        }
+
+        $this->value = trim($this->value);
     }
 
-    $sqlLengthOrValues = $this->lengthOrValues;
-    if (is_null($sqlLengthOrValues))
+    /**
+     * @return string
+     */
+    public function getFieldType(): string
     {
-      $sqlLengthOrValues = match ($this->type) {
-        ColumnType::VARCHAR => strval(self::DEFAULT_LENGTH_VARCHAR),
-        ColumnType::DECIMAL => '16,2',
-        default => null
-      };
+        return str_replace('()', '', match ($this->type) {
+            ColumnType::TEXT,
+            ColumnType::DECIMAL,
+            ColumnType::ENUM => strtolower($this->type->value) . '(' . $this->getValuesAsString() . ')',
+            default => strtolower($this->type->value) . '(' . $this->getLength() . ')'
+        });
     }
 
-    $this->sqlDefinition = new SQLColumnDefinition(
-      name: $this->name,
-      type: $this->type,
-      lengthOrValues: $sqlLengthOrValues,
-      defaultValue: $this->default,
-      nullable: $this->nullable,
-      autoIncrement: $this->autoIncrement,
-      onUpdate: $this->onUpdate,
-      isUnique: $this->isUnique,
-      uniqueKey: $this->uniqueKey,
-      isPrimaryKey: $this->isPrimaryKey,
-      comment: $this->comment
-    );
-
-    $this->lengthOrValues = match(gettype($this->lengthOrValues)) {
-      'array' => empty($this->lengthOrValues) ? '' : '(' . implode(',', $this->lengthOrValues) . ')',
-      'NULL'  => '',
-      default => empty($this->lengthOrValues) ? '' : '(' . $this->lengthOrValues  . ')'
-    };
-
-    $this->value = "$type->value$this->lengthOrValues ";
-
-    if ($unsigned)                 { $this->value .= Column::UNSIGNED . ' '; }
-    if (!$nullable)              { $this->value .= 'NOT '; }
-
-    $this->value .= 'NULL ';
-
-    if ($zeroFilled && $unsigned)  { $this->value .= Column::ZEROFILL . ' '; }
-    if (isset($this->default))
+    /**
+     * @return string
+     */
+    public function getValuesAsString(): string
     {
-      if (is_object($this->default) && property_exists($this->default, 'value'))
-      {
-        $this->default = $this->default->value;
-      }
-      else if(is_callable($this->default))
-      {
-        $this->default = call_user_func($this->default);
-      }
+        if (!$this->getValues()) {
+            return '';
+        }
 
-      $this->value .= "DEFAULT $this->default ";
+        return implode(',', array_map(fn($case) => "'$case->value'" ?? "'$case'", $this->getValues()));
     }
 
-    if ($autoIncrement)           { $this->value .= "AUTO_INCREMENT "; }
-    if ($isUnique)                { $this->value .= "UNIQUE $uniqueKey"; }
-
-    if (isset($alias))            { $this->value .= "AS $alias"; }
-
-    $this->value = trim($this->value);
-  }
-
-  /**
-   * @return string
-   */
-  public function getFieldType(): string
-  {
-    return str_replace('()', '', match($this->type) {
-      ColumnType::TEXT,
-      ColumnType::DECIMAL,
-      ColumnType::ENUM => strtolower($this->type->value) . '(' . $this->getValuesAsString() . ')',
-      default => strtolower($this->type->value) . '(' . $this->getLength() . ')'
-    });
-  }
-
-  /**
-   * @return string
-   */
-  public function getFieldExtra(): string
-  {
-    return match(true) {
-      $this->type->isNumeric() => match(true) {
-        $this->autoIncrement => 'auto_increment',
-        default => '',
-      },
-      $this->type->isDateTime() => empty($this->onUpdate)
-        ? 'DEFAULT_GENERATED'
-        : 'DEFAULT_GENERATED on update ' . $this->onUpdate,
-      default => ''
-    };
-  }
-
-  /**
-   * @return int|null
-   */
-  public function getLength(): ?int
-  {
-    $length = $this->lengthOrValues;
-    if (!is_numeric($length))
+    /**
+     * @return array|null
+     */
+    public function getValues(): ?array
     {
-      $length = null;
+        if ($this->type === ColumnType::ENUM) {
+            return $this->enum::cases();
+        }
+
+        return null;
     }
 
-    if (is_string($length))
+    /**
+     * @return int|null
+     */
+    public function getLength(): ?int
     {
-      $length = (int)$length;
+        $length = $this->lengthOrValues;
+        if (!is_numeric($length)) {
+            $length = null;
+        }
+
+        if (is_string($length)) {
+            $length = (int)$length;
+        }
+
+        return $length ?? match ($this->type) {
+            ColumnType::CHAR => self::DEFAULT_LENGTH_CHAR,
+            ColumnType::VARCHAR => self::DEFAULT_LENGTH_VARCHAR,
+            ColumnType::BINARY => self::DEFAULT_LENGTH_BINARY,
+            ColumnType::VARBINARY => self::DEFAULT_LENGTH_VARBINARY,
+            ColumnType::TINYBLOB => self::DEFAULT_LENGTH_TINYBLOB,
+            ColumnType::BLOB => self::DEFAULT_LENGTH_BLOB,
+            ColumnType::TEXT => self::DEFAULT_LENGTH_TEXT,
+            ColumnType::MEDIUMBLOB => self::DEFAULT_LENGTH_MEDIUMBLOB,
+            ColumnType::MEDIUMTEXT => self::DEFAULT_LENGTH_MEDIUMTEXT,
+            ColumnType::LONGBLOB => self::DEFAULT_LENGTH_LONGBLOB,
+            ColumnType::LONGTEXT => self::DEFAULT_LENGTH_LONGTEXT,
+            default => null
+        };
     }
 
-    return $length ?? match ($this->type) {
-      ColumnType::CHAR => self::DEFAULT_LENGTH_CHAR,
-      ColumnType::VARCHAR => self::DEFAULT_LENGTH_VARCHAR,
-      ColumnType::BINARY => self::DEFAULT_LENGTH_BINARY,
-      ColumnType::VARBINARY => self::DEFAULT_LENGTH_VARBINARY,
-      ColumnType::TINYBLOB => self::DEFAULT_LENGTH_TINYBLOB,
-      ColumnType::BLOB => self::DEFAULT_LENGTH_BLOB,
-      ColumnType::TEXT => self::DEFAULT_LENGTH_TEXT,
-      ColumnType::MEDIUMBLOB => self::DEFAULT_LENGTH_MEDIUMBLOB,
-      ColumnType::MEDIUMTEXT => self::DEFAULT_LENGTH_MEDIUMTEXT,
-      ColumnType::LONGBLOB => self::DEFAULT_LENGTH_LONGBLOB,
-      ColumnType::LONGTEXT => self::DEFAULT_LENGTH_LONGTEXT,
-      default => null
-    };
-  }
-
-  /**
-   * @return array|null
-   */
-  public function getValues(): ?array
-  {
-    if ($this->type === ColumnType::ENUM)
+    /**
+     * @return string
+     */
+    public function getFieldExtra(): string
     {
-      return $this->enum::cases();
+        return match (true) {
+            $this->type->isNumeric() => match (true) {
+                $this->autoIncrement => 'auto_increment',
+                default => '',
+            },
+            $this->type->isDateTime() => empty($this->onUpdate)
+                ? 'DEFAULT_GENERATED'
+                : 'DEFAULT_GENERATED on update ' . $this->onUpdate,
+            default => ''
+        };
     }
 
-    return null;
-  }
-
-  /**
-   * @return string
-   */
-  public function getValuesAsString(): string
-  {
-    if (!$this->getValues())
+    public function getSqlDefinition(SQLDialect $dialect = SQLDialect::MYSQL): SQLColumnDefinition
     {
-      return '';
+        $sqlLengthOrValues = $this->lengthOrValues;
+
+        if ($this->type === ColumnType::ENUM && is_string($sqlLengthOrValues)) {
+            $sqlLengthOrValues = $this->normalizeEnumSqlValues($sqlLengthOrValues);
+        }
+
+        return SQLColumnDefinition::forDialect(
+            name: $this->name,
+            type: $this->type,
+            lengthOrValues: $sqlLengthOrValues,
+            defaultValue: $this->default,
+            nullable: $this->nullable,
+            autoIncrement: $this->autoIncrement,
+            onUpdate: $this->onUpdate,
+            isUnique: $this->isUnique,
+            uniqueKey: $this->uniqueKey,
+            isPrimaryKey: $this->isPrimaryKey,
+            comment: $this->comment,
+            dialect: $dialect,
+        );
     }
 
-    return implode(',', array_map(fn($case) => "'$case->value'" ?? "'$case'", $this->getValues()));
-  }
-
-  public function getSqlDefinition(SQLDialect $dialect = SQLDialect::MYSQL): SQLColumnDefinition
-  {
-    $sqlLengthOrValues = $this->lengthOrValues;
-
-    if ($this->type === ColumnType::ENUM && is_string($sqlLengthOrValues))
+    /**
+     * @return array|string
+     */
+    private function normalizeEnumSqlValues(string $sqlLengthOrValues): array|string
     {
-      $sqlLengthOrValues = $this->normalizeEnumSqlValues($sqlLengthOrValues);
+        $normalizedValues = trim($sqlLengthOrValues);
+
+        if (preg_match('/^\((.*)\)$/', $normalizedValues, $matches)) {
+            $normalizedValues = $matches[1];
+        }
+
+        if (!str_contains($normalizedValues, ',')) {
+            return $normalizedValues === '' ? [] : [trim($normalizedValues, " \t\n\r\0\x0B'\"")];
+        }
+
+        return array_values(
+            array_filter(
+                array_map(
+                    static fn(string $value): string => trim($value, " \t\n\r\0\x0B'\""),
+                    explode(',', $normalizedValues)
+                ),
+                static fn(string $value): bool => $value !== ''
+            )
+        );
     }
-
-    return SQLColumnDefinition::forDialect(
-      name: $this->name,
-      type: $this->type,
-      lengthOrValues: $sqlLengthOrValues,
-      defaultValue: $this->default,
-      nullable: $this->nullable,
-      autoIncrement: $this->autoIncrement,
-      onUpdate: $this->onUpdate,
-      isUnique: $this->isUnique,
-      uniqueKey: $this->uniqueKey,
-      isPrimaryKey: $this->isPrimaryKey,
-      comment: $this->comment,
-      dialect: $dialect,
-    );
-  }
-
-  /**
-   * @return array|string
-   */
-  private function normalizeEnumSqlValues(string $sqlLengthOrValues): array|string
-  {
-    $normalizedValues = trim($sqlLengthOrValues);
-
-    if (preg_match('/^\((.*)\)$/', $normalizedValues, $matches))
-    {
-      $normalizedValues = $matches[1];
-    }
-
-    if (!str_contains($normalizedValues, ','))
-    {
-      return $normalizedValues === '' ? [] : [trim($normalizedValues, " \t\n\r\0\x0B'\"")];
-    }
-
-    return array_values(
-      array_filter(
-        array_map(
-          static fn(string $value): string => trim($value, " \t\n\r\0\x0B'\""),
-          explode(',', $normalizedValues)
-        ),
-        static fn(string $value): bool => $value !== ''
-      )
-    );
-  }
 }

--- a/src/Exceptions/GeneralSQLQueryException.php
+++ b/src/Exceptions/GeneralSQLQueryException.php
@@ -22,7 +22,8 @@ class GeneralSQLQueryException extends ORMException
         $query,
         $code,
         $info
-      )
+      ),
+      $previous
     );
   }
 }

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -180,6 +180,18 @@ class EntityManager implements IEntityStoreOwner
         return null;
     }
 
+    private function publicResultErrors(QueryResultInterface $result): array
+    {
+        if (!OrmRuntime::isProduction()) {
+            return $result->getErrors();
+        }
+
+        return array_values(array_filter(
+            $result->getErrors(),
+            fn(mixed $error): bool => !$error instanceof PDOException
+        ));
+    }
+
     /**
      * @param string|object $objectOrClass
      * @return bool
@@ -368,10 +380,10 @@ class EntityManager implements IEntityStoreOwner
             if (!headers_sent()) {
                 http_response_code(500);
             }
-            $error = new GeneralSQLQueryException($this->query);
+            $error = $this->newGeneralSqlQueryException($this->query, $result);
             OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
 
-            return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$error, ...$result->getErrors()]);
+            return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$error, ...$this->publicResultErrors($result)]);
         }
 
         if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
@@ -433,7 +445,7 @@ class EntityManager implements IEntityStoreOwner
             $error = new GeneralSQLQueryException($this->query);
             OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
 
-            return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$result->getErrors()]);
+            return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: $this->publicResultErrors($result));
         }
 
         $entity = is_array($result->getData()) && array_is_list($result->getData())
@@ -840,7 +852,7 @@ class EntityManager implements IEntityStoreOwner
         $result = $statement->execute();
 
         if ($result->isError()) {
-            return new FindResult(raw: $result->getRaw(), data: $result->value(), errors: [new GeneralSQLQueryException($this->query), ...$result->getErrors()], affected: $result->getTotalAffectedRows());
+            return new FindResult(raw: $result->getRaw(), data: $result->value(), errors: [$this->newGeneralSqlQueryException($this->query, $result), ...$this->publicResultErrors($result)], affected: $result->getTotalAffectedRows());
         }
 
         $loadedRelations = $this->loadRequestedRelations($entityClass, $result->getData(), $findOptions, $availableRelations);
@@ -854,10 +866,10 @@ class EntityManager implements IEntityStoreOwner
                 $total = 0;
             }
 
-            return new FindResult(raw: $result->getRaw(), data: $resultSet, errors: $result->getErrors(), total: $total);
+            return new FindResult(raw: $result->getRaw(), data: $resultSet, errors: $this->publicResultErrors($result), total: $total);
         }
 
-        return new FindResult(raw: $result->getRaw(), data: $resultSet, errors: $result->getErrors());
+        return new FindResult(raw: $result->getRaw(), data: $resultSet, errors: $this->publicResultErrors($result));
     }
 
     /**
@@ -1756,7 +1768,7 @@ class EntityManager implements IEntityStoreOwner
             throw $this->newGeneralSqlQueryException($this->query, $result);
         }
 
-        return new FindResult(raw: $result->getRaw(), data: $result->getData(), errors: $result->getErrors());
+        return new FindResult(raw: $result->getRaw(), data: $result->getData(), errors: $this->publicResultErrors($result));
     }
 
     /**
@@ -2148,7 +2160,7 @@ class EntityManager implements IEntityStoreOwner
                 $result = $this->upsert(entityClass: $entityClass, entityOrEntities: $entity, options: $options);
 
                 if ($result->isError()) {
-                    $errors[] = $result->getErrors();
+                    $errors[] = $this->publicResultErrors($result);
                 }
 
                 $results[] = $result->getData();
@@ -2224,8 +2236,8 @@ class EntityManager implements IEntityStoreOwner
 
         if ($result->isError()) {
             $errors[] = $this->query->getConnection()->errorInfo();
-            $errors[] = new GeneralSQLQueryException($this->query);
-            $errors = [...$errors, ...$result->getErrors()];
+            $errors[] = $this->newGeneralSqlQueryException($this->query, $result);
+            $errors = [...$errors, ...$this->publicResultErrors($result)];
         }
 
         if ($result->isOk()) {
@@ -2335,8 +2347,8 @@ class EntityManager implements IEntityStoreOwner
 
         if ($result->isError()) {
             $errors[] = $this->query->getConnection()->errorInfo();
-            $errors[] = new GeneralSQLQueryException($this->query);
-            $errors = [...$errors, ...$result->getErrors()];
+            $errors[] = $this->newGeneralSqlQueryException($this->query, $result);
+            $errors = [...$errors, ...$this->publicResultErrors($result)];
         }
 
         $identifierValue = $this->extractReturningIdentifier($result->getData(), $primaryKeyField, $primaryColumn)
@@ -2452,8 +2464,8 @@ class EntityManager implements IEntityStoreOwner
         $errors = [];
         if ($result->isError()) {
             $errors[] = $this->query->getConnection()->errorInfo();
-            $errors[] = new GeneralSQLQueryException($this->query);
-            $errors = [...$errors, ...$result->getErrors()];
+            $errors[] = $this->newGeneralSqlQueryException($this->query, $result);
+            $errors = [...$errors, ...$this->publicResultErrors($result)];
         }
 
         $identifierValue = $entityOrEntities->{$primaryKeyField} ?? null;
@@ -2676,7 +2688,7 @@ class EntityManager implements IEntityStoreOwner
             throw $this->newGeneralSqlQueryException($this->query, $deletionResult);
         }
 
-        return new DeleteResult(raw: $deletionResult->value(), affected: $this->query->rowCount(), errors: $deletionResult->getErrors());
+        return new DeleteResult(raw: $deletionResult->value(), affected: $this->query->rowCount(), errors: $this->publicResultErrors($deletionResult));
     }
 
     /**
@@ -2718,7 +2730,7 @@ class EntityManager implements IEntityStoreOwner
             $generatedMaps->$key = $value;
         }
 
-        return new UpdateResult(raw: $restoreResult->value(), affected: $this->query->rowCount(), identifiers: $entity, generatedMaps: $generatedMaps, errors: $restoreResult->getErrors());
+        return new UpdateResult(raw: $restoreResult->value(), affected: $this->query->rowCount(), identifiers: $entity, generatedMaps: $generatedMaps, errors: $this->publicResultErrors($restoreResult));
     }
 
     /**
@@ -2739,7 +2751,7 @@ class EntityManager implements IEntityStoreOwner
     {
         $result = $this->find(entityClass: $entityClass, findOptions: $options);
 
-        return new FindResult($result->getRaw(), $result->getTotal(), $result->getErrors(), $result->getTotalAffectedRows());
+        return new FindResult($result->getRaw(), $result->getTotal(), $this->publicResultErrors($result), $result->getTotalAffectedRows());
     }
 
     /**
@@ -2758,7 +2770,7 @@ class EntityManager implements IEntityStoreOwner
     {
         $result = $this->findBy(entityClass: $entityClass, where: $where);
 
-        return new FindResult($result->getRaw(), $result->getTotal(), $result->getErrors(), $result->getTotalAffectedRows());
+        return new FindResult($result->getRaw(), $result->getTotal(), $this->publicResultErrors($result), $result->getTotalAffectedRows());
     }
 
     /**

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -69,6 +69,7 @@ use ReflectionProperty;
 use ReflectionUnionType;
 use stdClass;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Throwable;
 use UnitEnum;
 
 /**
@@ -156,6 +157,18 @@ class EntityManager implements IEntityStoreOwner
         $isDebugMode = filter_var($_ENV['DEBUG_MODE'] ?? false, FILTER_VALIDATE_BOOL);
         $environment = strtoupper($_ENV['ENV'] ?? 'development');
         $this->isDebug = !in_array($environment, ['PROD', 'PRODUCTION']) && $isDebugMode === true;
+    }
+
+    private function newGeneralSqlQueryException(?SQLQuery $query, QueryResultInterface $result): GeneralSQLQueryException
+    {
+        return new GeneralSQLQueryException($query, $this->firstThrowableError($result));
+    }
+
+    private function firstThrowableError(QueryResultInterface $result): ?Throwable
+    {
+        $error = $result->getErrors()[0] ?? null;
+
+        return $error instanceof Throwable ? $error : null;
     }
 
     /**
@@ -1235,7 +1248,7 @@ class EntityManager implements IEntityStoreOwner
             ->execute();
 
         if ($result->isError()) {
-            throw new GeneralSQLQueryException($query, $result->getErrors()[0]);
+            throw $this->newGeneralSqlQueryException($query, $result);
         }
 
         return array_map(
@@ -1406,7 +1419,7 @@ class EntityManager implements IEntityStoreOwner
             ->execute();
 
         if ($result->isError()) {
-            throw new GeneralSQLQueryException($query, $result->getErrors()[0]);
+            throw $this->newGeneralSqlQueryException($query, $result);
         }
 
         $groupedRows = [];
@@ -1674,7 +1687,7 @@ class EntityManager implements IEntityStoreOwner
         $result = $statement->execute();
 
         if ($result->isError()) {
-            throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+            throw $this->newGeneralSqlQueryException($this->query, $result);
         }
 
         return $result->value()[0]?->total ?? 0;
@@ -1731,7 +1744,7 @@ class EntityManager implements IEntityStoreOwner
         $result = $statement->execute();
 
         if ($result->isError()) {
-            throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+            throw $this->newGeneralSqlQueryException($this->query, $result);
         }
 
         return new FindResult(raw: $result->getRaw(), data: $result->getData(), errors: $result->getErrors());
@@ -1850,7 +1863,7 @@ class EntityManager implements IEntityStoreOwner
         $raw = $result->getRaw();
 
         if ($result->isError()) {
-            throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+            throw $this->newGeneralSqlQueryException($this->query, $result);
         }
 
         $generatedMaps = null;
@@ -2503,7 +2516,7 @@ class EntityManager implements IEntityStoreOwner
             $raw = $result->getRaw();
 
             if ($result->isError()) {
-                throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+                throw $this->newGeneralSqlQueryException($this->query, $result);
             }
 
             $affected = $this->query->getDialect() === SQLDialect::POSTGRESQL
@@ -2569,7 +2582,7 @@ class EntityManager implements IEntityStoreOwner
             $result = $statement->execute();
 
             if ($result->isError()) {
-                throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+                throw $this->newGeneralSqlQueryException($this->query, $result);
             }
 
             // TODO: #88 Verify that delete occurred @amasiye
@@ -2651,7 +2664,7 @@ class EntityManager implements IEntityStoreOwner
         $deletionResult = $statement->execute();
 
         if ($deletionResult->isError()) {
-            throw new GeneralSQLQueryException($this->query, $deletionResult->getErrors()[0]);
+            throw $this->newGeneralSqlQueryException($this->query, $deletionResult);
         }
 
         return new DeleteResult(raw: $deletionResult->value(), affected: $this->query->rowCount(), errors: $deletionResult->getErrors());
@@ -2687,7 +2700,7 @@ class EntityManager implements IEntityStoreOwner
         $restoreResult = $statement->execute();
 
         if ($restoreResult->isError()) {
-            throw new GeneralSQLQueryException($this->query, $restoreResult->getErrors()[0]);
+            throw $this->newGeneralSqlQueryException($this->query, $restoreResult);
         }
 
         $generatedMaps = new stdClass();

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -43,6 +43,7 @@ use Assegai\Orm\Metadata\RelationPropertyMetadata;
 use Assegai\Orm\Queries\QueryBuilder\Results\DeleteResult;
 use Assegai\Orm\Queries\QueryBuilder\Results\InsertResult;
 use Assegai\Orm\Queries\QueryBuilder\Results\UpdateResult;
+use Assegai\Orm\Queries\Sql\SQLExpression;
 use Assegai\Orm\Queries\Sql\SQLQuery;
 use Assegai\Orm\Queries\Sql\SQLQueryResult;
 use Assegai\Orm\Relations\RelationOptions;
@@ -654,6 +655,163 @@ class EntityManager implements IEntityStoreOwner
     {
         $parts = explode('.', $column);
         return end($parts);
+    }
+
+    /**
+     * Adds ORM-managed ON UPDATE assignments for columns that were not explicitly assigned.
+     *
+     * @param object $entity The entity whose column metadata should be inspected.
+     * @param array<string, mixed> $assignmentList Existing update assignments keyed by column name.
+     * @return array<string, mixed>
+     */
+    private function applyOnUpdateColumnAssignments(object $entity, array $assignmentList): array
+    {
+        if (empty($assignmentList)) {
+            return $assignmentList;
+        }
+
+        $assignedColumns = $this->columnNameLookup(array_keys($assignmentList));
+
+        foreach ($this->getOnUpdateColumnExpressions($entity) as $columnName => $expression) {
+            if (isset($assignedColumns[$this->normalizeColumnNameForComparison($columnName)])) {
+                continue;
+            }
+
+            $assignmentList[$columnName] = $expression;
+        }
+
+        return $assignmentList;
+    }
+
+    /**
+     * @param object $entity The entity whose column metadata should be inspected.
+     * @param string[] $updateColumns Columns that should use the inserted row values on conflict.
+     * @param string[] $conflictPaths Conflict target columns that should not be rewritten by this fallback.
+     * @param string $sourcePrefix Prefix used by the dialect to reference the proposed insert row.
+     * @return string[]
+     */
+    private function buildExcludedUpsertAssignments(
+        object $entity,
+        array $updateColumns,
+        array $conflictPaths,
+        string $sourcePrefix,
+    ): array
+    {
+        $assignmentList = [];
+        $assignedColumns = [];
+        $conflictColumns = $this->columnNameLookup($conflictPaths);
+
+        foreach ($updateColumns as $column) {
+            $column = $this->stripTableName($column);
+            $quotedColumn = SqlIdentifier::quote($column, $this->query->getDialect());
+            $assignmentList[] = "$quotedColumn=$sourcePrefix.$quotedColumn";
+            $assignedColumns[$this->normalizeColumnNameForComparison($column)] = true;
+        }
+
+        foreach ($this->getOnUpdateColumnExpressions($entity) as $columnName => $expression) {
+            $normalizedColumnName = $this->normalizeColumnNameForComparison($columnName);
+
+            if (isset($assignedColumns[$normalizedColumnName]) || isset($conflictColumns[$normalizedColumnName])) {
+                continue;
+            }
+
+            $assignmentList[] = SqlIdentifier::quote($columnName, $this->query->getDialect()) . "=$expression";
+        }
+
+        return $assignmentList;
+    }
+
+    /**
+     * @param object $entity The entity whose column metadata should be inspected.
+     * @param string[] $updateColumns Columns that should use VALUES(column) on duplicate key.
+     * @param string $primaryColumn The primary key column used for LAST_INSERT_ID preservation.
+     * @return string[]
+     */
+    private function buildMySqlUpsertAssignments(object $entity, array $updateColumns, string $primaryColumn): array
+    {
+        $assignmentList = [];
+        $assignedColumns = [];
+
+        foreach (array_values($updateColumns) as $column) {
+            $column = $this->stripTableName($column);
+            $quotedColumn = $this->query->quoteIdentifier($column);
+            $assignmentList[] = "$quotedColumn=VALUES($quotedColumn)";
+            $assignedColumns[$this->normalizeColumnNameForComparison($column)] = true;
+        }
+
+        $quotedPrimaryColumn = $this->query->quoteIdentifier($primaryColumn);
+        array_unshift($assignmentList, "$quotedPrimaryColumn=LAST_INSERT_ID($quotedPrimaryColumn)");
+        $assignedColumns[$this->normalizeColumnNameForComparison($primaryColumn)] = true;
+
+        foreach ($this->getOnUpdateColumnExpressions($entity) as $columnName => $expression) {
+            if (isset($assignedColumns[$this->normalizeColumnNameForComparison($columnName)])) {
+                continue;
+            }
+
+            $assignmentList[] = $this->query->quoteIdentifier($columnName) . "=$expression";
+        }
+
+        return $assignmentList;
+    }
+
+    /**
+     * @param object $entity The entity whose column metadata should be inspected.
+     * @return array<string, SQLExpression>
+     */
+    private function getOnUpdateColumnExpressions(object $entity): array
+    {
+        $expressions = [];
+        $reflectionClass = new ReflectionClass($entity);
+
+        foreach ($reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            foreach ($property->getAttributes() as $attribute) {
+                $attributeInstance = $attribute->newInstance();
+
+                if (!$attributeInstance instanceof Column || !$attributeInstance->canUpdate) {
+                    continue;
+                }
+
+                $onUpdate = trim($attributeInstance->onUpdate);
+
+                if ($onUpdate === '') {
+                    continue;
+                }
+
+                $columnName = $attributeInstance->name ?: strtosnake($property->getName());
+                $expressions[$columnName] = new SQLExpression($this->normalizeOnUpdateExpression($onUpdate));
+            }
+        }
+
+        return $expressions;
+    }
+
+    /**
+     * @param string[] $columns
+     * @return array<string, true>
+     */
+    private function columnNameLookup(array $columns): array
+    {
+        $lookup = [];
+
+        foreach ($columns as $column) {
+            $lookup[$this->normalizeColumnNameForComparison((string)$column)] = true;
+        }
+
+        return $lookup;
+    }
+
+    private function normalizeColumnNameForComparison(string $column): string
+    {
+        return strtolower(str_replace(['`', '"', '[', ']'], '', $this->stripTableName($column)));
+    }
+
+    private function normalizeOnUpdateExpression(string $expression): string
+    {
+        return match (strtoupper($expression)) {
+            'CURRENT_DATE()' => 'CURRENT_DATE',
+            'CURRENT_TIME()' => 'CURRENT_TIME',
+            default => $expression,
+        };
     }
 
     private function buildReturningProjection(object $entity): string
@@ -1860,6 +2018,8 @@ class EntityManager implements IEntityStoreOwner
             }
         }
 
+        $assignmentList = $this->applyOnUpdateColumnAssignments($entityInstance, $assignmentList);
+
         if (empty($assignmentList)) {
             return new UpdateResult(null, 0, $partialEntity, new stdClass());
         }
@@ -2217,7 +2377,7 @@ class EntityManager implements IEntityStoreOwner
         $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
         $placeholders = array_fill(0, count($values), '?');
         $valueList = implode(', ', $placeholders);
-        $assignmentList = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()) . '=excluded.' . SqlIdentifier::quote($column, $this->query->getDialect()), $updateColumns));
+        $assignmentList = implode(', ', $this->buildExcludedUpsertAssignments($entity, $updateColumns, $conflictPaths, 'excluded'));
         $conflictAction = empty($assignmentList) ? 'DO NOTHING' : "DO UPDATE SET $assignmentList";
 
         $queryString = 'INSERT INTO ' . $this->query->quoteIdentifier($tableName) . " ($quotedColumns) VALUES ($valueList) ON CONFLICT ($quotedConflictPaths) $conflictAction";
@@ -2322,10 +2482,7 @@ class EntityManager implements IEntityStoreOwner
         $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
         $placeholders = array_fill(0, count($values), '?');
         $valueList = implode(', ', $placeholders);
-        $assignmentList = implode(', ', array_map(
-            fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()) . '=excluded.' . SqlIdentifier::quote($column, $this->query->getDialect()),
-            $updateColumns
-        ));
+        $assignmentList = implode(', ', $this->buildExcludedUpsertAssignments($entity, $updateColumns, $conflictPaths, 'excluded'));
         $conflictAction = empty($assignmentList) ? 'DO NOTHING' : "DO UPDATE SET $assignmentList";
         $returning = $this->query->quoteIdentifier($primaryColumn) . ' AS ' . $this->query->quoteIdentifier($primaryKeyField);
 
@@ -2445,12 +2602,7 @@ class EntityManager implements IEntityStoreOwner
         string        $primaryColumn,
     ): InsertResult
     {
-        $assignmentList = array_map(function ($column): string {
-            $column = $this->stripTableName($column);
-            return "$column=VALUES($column)";
-        }, array_values($updateColumns));
-
-        array_unshift($assignmentList, "$primaryColumn=LAST_INSERT_ID($primaryColumn)");
+        $assignmentList = $this->buildMySqlUpsertAssignments($entityOrEntities, $updateColumns, $primaryColumn);
 
         $this->query->insertInto(tableName: $tableName)->singleRow(columns: $columns)->values(valuesList: $values)->onDuplicateKeyUpdate(assignmentList: $assignmentList);
 

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -161,14 +161,18 @@ class EntityManager implements IEntityStoreOwner
 
     private function newGeneralSqlQueryException(?SQLQuery $query, QueryResultInterface $result): GeneralSQLQueryException
     {
-        return new GeneralSQLQueryException($query, $this->firstThrowableError($result));
+        return new GeneralSQLQueryException($query, $this->previousThrowableError($result));
     }
 
-    private function firstThrowableError(QueryResultInterface $result): ?Throwable
+    private function previousThrowableError(QueryResultInterface $result): ?Throwable
     {
-        $error = $result->getErrors()[0] ?? null;
+        foreach (array_reverse($result->getErrors()) as $error) {
+            if ($error instanceof Throwable) {
+                return $error;
+            }
+        }
 
-        return $error instanceof Throwable ? $error : null;
+        return null;
     }
 
     /**

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -189,8 +189,17 @@ class EntityManager implements IEntityStoreOwner
 
         return array_values(array_filter(
             $result->getErrors(),
-            fn(mixed $error): bool => !$error instanceof PDOException
+            fn(mixed $error): bool => $error instanceof Throwable && !$error instanceof PDOException
         ));
+    }
+
+    private function publicDriverErrorPayload(mixed $error): array
+    {
+        if (OrmRuntime::isProduction()) {
+            return [];
+        }
+
+        return [$error];
     }
 
     /**
@@ -2395,7 +2404,7 @@ class EntityManager implements IEntityStoreOwner
         $errors = [];
 
         if ($result->isError()) {
-            $errors[] = $this->query->getConnection()->errorInfo();
+            $errors = [...$errors, ...$this->publicDriverErrorPayload($this->query->getConnection()->errorInfo())];
             $errors[] = $this->newGeneralSqlQueryException($this->query, $result);
             $errors = [...$errors, ...$this->publicResultErrors($result)];
         }
@@ -2503,7 +2512,7 @@ class EntityManager implements IEntityStoreOwner
         $errors = [];
 
         if ($result->isError()) {
-            $errors[] = $this->query->getConnection()->errorInfo();
+            $errors = [...$errors, ...$this->publicDriverErrorPayload($this->query->getConnection()->errorInfo())];
             $errors[] = $this->newGeneralSqlQueryException($this->query, $result);
             $errors = [...$errors, ...$this->publicResultErrors($result)];
         }
@@ -2615,7 +2624,7 @@ class EntityManager implements IEntityStoreOwner
 
         $errors = [];
         if ($result->isError()) {
-            $errors[] = $this->query->getConnection()->errorInfo();
+            $errors = [...$errors, ...$this->publicDriverErrorPayload($this->query->getConnection()->errorInfo())];
             $errors[] = $this->newGeneralSqlQueryException($this->query, $result);
             $errors = [...$errors, ...$this->publicResultErrors($result)];
         }

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -61,6 +61,7 @@ use DateTimeZone;
 use Exception;
 use JetBrains\PhpStorm\ArrayShape;
 use NumberFormatter;
+use PDOException;
 use PDOStatement;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
@@ -167,6 +168,10 @@ class EntityManager implements IEntityStoreOwner
     private function previousThrowableError(QueryResultInterface $result): ?Throwable
     {
         foreach (array_reverse($result->getErrors()) as $error) {
+            if (OrmRuntime::isProduction() && $error instanceof PDOException) {
+                continue;
+            }
+
             if ($error instanceof Throwable) {
                 return $error;
             }

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -13,11 +13,8 @@ use Assegai\Orm\Attributes\Columns\URLColumn;
 use Assegai\Orm\Attributes\Entity;
 use Assegai\Orm\Attributes\Relations\JoinColumn;
 use Assegai\Orm\Attributes\Relations\JoinTable;
-use Assegai\Orm\Attributes\Relations\ManyToOne;
-use Assegai\Orm\Attributes\Relations\OneToMany;
 use Assegai\Orm\Attributes\Relations\OneToOne;
 use Assegai\Orm\DataSource\DataSource;
-use Assegai\Orm\Enumerations\DataSourceType;
 use Assegai\Orm\Enumerations\RelationType;
 use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Exceptions\ClassNotFoundException;
@@ -25,7 +22,6 @@ use Assegai\Orm\Exceptions\ContainerException;
 use Assegai\Orm\Exceptions\EmptyCriteriaException;
 use Assegai\Orm\Exceptions\GeneralSQLQueryException;
 use Assegai\Orm\Exceptions\IllegalTypeException;
-use Assegai\Orm\Exceptions\NotFoundException;
 use Assegai\Orm\Exceptions\NotImplementedException;
 use Assegai\Orm\Exceptions\ORMException;
 use Assegai\Orm\Exceptions\SaveException;
@@ -45,14 +41,14 @@ use Assegai\Orm\Management\Options\UpdateOptions;
 use Assegai\Orm\Management\Options\UpsertOptions;
 use Assegai\Orm\Metadata\RelationPropertyMetadata;
 use Assegai\Orm\Queries\QueryBuilder\Results\DeleteResult;
-use Assegai\Orm\Results\FindResult;
 use Assegai\Orm\Queries\QueryBuilder\Results\InsertResult;
 use Assegai\Orm\Queries\QueryBuilder\Results\UpdateResult;
 use Assegai\Orm\Queries\Sql\SQLQuery;
 use Assegai\Orm\Queries\Sql\SQLQueryResult;
 use Assegai\Orm\Relations\RelationOptions;
-use Assegai\Orm\Util\Filter;
+use Assegai\Orm\Results\FindResult;
 use Assegai\Orm\Support\OrmRuntime;
+use Assegai\Orm\Util\Filter;
 use Assegai\Orm\Util\Log\Logger;
 use Assegai\Orm\Util\SqlIdentifier;
 use Assegai\Orm\Util\TypeConversion\BasicTypeConverter;
@@ -60,8 +56,8 @@ use Assegai\Orm\Util\TypeConversion\TypeResolver;
 use DateInvalidTimeZoneException;
 use DateMalformedStringException;
 use DateTime;
-use DateTimeZone;
 use DateTimeImmutable;
+use DateTimeZone;
 use Exception;
 use JetBrains\PhpStorm\ArrayShape;
 use NumberFormatter;
@@ -83,2813 +79,2817 @@ use UnitEnum;
  */
 class EntityManager implements IEntityStoreOwner
 {
-  const string LOG_TAG = '[Entity Manager]';
-  const string DEFAULT_TIMEZONE = 'UTC';
-  const string DEFAULT_DELETED_AT_FORMAT = 'Y-m-d H:i:s';
+    const string LOG_TAG = '[Entity Manager]';
+    const string DEFAULT_TIMEZONE = 'UTC';
+    const string DEFAULT_DELETED_AT_FORMAT = 'Y-m-d H:i:s';
 
-  /**
-   * Once created and then reused by repositories.
-   */
-  protected array $entities = [];
+    /**
+     * Once created and then reused by repositories.
+     */
+    protected array $entities = [];
 
-  /**
-   * @var array|string[]
-   */
-  protected array $readonlyColumns = ['id', 'createdAt', 'updatedAt', 'deletedAt'];
-  /**
-   * @var array|string[]
-   */
-  protected array $secure = ['password'];
-  /**
-   * @var array
-   */
-  protected array $customSecure = [];
+    /**
+     * @var array|string[]
+     */
+    protected array $readonlyColumns = ['id', 'createdAt', 'updatedAt', 'deletedAt'];
+    /**
+     * @var array|string[]
+     */
+    protected array $secure = ['password'];
+    /**
+     * @var array
+     */
+    protected array $customSecure = [];
 
-  /**
-   * @var array An array of default converters.
-   */
-  protected array $defaultConverters = [];
+    /**
+     * @var array An array of default converters.
+     */
+    protected array $defaultConverters = [];
 
-  /**
-   * @var BasicTypeConverter[] An array of custom converters.
-   */
-  protected array $customConverters = [];
-  /**
-   * @var bool Is debug mode enabled.
-   */
-  protected bool $isDebug = false;
-  /**
-   * @var LoggerInterface The logger instance.
-   */
-  protected LoggerInterface $logger;
+    /**
+     * @var BasicTypeConverter[] An array of custom converters.
+     */
+    protected array $customConverters = [];
+    /**
+     * @var bool Is debug mode enabled.
+     */
+    protected bool $isDebug = false;
+    /**
+     * @var LoggerInterface The logger instance.
+     */
+    protected LoggerInterface $logger;
 
-  /**
-   * Constructs a new EntityManager instance.
-   *
-   * @param DataSource $connection The data source to use.
-   * @param SQLQuery|null $query The query to use.
-   * @param EntityInspector|null $entityInspector The entity inspector to use.
-   * @param TypeResolver|null $typeResolver The type resolver to use.
-   * @throws ReflectionException
-   */
-  public function __construct(protected DataSource $connection, protected ?SQLQuery $query = null, protected ?EntityInspector $entityInspector = null, protected ?TypeResolver $typeResolver = null)
-  {
-    $this->logger = new Logger(new ConsoleOutput());
-    $this->query = $query ?? SQLQuery::forConnection(db: $connection->getClient(), dialect: $connection->getDialect());
+    /**
+     * Constructs a new EntityManager instance.
+     *
+     * @param DataSource $connection The data source to use.
+     * @param SQLQuery|null $query The query to use.
+     * @param EntityInspector|null $entityInspector The entity inspector to use.
+     * @param TypeResolver|null $typeResolver The type resolver to use.
+     * @throws ReflectionException
+     */
+    public function __construct(protected DataSource $connection, protected ?SQLQuery $query = null, protected ?EntityInspector $entityInspector = null, protected ?TypeResolver $typeResolver = null)
+    {
+        $this->logger = new Logger(new ConsoleOutput());
+        $this->query = $query ?? SQLQuery::forConnection(db: $connection->getClient(), dialect: $connection->getDialect());
 
-    // TODO: *BREAKING_CHANGE* Remove this binding as it breaks the inversion of control principal
-    if (!$this->entityInspector) {
-      $this->entityInspector = EntityInspector::getInstance();
-      $this->entityInspector->setLogger($this->logger);
-    }
-
-    // TODO: *BREAKING_CHANGE* Remove this binding as it breaks the inversion of control principal
-    if (!$this->typeResolver) {
-      $this->typeResolver = TypeResolver::getInstance();
-    }
-
-    $this->defaultConverters[] = new BasicTypeConverter();
-    if ($customConverters = OrmRuntime::moduleConfig('converters', [])) {
-      foreach ($customConverters as $converterClassName) {
-        $converterReflection = new ReflectionClass($converterClassName);
-        $customConvertor = $converterReflection->newInstance();
-        $this->customConverters[] = $customConvertor;
-      }
-    }
-
-    $isDebugMode = filter_var($_ENV['DEBUG_MODE'] ?? false, FILTER_VALIDATE_BOOL);
-    $environment = strtoupper($_ENV['ENV'] ?? 'development');
-    $this->isDebug = !in_array($environment, ['PROD', 'PRODUCTION']) && $isDebugMode === true;
-  }
-
-  /**
-   * @param string|object $objectOrClass
-   * @return bool
-   * @throws ReflectionException
-   */
-  public static function objectOrClassIsNotEntity(string|object $objectOrClass): bool
-  {
-    return !self::objectOrClassIsEntity(objectOrClass: $objectOrClass);
-  }
-
-  /**
-   * Checks if the given object or class name is a valid Entity class name.
-   *
-   * @param string|object $objectOrClass The name of the class to check.
-   * @return bool Returns `true` if the given class name is an Entity instance.
-   * @throws ReflectionException
-   */
-  public static function objectOrClassIsEntity(string|object $objectOrClass): bool
-  {
-    $reflectionClass = new ReflectionClass($objectOrClass);
-    $entityAttributes = $reflectionClass->getAttributes(Entity::class);
-
-    if ($entityAttributes) {
-      return true;
-    }
-
-    if ($objectOrClass instanceof Entity) {
-      return true;
-    }
-
-    if (in_array(Entity::class, class_implements($objectOrClass))) {
-      return true;
-    }
-
-    return false;
-  }
-
-  /**
-   * Executes a raw SQL query and returns the executed database statement.
-   *
-   * @param string $query
-   * @param array $parameters
-   *
-   * @return PDOStatement|false Returns a PDOStatement object, or FALSE on failure.
-   * @link https://php.net/manual/en/pdo.query.php
-   */
-  public function query(string $query, array $parameters = []): PDOStatement|false
-  {
-    $statement = $this->connection->getClient()->prepare($query);
-
-    if ($statement === false) {
-      return false;
-    }
-
-    if (!$statement->execute($parameters)) {
-      return false;
-    }
-
-    return $statement;
-  }
-
-  /**
-   * Saves all given entities in the database.
-   * If entities do not exist in the database then inserts, otherwise updates.
-   *
-   * @param object|object[] $targetOrEntity The entity or entities to save.
-   * @param InsertOptions|UpdateOptions|null $options The insert options.
-   * @return QueryResultInterface
-   * @throws ClassNotFoundException
-   * @throws EmptyCriteriaException
-   * @throws GeneralSQLQueryException
-   * @throws IllegalTypeException
-   * @throws ORMException
-   * @throws ReflectionException
-   * @throws SaveException
-   * @throws ValidationException
-   */
-  public function save(object|array $targetOrEntity, InsertOptions|UpdateOptions|null $options = null): QueryResultInterface
-  {
-    $results = [];
-    $primaryKeyField = $options->primaryKeyField ?? 'id';
-
-    /** @var object $targetOrEntity */
-    if (is_object($targetOrEntity)) {
-      $primaryKeyValue = $targetOrEntity->{$primaryKeyField} ?? null;
-
-      if (empty($primaryKeyValue)) {
-        $saveResult = $this->insert(
-          entityClass: $targetOrEntity::class,
-          entity: $targetOrEntity,
-          options: $this->normalizeSaveInsertOptions($options)
-        );
-      } else {
-        $existingEntityResult = $this->findBy(
-          $targetOrEntity::class,
-          new FindWhereOptions(conditions: [$primaryKeyField => $primaryKeyValue])
-        );
-
-        if (!$existingEntityResult->isEmpty()) {
-          $saveResult = $this->update(
-            entityClass: $targetOrEntity::class,
-            partialEntity: $targetOrEntity,
-            conditions: [$primaryKeyField => $primaryKeyValue],
-            options: $this->normalizeSaveUpdateOptions($options)
-          );
-        } else {
-          $saveResult = $this->insert(
-            entityClass: $targetOrEntity::class,
-            entity: $targetOrEntity,
-            options: $this->normalizeSaveInsertOptions($options)
-          );
+        // TODO: *BREAKING_CHANGE* Remove this binding as it breaks the inversion of control principal
+        if (!$this->entityInspector) {
+            $this->entityInspector = EntityInspector::getInstance();
+            $this->entityInspector->setLogger($this->logger);
         }
-      }
 
-      if ($saveResult instanceof InsertResult || $saveResult instanceof UpdateResult || $saveResult instanceof DeleteResult) {
-        return $saveResult;
-      }
+        // TODO: *BREAKING_CHANGE* Remove this binding as it breaks the inversion of control principal
+        if (!$this->typeResolver) {
+            $this->typeResolver = TypeResolver::getInstance();
+        }
 
-      return $this->findBy($targetOrEntity::class, new FindWhereOptions(conditions: [$primaryKeyField => $this->query->lastInsertId()]));
-    }
-
-    foreach ($targetOrEntity as $entity) {
-      $results[] = $this->save(targetOrEntity: $entity, options: $options);
-    }
-
-    return new SQLQueryResult($results);
-  }
-
-  private function normalizeSaveInsertOptions(InsertOptions|UpdateOptions|null $options): InsertOptions
-  {
-    if ($options instanceof InsertOptions) {
-      return $options;
-    }
-
-    if ($options instanceof UpdateOptions) {
-      return new InsertOptions(
-        relations: $options->relations,
-        isDebug: $options->isDebug,
-        readonlyColumns: $options->readonlyColumns,
-        primaryKeyField: $options->primaryKeyField,
-      );
-    }
-
-    return new InsertOptions();
-  }
-
-  private function normalizeSaveUpdateOptions(InsertOptions|UpdateOptions|null $options): UpdateOptions
-  {
-    if ($options instanceof UpdateOptions) {
-      return $options;
-    }
-
-    if ($options instanceof InsertOptions) {
-      return new UpdateOptions(
-        relations: $options->relations,
-        isDebug: $options->isDebug,
-        readonlyColumns: $options->readonlyColumns,
-        primaryKeyField: $options->primaryKeyField,
-      );
-    }
-
-    return new UpdateOptions();
-  }
-
-  /**
-   * Inserts a given entity into the database.
-   * Unlike the save method executes a primitive operation without
-   * cascades, relations and other operations included.
-   * Executes a fast and efficient `INSERT` query.
-   * Does not check if the entity exist in the database, so the query will fail if
-   * duplicate entity is being inserted.
-   * You can execute bulk inserts using this method.
-   *
-   * @template TEntity of object
-   * @param class-string<TEntity> $entityClass The entity class name.
-   * @param TEntity|array<string, mixed> $entity The entity to insert.
-   * @param InsertOptions|null $options The options to use when inserting the entity.
-   * @return InsertResult<TEntity>
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function insert(string $entityClass, array|object $entity, ?InsertOptions $options = null): InsertResult
-  {
-    # Check if the entity matches the given entity class
-    if (!$this->entityInspector->hasValidEntityStructure(entity: $entity, entityClass: $entityClass)) {
-      return new InsertResult(identifiers: $entity, raw: $this->query->queryString(), generatedMaps: null, errors: [new ORMException("Entity does not match the given entity class.")]);
-    }
-
-    $instance = $this->create(entityClass: $entityClass, entityLike: (object)$entity);
-    $primaryKey = $this->getPrimaryKeyMetadata($instance);
-    $primaryKeyField = $primaryKey['field'];
-    $columnsMeta = [];
-    $relations = [];
-    $relationProperties = [];
-
-    if ($options?->relations) {
-      $relations = is_object($options->relations) ? (array)$options->relations : $options->relations;
-    }
-
-    $columns = $this->entityInspector->getColumns(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnsMeta);
-    $values = $this->entityInspector->getValues(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, options: ['relations' => $relations, 'relation_properties' => $relationProperties, 'filter' => true, 'column_types' => $columnsMeta['column_types'] ?? []]);
-
-    $columnCount = count($columns);
-    $valueCount = count($values);
-
-    $this->query->insertInto(tableName: $this->entityInspector->getTableName(entity: $instance))->singleRow(columns: $columns)->values(valuesList: $values);
-
-    if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
-      $this->query->appendQueryString('RETURNING ' . $this->buildReturningProjection($instance));
-    }
-
-    if ($this->isDebug || $options?->isDebug) {
-      $this->query->debug();
-    }
-
-    $result = $this->query->execute();
-    $raw = $result->getRaw();
-
-    if ($result->isError()) {
-      if (!headers_sent()) {
-        http_response_code(500);
-      }
-      $error = new GeneralSQLQueryException($this->query);
-      OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
-
-      return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$error]);
-    }
-
-    if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
-      $generatedMaps = $this->hydrateGeneratedMaps($entityClass, $result->getData()) ?? $instance;
-      $generatedMaps = $this->sanitizeGeneratedMaps($generatedMaps);
-      $identifierValue = $generatedMaps?->{$primaryKeyField} ?? $instance->{$primaryKeyField} ?? $this->lastInsertId();
-
-      if ($identifierValue !== null && $identifierValue !== '') {
-        $instance->{$primaryKeyField} = $identifierValue;
-      }
-
-      return new InsertResult(
-        identifiers: (object)[$primaryKeyField => $identifierValue],
-        raw: $raw,
-        generatedMaps: $generatedMaps,
-        errors: [],
-        affected: $this->query->rowCount() ?? 0,
-      );
-    }
-
-    # Find the record by the resolved primary key and hydrate the entity
-    $identifierCandidates = [];
-    $explicitIdentifierValue = $instance->{$primaryKeyField} ?? null;
-    $lastInsertId = $this->lastInsertId();
-
-    if ($explicitIdentifierValue !== null && $explicitIdentifierValue !== '') {
-      $identifierCandidates[] = $explicitIdentifierValue;
-    }
-
-    if ($lastInsertId !== null && $lastInsertId !== '' && !in_array($lastInsertId, $identifierCandidates, true)) {
-      $identifierCandidates[] = $lastInsertId;
-    }
-
-    if (empty($identifierCandidates)) {
-      $identifierCandidates[] = $explicitIdentifierValue;
-    }
-
-    $identifierValue = $identifierCandidates[0] ?? null;
-    $result = null;
-
-    foreach ($identifierCandidates as $candidateIdentifierValue) {
-      $lookupResult = $this->findOne(
-        entityClass: $entityClass,
-        options: new FindOneOptions(where: [$primaryKeyField => $candidateIdentifierValue])
-      );
-
-      $result = $lookupResult;
-
-      if (!$lookupResult->isError() && !$lookupResult->isEmpty()) {
-        $identifierValue = $candidateIdentifierValue;
-        break;
-      }
-    }
-
-    if ($result?->isError()) {
-      if (!headers_sent()) {
-        http_response_code(500);
-      }
-      $error = new GeneralSQLQueryException($this->query);
-      OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
-
-      return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$result->getErrors()]);
-    }
-
-    $entity = is_array($result->getData()) && array_is_list($result->getData())
-      ? ($result->getData()[0] ?? null)
-      : $result->getData();
-
-    if (is_object($entity) && isset($entity->{$primaryKeyField}) && $entity->{$primaryKeyField} !== null && $entity->{$primaryKeyField} !== '') {
-      $identifierValue = $entity->{$primaryKeyField};
-    }
-
-    $generatedMaps = (object)array_merge((array)$entity, (array)new stdClass());
-    $generatedMaps->{$primaryKeyField} = $identifierValue;
-
-    foreach ($generatedMaps as $prop => $value) {
-      if (in_array($prop, $this->getSecure())) {
-        unset($generatedMaps->$prop);
-      }
-    }
-
-    $identifiers = is_array($entity) ? (object)$entity : $entity;
-
-    return new InsertResult(identifiers: $identifiers, raw: $raw, generatedMaps: $generatedMaps);
-  }
-
-  /**
-   * Creates a new entity instance or instances. Optionally accepts an object literal with entity
-   * properties which will be written into newly created Entity object.
-   *
-   * @param string $entityClass
-   * @param object|array|null $entityLike An entity like object or array literal with entity properties
-   *
-   * @return object Returns a newly created Entity object
-   * @throws ClassNotFoundException
-   * @throws ORMException|ReflectionException
-   */
-  public function create(string $entityClass, null|object|array $entityLike = null): object
-  {
-    $this->validateEntityName(entityClass: $entityClass);
-
-    $entity = new $entityClass;
-
-    if (!empty($entityLike)) {
-      foreach ($entityLike as $entityLikePropertyName => $entityLikePropertyValue) {
-        if (property_exists($entity, $entityLikePropertyName)) {
-          $entityClassReflectionProperty = new ReflectionProperty($entityClass, $entityLikePropertyName);
-
-          if (is_null($entityLikePropertyValue)) {
-            $entityLikePropertyValue = $this->getDefaultColumnValue($entityClassReflectionProperty);
-
-            if (!$entityClassReflectionProperty->getType()->allowsNull()) {
-              continue;
+        $this->defaultConverters[] = new BasicTypeConverter();
+        if ($customConverters = OrmRuntime::moduleConfig('converters', [])) {
+            foreach ($customConverters as $converterClassName) {
+                $converterReflection = new ReflectionClass($converterClassName);
+                $customConvertor = $converterReflection->newInstance();
+                $this->customConverters[] = $customConvertor;
             }
-          }
-
-          $entityLikeReflectionPropertyType = is_array($entityLike)
-            ? strtolower(gettype($entityLikePropertyValue))
-            : match (true) {
-              (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType() instanceof ReflectionUnionType => strtolower(gettype($entityLikePropertyValue)),
-              default => (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType()?->getName()
-            };
-          $entityClassReflectionPropertyType = match (true) {
-            $entityClassReflectionProperty->getType() instanceof ReflectionUnionType => strval($entityClassReflectionProperty->getType()),
-            default => $entityClassReflectionProperty->getType()?->getName()
-          };
-          $typesMatch = ($entityLikeReflectionPropertyType === $entityClassReflectionPropertyType) || ( (!empty($entityClassReflectionPropertyType) && !empty($entityLikeReflectionPropertyType))  && str_contains($entityClassReflectionPropertyType, ($entityLikeReflectionPropertyType ?? '')) );
-
-          $sourceType = $entityLikeReflectionPropertyType ?? gettype($entityLikePropertyValue);
-          $targetType = $entityClassReflectionPropertyType ?? gettype($entityLikePropertyValue);
-
-          $entity->$entityLikePropertyName = $typesMatch ? $entityLikePropertyValue : $this->castValue(value: $entityLikePropertyValue, sourceType: $sourceType, targetType: $targetType) ?? $entityLikePropertyValue;
-        }
-      }
-    }
-
-    return $entity;
-  }
-
-  /**
-   * Asserts that the specified class name is a valid entity and throws an exception if it is not.
-   *
-   * @param string $entityClass The name of the class to validate.
-   * @return void
-   * @throws ClassNotFoundException If the class does not exist.
-   * @throws ORMException If the class does not have the required attributes.
-   */
-  public static function validateEntityName(string $entityClass): void
-  {
-    EntityInspector::getInstance()->validateEntityName(entityClass: $entityClass);
-  }
-
-  /**
-   * Returns the default value for a given column. If no default value is specified, returns null.
-   *
-   * @param ReflectionProperty $reflectionProperty The reflection property to get the default value for.
-   * @return mixed Returns the default value for the given column.
-   * @throws ValidationException If the default value is invalid.
-   */
-  private function getDefaultColumnValue(ReflectionProperty $reflectionProperty): mixed
-  {
-    # Load Column attribute for the property
-    $attributes = $reflectionProperty->getAttributes();
-
-    foreach ($attributes as $attribute) {
-      $attributeInstance = $attribute->newInstance();
-
-      if (!property_exists($attributeInstance, 'default')) {
-        continue;
-      }
-
-      try {
-        # Check if a default value is specified
-        if (!is_null($attributeInstance->default)) {
-          return match (true) {
-            $attributeInstance->default === 'CURRENT_TIMESTAMP', $attributeInstance->default === 'NOW()' => new DateTime(),
-            # Match ISO 8601 date format
-            preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $attributeInstance->default) => new DateTime($attributeInstance->default),
-            # Match ATOM date format
-            preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+$/', $attributeInstance->default) => new DateTime($attributeInstance->default),
-            default => $attributeInstance->default
-          };
-        }
-      } catch (Exception $exception) {
-        throw new ValidationException($exception);
-      }
-    }
-
-    # If no default value is specified, return null
-    return null;
-  }
-
-  /**
-   * @throws ReflectionException
-   * @throws TypeConversionException
-   */
-  private function castValue(mixed $value, string $sourceType, string $targetType): mixed
-  {
-    if (is_null($value)) {
-      return null;
-    }
-
-    foreach ($this->customConverters as $converter) {
-      $result = $this->typeResolver->resolve(converterHost: $converter, value: $value, fromType: $sourceType, toType: $targetType);
-
-      if (!is_null($result)) {
-        return $result;
-      }
-    }
-
-    foreach ($this->defaultConverters as $converter) {
-      $result = $this->typeResolver->resolve(converterHost: $converter, value: $value, fromType: $sourceType, toType: $targetType);
-
-      if (!is_null($result)) {
-        return $result;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Finds first entity by a given find options.
-   * If entity was not found in the database - returns null.
-   *
-   * @param string $entityClass
-   * @param FindOptions|FindOneOptions $options
-   * @return FindResult
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function findOne(string $entityClass, FindOptions|FindOneOptions $options): FindResult
-  {
-    $result = $this->find(entityClass: $entityClass, findOptions: $options);
-
-    if ($result->isError()) {
-      return $result;
-    }
-
-    if ($result->getTotal() === 0) {
-      return new FindResult(raw: $result->getRaw(), data: null);
-    }
-
-    /** @var Entity $entityClass */
-    return new FindResult(raw: $result->getRaw(), data: $result->getData()[0] ?? null);
-  }
-
-  /**
-   * Find entities that match the given `FindOptions`.
-   *
-   * @param string $entityClass
-   * @param null|FindOptions $findOptions
-   *
-   * @return FindResult<T>
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function find(string $entityClass, ?FindOptions $findOptions = new FindOptions()): FindResult
-  {
-    $entity = $this->create(entityClass: $entityClass);
-    $conditions = [];
-    $availableRelations = [];
-    $requestedRelations = $this->getRequestedRelationNames($findOptions);
-    $baseExcludeColumns = $this->resolveBaseEntityExcludeColumns($findOptions, $requestedRelations);
-
-    if ($deleteColumnName = $this->getDeleteDateColumnName(entityClass: $entityClass)) {
-      $conditions = array_merge($findOptions->where->conditions ?? $findOptions->where ?? [], [$deleteColumnName => 'NULL']);
-    }
-
-    $columns = $this->entityInspector->getColumns(
-      entity: $entity,
-      exclude: $baseExcludeColumns,
-      relations: $requestedRelations,
-      relationProperties: $availableRelations
-    );
-    $columns = $this->appendRequiredRelationColumns($entity, $columns, $availableRelations);
-
-    $tableName = $this->entityInspector->getTableName(entity: $entity);
-    $statement = $this->query->select()->all(columns: $columns)->from(tableReferences: $tableName);
-
-    if (!empty($findOptions)) {
-      foreach ($requestedRelations as $relationName) {
-        if (!isset($availableRelations[$relationName])) {
-          if ($this->isDebug) {
-            throw new ORMException("Relation $relationName does not exist in the entity $entityClass.");
-          }
-
-          $this->logger->warning("Relation $relationName does not exist in the entity $entityClass. \n\tThrown in " . __FILE__ . ' on line ' . __LINE__);
-        }
-      }
-
-      # Resolve where conditions
-      if ($conditions) {
-        $findWhereOptions = new FindWhereOptions(conditions: $conditions, entityClass: $entityClass);
-      }
-
-      $statement = $statement->where(condition: $findWhereOptions ?? $findOptions);
-    }
-
-    if ($findOptions->order) {
-      $statement->orderBy($findOptions->order);
-    }
-
-    $limit = $findOptions->limit ?? $_GET['limit'] ?? OrmRuntime::defaultLimit();
-    $skip = $findOptions->skip ?? $_GET['skip'] ?? OrmRuntime::defaultSkip();
-
-    $statement = $statement->limit(limit: $limit, offset: $skip);
-
-    if ($this->isDebug || $findOptions->isDebug) {
-      $statement->debug();
-    }
-
-    $result = $statement->execute();
-
-    if ($result->isError()) {
-      return new FindResult(raw: $result->getRaw(), data: $result->value(), errors: [new GeneralSQLQueryException($this->query), ...$result->getErrors()], affected: $result->getTotalAffectedRows());
-    }
-
-    $loadedRelations = $this->loadRequestedRelations($entityClass, $result->getData(), $findOptions, $availableRelations);
-    $resultSet = $this->processRelations($result->getData(), $entityClass, $findOptions, $availableRelations, $loadedRelations);
-    $resultSet = $this->stripExcludedColumns($resultSet, $findOptions->exclude ?? []);
-
-    if ($findOptions->withRealTotal) {
-      $total = $this->count(entityClass: $entityClass, options: $findOptions);
-
-      if (count($resultSet) === 0) {
-        $total = 0;
-      }
-
-      return new FindResult(raw: $result->getRaw(), data: $resultSet, errors: $result->getErrors(), total: $total);
-    }
-
-    return new FindResult(raw: $result->getRaw(), data: $resultSet, errors: $result->getErrors());
-  }
-
-  /**
-   * @param string|ReflectionClass $entityClass
-   * @return string|null
-   * @throws ReflectionException
-   */
-  private function getDeleteDateColumnName(string|ReflectionClass $entityClass): ?string
-  {
-    # If $entityClass is a string, get a reflection class
-    $reflection = is_string($entityClass) ? new ReflectionClass($entityClass) : $entityClass;
-
-    # Get properties
-    $properties = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
-
-    foreach ($properties as $property) {
-      # Find DeleteDateColumn attribute
-      $deleteDateColumnAttributes = $property->getAttributes(DeleteDateColumn::class);
-
-      if (empty($deleteDateColumnAttributes)) {
-        continue;
-      }
-
-      # If name is specified use name, else use property name
-      $columnInstance = $deleteDateColumnAttributes[0]->newInstance();
-
-      return $columnInstance->name ?? $property->getName();
-    }
-
-    return null;
-  }
-
-  /**
-   * @param FindOptions|null $findOptions
-   * @return string[]
-   */
-  protected function getRequestedRelationNames(?FindOptions $findOptions): array
-  {
-    $relations = $findOptions?->relations ?? [];
-
-    if (!is_array($relations)) {
-      $relations = (array)$relations;
-    }
-
-    if (array_is_list($relations)) {
-      return array_values(
-        array_filter(
-          array_map(
-            fn($relation) => is_string($relation) ? trim($relation) : null,
-            $relations
-          )
-        )
-      );
-    }
-
-    $requestedRelations = [];
-
-    foreach ($relations as $relation => $enabled) {
-      if (!is_string($relation)) {
-        continue;
-      }
-
-      if ($enabled) {
-        $requestedRelations[] = trim($relation);
-      }
-    }
-
-    return $requestedRelations;
-  }
-
-  /**
-   * Keeps relation keys available internally even when callers exclude them from the final payload.
-   *
-   * @param FindOptions|null $findOptions
-   * @param string[] $requestedRelations
-   * @return string[]
-   */
-  private function resolveBaseEntityExcludeColumns(?FindOptions $findOptions, array $requestedRelations): array
-  {
-    $excludeColumns = $findOptions?->exclude ?? [];
-
-    if (empty($excludeColumns) || empty($requestedRelations)) {
-      return $excludeColumns;
-    }
-
-    $requiredColumns = array_unique(array_merge(['id'], $requestedRelations));
-
-    return array_values(
-      array_filter(
-        $excludeColumns,
-        fn(string $column): bool => !in_array($column, $requiredColumns, true)
-      )
-    );
-  }
-
-  /**
-   * Ensures relation loading can still read required local keys from the root entity rows.
-   *
-   * @param array<int|string, string> $columns
-   * @param array<string, RelationPropertyMetadata> $availableRelations
-   * @return array<int|string, string>
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  private function appendRequiredRelationColumns(object $entity, array $columns, array $availableRelations): array
-  {
-    foreach ($availableRelations as $relationProperty) {
-      if (!$relationProperty instanceof RelationPropertyMetadata) {
-        continue;
-      }
-
-      $columns = match ($relationProperty->getRelationType()) {
-        RelationType::ONE_TO_ONE => $relationProperty->joinColumn
-          ? $this->appendJoinColumnSelection(
-            columns: $columns,
-            entityClass: $entity::class,
-            propertyName: $relationProperty->name,
-            joinColumn: $relationProperty->joinColumn
-          )
-          : $this->appendPropertyColumnSelection(
-            columns: $columns,
-            entity: $entity,
-            propertyName: 'id'
-          ),
-        RelationType::ONE_TO_MANY => $this->appendPropertyColumnSelection(
-          columns: $columns,
-          entity: $entity,
-          propertyName: $relationProperty->relationAttribute->referencedProperty ?? 'id'
-        ),
-        RelationType::MANY_TO_ONE => $this->appendJoinColumnSelection(
-          columns: $columns,
-          entityClass: $entity::class,
-          propertyName: $relationProperty->name,
-          joinColumn: $relationProperty->joinColumn
-            ?? $this->entityInspector->getJoinColumnAttribute($entity::class, $relationProperty->name)
-        ),
-        RelationType::MANY_TO_MANY => $this->appendPropertyColumnSelection(
-          columns: $columns,
-          entity: $entity,
-          propertyName: 'id'
-        ),
-        default => $columns,
-      };
-    }
-
-    return $columns;
-  }
-
-  /**
-   * @param array<int|string, string> $columns
-   * @return array<int|string, string>
-   */
-  private function appendPropertyColumnSelection(array $columns, object $entity, string $propertyName): array
-  {
-    if (!property_exists($entity, $propertyName)) {
-      return $columns;
-    }
-
-    $reflectionProperty = new ReflectionProperty($entity, $propertyName);
-
-    foreach ($reflectionProperty->getAttributes() as $attribute) {
-      $attributeInstance = $attribute->newInstance();
-
-      if (!$attributeInstance instanceof Column) {
-        continue;
-      }
-
-      $tableName = $this->entityInspector->getTableName($entity);
-      $columnName = $attributeInstance->name ?? $propertyName;
-      $columnAlias = $attributeInstance->alias ?: ($attributeInstance->name ? $propertyName : null);
-
-      return $this->appendColumnSelection($columns, $columnAlias, "$tableName.$columnName");
-    }
-
-    return $columns;
-  }
-
-  /**
-   * @param array<int|string, string> $columns
-   * @return array<int|string, string>
-   * @throws ORMException
-   */
-  private function appendJoinColumnSelection(array $columns, string $entityClass, string $propertyName, JoinColumn $joinColumn): array
-  {
-    $tableName = $this->entityInspector->getTableName($this->create($entityClass));
-    $columnName = $joinColumn->effectiveColumnName ?? $joinColumn->name ?? $propertyName;
-
-    return $this->appendColumnSelection($columns, $propertyName, "$tableName.$columnName");
-  }
-
-  /**
-   * @param array<int|string, string> $columns
-   * @return array<int|string, string>
-   */
-  private function appendColumnSelection(array $columns, ?string $columnAlias, string $columnSelection): array
-  {
-    if (
-      ($columnAlias !== null && array_key_exists($columnAlias, $columns)) ||
-      in_array($columnSelection, $columns, true) ||
-      in_array($columnSelection, array_values($columns), true)
-    ) {
-      return $columns;
-    }
-
-    if ($columnAlias === null) {
-      $columns[] = $columnSelection;
-      return $columns;
-    }
-
-    $columns[$columnAlias] = $columnSelection;
-
-    return $columns;
-  }
-
-  /**
-   * @param object[] $rows
-   * @param string[] $excludeColumns
-   * @return object[]
-   */
-  private function stripExcludedColumns(array $rows, array $excludeColumns): array
-  {
-    if (empty($excludeColumns)) {
-      return $rows;
-    }
-
-    return array_map(function(object|array $row) use ($excludeColumns): object {
-      $row = is_array($row) ? (object)$row : $row;
-
-      foreach ($excludeColumns as $column) {
-        unset($row->{$column});
-      }
-
-      return $row;
-    }, $rows);
-  }
-
-  /**
-   * Generates an alias for a given table name.
-   *
-   * @param string $tableName The table name to generate an alias for.
-   * @param array $knownAliases The list of known aliases.
-   * @return string Returns the generated alias.
-   */
-  private function generateAlias(string $tableName, array &$knownAliases): string
-  {
-    $tableNameLetters = str_split($tableName);
-    $alias = '';
-
-    foreach ($tableNameLetters as $letter) {
-      $alias .= $letter;
-      if (!in_array($alias, $knownAliases)) {
-        $knownAliases[] = $alias;
-        return $alias;
-      }
-    }
-
-    return $alias;
-  }
-
-  /**
-   * Processes the relations of the given data.
-   *
-   * @param object[] $data The data to process.
-   * @param string $entityClass The entity class name.
-   * @param FindWhereOptions|FindOptions|null $findOptions The find options.
-   * @param RelationPropertyMetadata[] $relationInfo The relation information.
-   * @param array $loadedRelations The loaded relations.
-   * @return object[] Returns the processed data.
-   */
-  private function processRelations(array $data, string $entityClass, FindWhereOptions|FindOptions|null $findOptions, array $relationInfo, array $loadedRelations): array
-  {
-    if (!$findOptions || !$findOptions->relations) {
-      return $data;
-    }
-
-    $results = [];
-    $requestedRelations = $this->getRequestedRelationNames($findOptions);
-
-    foreach ($data as $datum) {
-      if (is_array($datum)) {
-        $datum = (object)$datum;
-      }
-
-      foreach ($requestedRelations as $relation) {
-        if (!isset($relationInfo[$relation])) {
-          $this->logger->warning("Relation $relation does not exist in the entity $entityClass. \n\tThrown in " . __FILE__ . ' on line ' . __LINE__);
-          continue;
         }
 
-        $datum = $this->bindEntityRelations($entityClass, $datum, $relation, $relationInfo[$relation], $loadedRelations);
-      }
-
-      $results[] = $datum;
+        $isDebugMode = filter_var($_ENV['DEBUG_MODE'] ?? false, FILTER_VALIDATE_BOOL);
+        $environment = strtoupper($_ENV['ENV'] ?? 'development');
+        $this->isDebug = !in_array($environment, ['PROD', 'PRODUCTION']) && $isDebugMode === true;
     }
 
-    return $results;
-  }
-
-  /**
-   * Binds entity relations to the entity.
-   *
-   * @param string $entityClass The entity class name.
-   * @param object $entity The entity to bind the relations to.
-   * @param string $relationName The name of the relation to bind.
-   * @param RelationPropertyMetadata $relationInfo The relation information.
-   * @param array<string, mixed> $loadedRelations The loaded relations. This list is used to prevent previously loaded relations from being loaded again.
-   * @return object Returns the entity with the relations bound.
-   */
-  private function bindEntityRelations(string $entityClass, object $entity, string $relationName, RelationPropertyMetadata $relationInfo, array $loadedRelations): object
-  {
-    if ($this->isDebug) {
-      $this->logger->debug("Restructuring entity $entityClass with relation $relationName");
+    /**
+     * @param string|object $objectOrClass
+     * @return bool
+     * @throws ReflectionException
+     */
+    public static function objectOrClassIsNotEntity(string|object $objectOrClass): bool
+    {
+        return !self::objectOrClassIsEntity(objectOrClass: $objectOrClass);
     }
 
-    $entity = is_array($entity) ? (object)$entity : $entity;
-    $relationValue = match ($relationInfo->getRelationType()) {
-      RelationType::ONE_TO_ONE => $this->resolveOneToOneRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
-      RelationType::ONE_TO_MANY => $this->resolveOneToManyRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
-      RelationType::MANY_TO_ONE => $this->resolveManyToOneRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
-      RelationType::MANY_TO_MANY => $this->resolveManyToManyRelationValue($entity, $loadedRelations[$relationName] ?? []),
-      default => null,
-    };
+    /**
+     * Checks if the given object or class name is a valid Entity class name.
+     *
+     * @param string|object $objectOrClass The name of the class to check.
+     * @return bool Returns `true` if the given class name is an Entity instance.
+     * @throws ReflectionException
+     */
+    public static function objectOrClassIsEntity(string|object $objectOrClass): bool
+    {
+        $reflectionClass = new ReflectionClass($objectOrClass);
+        $entityAttributes = $reflectionClass->getAttributes(Entity::class);
 
-    $entity->$relationName = $relationValue;
-    return $entity;
-  }
+        if ($entityAttributes) {
+            return true;
+        }
 
-  /**
-   * @param array<int, object|array> $data
-   * @param array<string, RelationPropertyMetadata> $availableRelations
-   * @return array<string, array<mixed, mixed>>
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  private function loadRequestedRelations(string $entityClass, array $data, ?FindOptions $findOptions, array $availableRelations): array
-  {
-    if (!$findOptions || !$findOptions->relations || empty($data)) {
-      return [];
+        if ($objectOrClass instanceof Entity) {
+            return true;
+        }
+
+        if (in_array(Entity::class, class_implements($objectOrClass))) {
+            return true;
+        }
+
+        return false;
     }
 
-    $loadedRelations = [];
-    $rows = array_map(
-      fn(object|array $row) => is_array($row) ? (object)$row : $row,
-      $data
-    );
+    /**
+     * Executes a raw SQL query and returns the executed database statement.
+     *
+     * @param string $query
+     * @param array $parameters
+     *
+     * @return PDOStatement|false Returns a PDOStatement object, or FALSE on failure.
+     * @link https://php.net/manual/en/pdo.query.php
+     */
+    public function query(string $query, array $parameters = []): PDOStatement|false
+    {
+        $statement = $this->connection->getClient()->prepare($query);
 
-    foreach ($this->getRequestedRelationNames($findOptions) as $relationName) {
-      $relationProperty = $availableRelations[$relationName] ?? null;
+        if ($statement === false) {
+            return false;
+        }
 
-      if (!$relationProperty instanceof RelationPropertyMetadata) {
-        continue;
-      }
+        if (!$statement->execute($parameters)) {
+            return false;
+        }
 
-      $loadedRelations[$relationName] = match ($relationProperty->getRelationType()) {
-        RelationType::ONE_TO_ONE => $this->loadOneToOneRelation($entityClass, $rows, $relationProperty, $findOptions),
-        RelationType::ONE_TO_MANY => $this->loadOneToManyRelation($rows, $relationProperty, $findOptions),
-        RelationType::MANY_TO_ONE => $this->loadManyToOneRelation($rows, $relationProperty, $findOptions),
-        RelationType::MANY_TO_MANY => $this->loadManyToManyRelation($entityClass, $rows, $relationProperty, $findOptions),
-        default => [],
-      };
+        return $statement;
     }
 
-    return $loadedRelations;
-  }
-
-  /**
-   * @param object[] $rows
-   * @return array<mixed, object>
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  private function loadManyToOneRelation(array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
-  {
-    $targetClass = $relationProperty->getEntityClass();
-
-    if (!$targetClass) {
-      return [];
-    }
-
-    $foreignKeys = $this->extractScalarValues($rows, $relationProperty->name);
-    if (empty($foreignKeys)) {
-      return [];
-    }
-
-    $joinColumn = $relationProperty->joinColumn ?? $this->entityInspector->getJoinColumnAttribute($relationProperty->reflectionProperty->getDeclaringClass()->getName(), $relationProperty->name);
-    $referenceColumn = $joinColumn->effectiveReferencedColumnName ?? 'id';
-    $relatedRows = $this->fetchEntityRows(
-      entityClass: $targetClass,
-      conditionColumn: $referenceColumn,
-      conditionValues: $foreignKeys,
-      excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions)
-    );
-
-    $groupedRows = [];
-    foreach ($relatedRows as $relatedRow) {
-      $key = $relatedRow->{$referenceColumn} ?? null;
-      if ($key !== null) {
-        $groupedRows[$key] = $relatedRow;
-      }
-    }
-
-    return $groupedRows;
-  }
-
-  /**
-   * @param object[] $rows
-   * @return array<mixed, object>
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  private function loadOneToOneRelation(string $entityClass, array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
-  {
-    if ($relationProperty->joinColumn) {
-      return $this->loadManyToOneRelation($rows, $relationProperty, $findOptions);
-    }
-
-    $targetClass = $relationProperty->getEntityClass();
-    if (!$targetClass) {
-      return [];
-    }
-
-    $inverseOwner = $this->resolveInverseOneToOneOwner($entityClass, $relationProperty);
-    if (!$inverseOwner) {
-      return [];
-    }
-
-    $localIds = $this->extractScalarValues($rows, 'id');
-    if (empty($localIds)) {
-      return [];
-    }
-
-    $inversePropertyName = $inverseOwner['property'];
-    $joinColumn = $inverseOwner['joinColumn'];
-    $relatedRows = $this->fetchEntityRows(
-      entityClass: $targetClass,
-      conditionColumn: $joinColumn->effectiveColumnName ?? $joinColumn->name ?? 'id',
-      conditionValues: $localIds,
-      excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions),
-      relations: [$inversePropertyName]
-    );
-
-    $groupedRows = [];
-    foreach ($relatedRows as $relatedRow) {
-      $ownerKey = $relatedRow->{$inversePropertyName} ?? null;
-      unset($relatedRow->{$inversePropertyName});
-
-      if ($ownerKey !== null) {
-        $groupedRows[$ownerKey] = $relatedRow;
-      }
-    }
-
-    return $groupedRows;
-  }
-
-  /**
-   * @param object[] $rows
-   * @return array<mixed, object[]>
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  private function loadOneToManyRelation(array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
-  {
-    $targetClass = $relationProperty->getEntityClass();
-    $referenceProperty = $relationProperty->relationAttribute->referencedProperty ?? 'id';
-    $inverseProperty = $relationProperty->relationAttribute->inverseSide ?? null;
-
-    if (!$targetClass || !$inverseProperty) {
-      return [];
-    }
-
-    $localKeys = $this->extractScalarValues($rows, $referenceProperty);
-    if (empty($localKeys)) {
-      return [];
-    }
-
-    $joinColumn = $this->entityInspector->getJoinColumnAttribute($targetClass, $inverseProperty);
-    $relatedRows = $this->fetchEntityRows(
-      entityClass: $targetClass,
-      conditionColumn: $joinColumn->effectiveColumnName ?? $joinColumn->name ?? 'id',
-      conditionValues: $localKeys,
-      excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions),
-      relations: [$inverseProperty]
-    );
-
-    $groupedRows = [];
-    foreach ($relatedRows as $relatedRow) {
-      $ownerKey = $relatedRow->{$inverseProperty} ?? null;
-      unset($relatedRow->{$inverseProperty});
-
-      if ($ownerKey === null) {
-        continue;
-      }
-
-      $groupedRows[$ownerKey] ??= [];
-      $groupedRows[$ownerKey][] = $relatedRow;
-    }
-
-    return $groupedRows;
-  }
-
-  /**
-   * @param object[] $rows
-   * @return array<mixed, object[]>
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  private function loadManyToManyRelation(string $entityClass, array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
-  {
-    $mapping = $this->resolveManyToManyMapping($entityClass, $relationProperty);
-    if (!$mapping) {
-      return [];
-    }
-
-    $localIds = $this->extractScalarValues($rows, 'id');
-    if (empty($localIds)) {
-      return [];
-    }
-
-    $targetClass = $relationProperty->getEntityClass();
-    if (!$targetClass) {
-      return [];
-    }
-
-    $targetEntity = $this->create($targetClass);
-    $targetTable = $this->entityInspector->getTableName($targetEntity);
-    $joinTable = $mapping['joinTable'];
-    $localJoinColumn = $mapping['localJoinColumn'];
-    $targetJoinColumn = $mapping['targetJoinColumn'];
-    $joinTableName = $joinTable->name ?? strtolower($mapping['ownerTable'] . '_' . $mapping['targetTable']);
-
-    $columns = $this->entityInspector->getColumns(
-      entity: $targetEntity,
-      exclude: $this->resolveRelationExcludeColumns($relationProperty, $findOptions)
-    );
-    $columns['__relation_owner_key'] = "$joinTableName.$localJoinColumn";
-
-    $query = SQLQuery::forConnection($this->query->getConnection(), dialect: $this->query->getDialect());
-    $statement = $query
-      ->select()
-      ->all(columns: $columns)
-      ->from(tableReferences: $targetTable)
-      ->join($joinTableName)
-      ->on("$joinTableName.$targetJoinColumn = $targetTable.id");
-    $condition = $this->buildInCondition("$joinTableName.$localJoinColumn", $localIds, $query);
-    if (!$condition) {
-      return [];
-    }
-
-    $result = $statement
-      ->where($condition)
-      ->execute();
-
-    if ($result->isError()) {
-      throw new GeneralSQLQueryException($query);
-    }
-
-    $groupedRows = [];
-    foreach ($result->getData() as $row) {
-      $row = is_array($row) ? (object)$row : $row;
-      $ownerKey = $row->__relation_owner_key ?? null;
-      unset($row->__relation_owner_key);
-
-      if ($ownerKey === null) {
-        continue;
-      }
-
-      $groupedRows[$ownerKey] ??= [];
-      $groupedRows[$ownerKey][] = $row;
-    }
-
-    return $groupedRows;
-  }
-
-  /**
-   * @param string[] $excludeColumns
-   * @param string[] $relations
-   * @return object[]
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  private function fetchEntityRows(string $entityClass, string $conditionColumn, array $conditionValues, array $excludeColumns = ['password'], array $relations = []): array
-  {
-    if (empty($conditionValues)) {
-      return [];
-    }
-
-    $entity = $this->create($entityClass);
-    $columns = $this->entityInspector->getColumns(entity: $entity, exclude: $excludeColumns, relations: $relations);
-    $tableName = $this->entityInspector->getTableName($entity);
-    $query = SQLQuery::forConnection($this->query->getConnection(), dialect: $this->query->getDialect());
-    $statement = $query
-      ->select()
-      ->all(columns: $columns)
-      ->from(tableReferences: $tableName);
-    $condition = $this->buildInCondition("$tableName.$conditionColumn", $conditionValues, $query);
-
-    if (!$condition) {
-      return [];
-    }
-
-    $result = $statement
-      ->where($condition)
-      ->execute();
-
-    if ($result->isError()) {
-      throw new GeneralSQLQueryException($query);
-    }
-
-    return array_map(
-      fn(object|array $row) => is_array($row) ? (object)$row : $row,
-      $result->getData()
-    );
-  }
-
-  private function resolveOneToOneRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): ?object
-  {
-    $relationKey = $relationInfo->joinColumn
-      ? ($entity->{$relationInfo->name} ?? null)
-      : ($entity->id ?? null);
-
-    if ($relationKey === null) {
-      return null;
-    }
-
-    return $loadedRelations[$relationKey] ?? null;
-  }
-
-  private function resolveOneToManyRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): array
-  {
-    $referenceProperty = $relationInfo->relationAttribute->referencedProperty ?? 'id';
-    $referenceValue = $entity->{$referenceProperty} ?? null;
-
-    if ($referenceValue === null) {
-      return [];
-    }
-
-    return $loadedRelations[$referenceValue] ?? [];
-  }
-
-  private function resolveManyToOneRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): ?object
-  {
-    $foreignKey = $entity->{$relationInfo->name} ?? null;
-
-    if ($foreignKey === null) {
-      return null;
-    }
-
-    return $loadedRelations[$foreignKey] ?? null;
-  }
-
-  private function resolveManyToManyRelationValue(object $entity, array $loadedRelations): array
-  {
-    $referenceValue = $entity->id ?? null;
-
-    if ($referenceValue === null) {
-      return [];
-    }
-
-    return $loadedRelations[$referenceValue] ?? [];
-  }
-
-  /**
-   * @return array{property: string, joinColumn: JoinColumn}|null
-   * @throws ReflectionException
-   */
-  private function resolveInverseOneToOneOwner(string $entityClass, RelationPropertyMetadata $relationProperty): ?array
-  {
-    $targetClass = $relationProperty->getEntityClass();
-    if (!$targetClass) {
-      return null;
-    }
-
-    $targetReflection = new ReflectionClass($targetClass);
-
-    foreach ($targetReflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-      $oneToOneAttributes = $property->getAttributes(OneToOne::class);
-      if (empty($oneToOneAttributes)) {
-        continue;
-      }
-
-      /** @var OneToOne $attribute */
-      $attribute = $oneToOneAttributes[0]->newInstance();
-      if ($attribute->type !== $entityClass) {
-        continue;
-      }
-
-      return [
-        'property' => $property->getName(),
-        'joinColumn' => $this->entityInspector->getJoinColumnAttribute($targetClass, $property->getName()),
-      ];
-    }
-
-    return null;
-  }
-
-  /**
-   * @return array{joinTable: JoinTable, ownerTable: string, targetTable: string, localJoinColumn: string, targetJoinColumn: string}|null
-   * @throws ReflectionException
-   * @throws ORMException
-   * @throws ClassNotFoundException
-   */
-  private function resolveManyToManyMapping(string $entityClass, RelationPropertyMetadata $relationProperty): ?array
-  {
-    $targetClass = $relationProperty->getEntityClass();
-    if (!$targetClass) {
-      return null;
-    }
-
-    $ownerTable = $this->entityInspector->getTableName($this->create($entityClass));
-    $targetTable = $this->entityInspector->getTableName($this->create($targetClass));
-    $joinTable = $relationProperty->joinTable;
-
-    if ($joinTable instanceof JoinTable) {
-      return [
-        'joinTable' => $joinTable,
-        'ownerTable' => $ownerTable,
-        'targetTable' => $targetTable,
-        'localJoinColumn' => $joinTable->joinColumn ?? strtosingular($ownerTable) . '_id',
-        'targetJoinColumn' => $joinTable->inverseJoinColumn ?? strtosingular($targetTable) . '_id',
-      ];
-    }
-
-    $inverseProperty = $relationProperty->relationAttribute->inverseSide ?? null;
-    $ownerProperty = $inverseProperty && property_exists($targetClass, $inverseProperty)
-      ? new ReflectionProperty($targetClass, $inverseProperty)
-      : $this->findManyToManyOwnerProperty($targetClass, $entityClass);
-
-    if (!$ownerProperty) {
-      return null;
-    }
-
-    $joinTableAttributes = $ownerProperty->getAttributes(JoinTable::class);
-    if (empty($joinTableAttributes)) {
-      return null;
-    }
-
-    /** @var JoinTable $joinTable */
-    $joinTable = $joinTableAttributes[0]->newInstance();
-    $inverseOwnerTable = $this->entityInspector->getTableName($this->create($targetClass));
-
-    return [
-      'joinTable' => $joinTable,
-      'ownerTable' => $inverseOwnerTable,
-      'targetTable' => $ownerTable,
-      'localJoinColumn' => $joinTable->inverseJoinColumn ?? strtosingular($ownerTable) . '_id',
-      'targetJoinColumn' => $joinTable->joinColumn ?? strtosingular($inverseOwnerTable) . '_id',
-    ];
-  }
-
-  private function findManyToManyOwnerProperty(string $targetClass, string $entityClass): ?ReflectionProperty
-  {
-    $targetReflection = new ReflectionClass($targetClass);
-
-    foreach ($targetReflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-      $relationAttributes = $property->getAttributes(\Assegai\Orm\Attributes\Relations\ManyToMany::class);
-      $joinTableAttributes = $property->getAttributes(JoinTable::class);
-
-      if (empty($relationAttributes) || empty($joinTableAttributes)) {
-        continue;
-      }
-
-      /** @var \Assegai\Orm\Attributes\Relations\ManyToMany $attribute */
-      $attribute = $relationAttributes[0]->newInstance();
-      if ($attribute->type === $entityClass) {
-        return $property;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * @param object[] $rows
-   * @return list<mixed>
-   */
-  private function extractScalarValues(array $rows, string $property): array
-  {
-    $values = [];
-
-    foreach ($rows as $row) {
-      $value = $row->{$property} ?? null;
-      if ($value !== null && $value !== '') {
-        $values[] = $value;
-      }
-    }
-
-    return array_values(array_unique($values, SORT_REGULAR));
-  }
-
-  /**
-   * @param list<mixed> $values
-   */
-  private function buildInCondition(string $qualifiedColumn, array $values, ?SQLQuery $query = null): ?string
-  {
-    if (empty($values)) {
-      return null;
-    }
-
-    $query ??= $this->query;
-
-    return SqlIdentifier::quote($qualifiedColumn, $query->getDialect()) . ' IN (' . implode(', ', $query->addParams(array_values($values))) . ')';
-  }
-
-  private function resolveRelationExcludeColumns(RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
-  {
-    $relationOptions = $relationProperty->relationAttribute->options ?? null;
-
-    if ($relationOptions instanceof RelationOptions) {
-      return $relationOptions->exclude;
-    }
-
-    return $findOptions->exclude ?? ['password'];
-  }
-
-  /**
-   * Counts entities that match given options.
-   * Useful for pagination.
-   *
-   * @param string $entityClass
-   * @param FindOptions|null $options
-   * @return int Returns the count of entities that match the given options
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function count(string $entityClass, ?FindOptions $options = null): int
-  {
-    $entity = $this->create(entityClass: $entityClass);
-
-    $statement = $this->query->select()->count()->from(tableReferences: $this->entityInspector->getTableName(entity: $entity));
-
-    if ($options) {
-      $conditions = [];
-
-      if ($deleteColumnName = $this->getDeleteDateColumnName(entityClass: $entityClass)) {
-        $conditions = array_merge($options->where->conditions ?? $options->where ?? [], [$deleteColumnName => 'NULL']);
-      }
-
-      $statement = $statement->where(condition: new FindWhereOptions(conditions: $conditions, entityClass: $entityClass));
-    }
-
-    if ($this->isDebug || $options?->isDebug) {
-      $statement->debug();
-    }
-
-    $result = $statement->execute();
-
-    if ($result->isError()) {
-      throw new GeneralSQLQueryException($this->query);
-    }
-
-    return $result->value()[0]?->total ?? 0;
-  }
-
-  /**
-   * Returns the id of the last inserted entity.
-   *
-   * @return int|null Returns the id of the last inserted entity.
-   */
-  public function lastInsertId(): ?int
-  {
-    return $this->query->lastInsertId();
-  }
-
-  /**
-   * @return array|string[]
-   */
-  public function getSecure(): array
-  {
-    return array_merge($this->secure, $this->customSecure);
-  }
-
-  /**
-   * @param array|string[] $secure
-   */
-  public function setSecure(array $secure): void
-  {
-    $this->customSecure = $secure;
-  }
-
-  /**
-   * Finds entities that match given `FindWhereOptions`.
-   *
-   * @param string $entityClass The entity class name.
-   * @param FindWhereOptions|array $where The find options.
-   * @return FindResult Returns a FindResult object representing the result of the query.
-   * @throws ClassNotFoundException If the given entity class does not exist.
-   * @throws GeneralSQLQueryException If the query fails.
-   * @throws ORMException|ReflectionException If the given entity class does not have the required attributes.
-   */
-  public function findBy(string $entityClass, FindWhereOptions|array $where): FindResult
-  {
-    $entity = $this->create(entityClass: $entityClass);
-    if (is_array($where)) {
-      $where = new FindWhereOptions(
-        conditions: $where['condition'] ?? $where,
-        entityClass: $entityClass
-      );
-    }
-    $statement = $this->query->select()->all(columns: $this->entityInspector->getColumns(entity: $entity, exclude: $where->exclude))->from(tableReferences: $this->entityInspector->getTableName(entity: $entity))->where(condition: $where);
-
-    $limit = $_GET['limit'] ?? 100;
-    $skip = $_GET['skip'] ?? 0;
-
-    $statement = $statement->limit(limit: $limit, offset: $skip);
-
-    if ($this->isDebug) {
-      $statement->debug();
-    }
-
-    $result = $statement->execute();
-
-    if ($result->isError()) {
-      throw new GeneralSQLQueryException($this->query);
-    }
-
-    return new FindResult(raw: $result->getRaw(), data: $result->getData(), errors: $result->getErrors());
-  }
-
-  /**
-   * Updates entity partially. Entity can be found by a given condition(s).
-   * Unlike save method executes a primitive operation without cascades, relations and other operations included.
-   * Executes fast and efficient UPDATE query.
-   * Does not check if entity exist in the database.
-   * Condition(s) cannot be empty.
-   *
-   * @param string $entityClass The entity class name.
-   * @param object|array $partialEntity The entity or entities to update.
-   * @param string|object|array $conditions The condition(s) to find the entity.
-   * @param UpdateOptions|null $options The options to use when updating the entity.
-   * @return UpdateResult
-   * @throws ClassNotFoundException
-   * @throws EmptyCriteriaException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   * @throws ValidationException
-   */
-  public function update(string $entityClass, object|array $partialEntity, string|object|array $conditions, ?UpdateOptions $options = null): UpdateResult
-  {
-    $this->validateConditions(conditions: $conditions, methodName: __METHOD__);
-
-    if (empty($conditions)) {
-      throw new ORMException("Empty criteria(s) are not allowed for the update method.");
-    }
-
-    if (is_array($partialEntity) && array_is_list($partialEntity)) {
-      $raw = '';
-      $affected = 0;
-      $generatedMaps = new stdClass();
-
-      foreach ($partialEntity as $partialItem) {
-        $result = $this->update(entityClass: $entityClass, partialEntity: $partialItem, conditions: $conditions);
-        $generatedMaps = $result->generatedMaps;
-      }
-
-      return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: (object)$partialEntity, generatedMaps: $generatedMaps);
-    }
-
-    $entityInstance = $this->create(entityClass: $entityClass, entityLike: $partialEntity);
-    $assignmentList = [];
-    $columnOptions = [];
-    $relations = [];
-    $relationProperties = [];
-
-    if ($options?->relations) {
-      $relations = is_object($options->relations) ? (array)$options->relations : $options->relations;
-    }
-
-    $columnMap = $this->entityInspector->getColumns(entity: $entityInstance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnOptions);
-
-    foreach ($partialEntity as $prop => $value) {
-      # Get the correct prop name
-      $columnName = $this->getColumnNameFromProperty($entityInstance, $prop);
-
-      if ($this->mapContainsColumnName($columnMap, $columnName)) {
-        if (!is_null($value)) {
-          if ($value instanceof UnitEnum && property_exists($value, 'value')) {
-            $value = $value->value;
-          }
-
-          if ($value instanceof DateTime) {
-            $value = $this->entityInspector->convertDateTimeToString($value, $prop, $columnOptions);
-          }
-
-          if ($value instanceof stdClass) {
-            $value = json_encode($value);
-          }
-
-          if (isset($columnMap[$columnName])) {
-            if (isset($relationProperties[$columnName])) {
-              assert($relationProperties[$columnName] instanceof RelationPropertyMetadata);
-
-              if (is_object($value) && property_exists($value, $relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName)) {
-                $value = $value->{$relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName};
-              }
-
-              $columnName = $relationProperties[$columnName]->joinColumn->effectiveColumnName;
+    /**
+     * Saves all given entities in the database.
+     * If entities do not exist in the database then inserts, otherwise updates.
+     *
+     * @param object|object[] $targetOrEntity The entity or entities to save.
+     * @param InsertOptions|UpdateOptions|null $options The insert options.
+     * @return QueryResultInterface
+     * @throws ClassNotFoundException
+     * @throws EmptyCriteriaException
+     * @throws GeneralSQLQueryException
+     * @throws IllegalTypeException
+     * @throws ORMException
+     * @throws ReflectionException
+     * @throws SaveException
+     * @throws ValidationException
+     */
+    public function save(object|array $targetOrEntity, InsertOptions|UpdateOptions|null $options = null): QueryResultInterface
+    {
+        $results = [];
+        $primaryKeyField = $options->primaryKeyField ?? 'id';
+
+        /** @var object $targetOrEntity */
+        if (is_object($targetOrEntity)) {
+            $primaryKeyValue = $targetOrEntity->{$primaryKeyField} ?? null;
+
+            if (empty($primaryKeyValue)) {
+                $saveResult = $this->insert(
+                    entityClass: $targetOrEntity::class,
+                    entity: $targetOrEntity,
+                    options: $this->normalizeSaveInsertOptions($options)
+                );
             } else {
-              $columnName = $this->getUnqualifiedColumnName($columnMap[$columnName]);
+                $existingEntityResult = $this->findBy(
+                    $targetOrEntity::class,
+                    new FindWhereOptions(conditions: [$primaryKeyField => $primaryKeyValue])
+                );
+
+                if (!$existingEntityResult->isEmpty()) {
+                    $saveResult = $this->update(
+                        entityClass: $targetOrEntity::class,
+                        partialEntity: $targetOrEntity,
+                        conditions: [$primaryKeyField => $primaryKeyValue],
+                        options: $this->normalizeSaveUpdateOptions($options)
+                    );
+                } else {
+                    $saveResult = $this->insert(
+                        entityClass: $targetOrEntity::class,
+                        entity: $targetOrEntity,
+                        options: $this->normalizeSaveInsertOptions($options)
+                    );
+                }
             }
-          }
 
-          $assignmentList[$columnName] = $value;
-        }
-      }
-    }
+            if ($saveResult instanceof InsertResult || $saveResult instanceof UpdateResult || $saveResult instanceof DeleteResult) {
+                return $saveResult;
+            }
 
-    if (empty($assignmentList)) {
-      return new UpdateResult(null, 0, $partialEntity, new stdClass());
-    }
-
-    $statement = $this->query
-      ->update(tableName: $this->entityInspector->getTableName(entity: $entityInstance))
-      ->set(assignmentList: $assignmentList);
-    $conditionString = is_string($conditions)
-      ? $conditions
-      : $this->buildConditionClause($conditions, $this->query, $entityInstance);
-    $statement->where(condition: $conditionString);
-
-    if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
-      $this->query->appendQueryString('RETURNING ' . $this->buildReturningProjection($entityInstance));
-    }
-
-    if ($this->isDebug || $options?->isDebug) {
-      $this->query->debug();
-    }
-
-    $result = $this->query->execute();
-    $raw = $result->getRaw();
-
-    if ($result->isError()) {
-      throw new GeneralSQLQueryException($this->query);
-    }
-
-    $generatedMaps = null;
-
-    if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
-      $generatedMaps = $this->hydrateGeneratedMaps($entityClass, $result->getData());
-    }
-
-    if (!$generatedMaps) {
-      $updatedEntity = $this->findOne(entityClass: $entityClass, options: new FindOptions(where: $conditions));
-      $generatedMaps = $updatedEntity->getData() ?? new stdClass();
-    }
-
-    $generatedMaps = $this->sanitizeGeneratedMaps($generatedMaps);
-
-    $identifiers = is_array($partialEntity) ? (object)$partialEntity : $partialEntity;
-    if ($generatedMaps && is_object($generatedMaps)) {
-      $primaryKeyMetadata = $this->getPrimaryKeyMetadata($entityInstance);
-      $primaryKeyField = $primaryKeyMetadata['field'];
-      $identifierValue = $generatedMaps->{$primaryKeyField} ?? null;
-
-      if ($identifierValue !== null && $identifierValue !== '') {
-        $identifiers = (object)(array_merge((array)$identifiers, [$primaryKeyField => $identifierValue]));
-      }
-    }
-
-    return new UpdateResult(raw: $raw, affected: $this->query->rowCount(), identifiers: $identifiers, generatedMaps: $generatedMaps);
-  }
-
-  /**
-   * Validates the given conditions. If the given conditions are invalid, then a `ValidationException` is thrown.
-   *
-   * @param string|object|array $conditions The conditions to validate.
-   * @param string $methodName The name of the method that called this method.
-   * @return void
-   * @throws ValidationException If the given conditions are invalid.
-   */
-  private function validateConditions(string|object|array $conditions, string $methodName): void
-  {
-    if (empty($conditions)) {
-      throw new EmptyCriteriaException(methodName: $methodName);
-    }
-  }
-
-  /**
-   * @param int|object|array $conditions
-   * @param SQLQuery $query
-   * @param object|null $entity
-   * @return string
-   */
-  private function buildConditionClause(int|object|array $conditions, SQLQuery $query, ?object $entity = null): string
-  {
-    if (is_int($conditions)) {
-      return SqlIdentifier::quote('id', $query->getDialect()) . '=' . $query->addParam($conditions);
-    }
-
-    $parts = [];
-
-    foreach ((array)$conditions as $key => $value) {
-      $columnName = $entity && is_string($key)
-        ? $this->getColumnNameFromProperty($entity, $key)
-        : (string)$key;
-      $identifier = SqlIdentifier::quote($columnName, $query->getDialect());
-
-      if (is_null($value) || $value === 'NULL') {
-        $parts[] = "$identifier IS NULL";
-        continue;
-      }
-
-      if (is_array($value) && array_is_list($value)) {
-        if (empty($value)) {
-          $parts[] = '1 = 0';
-          continue;
+            return $this->findBy($targetOrEntity::class, new FindWhereOptions(conditions: [$primaryKeyField => $this->query->lastInsertId()]));
         }
 
-        $parts[] = $identifier . ' IN (' . implode(', ', $query->addParams($value)) . ')';
-        continue;
-      }
-
-      $parts[] = $identifier . '=' . $query->addParam($value);
-    }
-
-    return implode(' AND ', $parts);
-  }
-
-  /**
-   * Removes the table prefix from a column reference when a SQL assignment target must be unqualified.
-   *
-   * @param string $columnReference The column reference to normalize.
-   * @return string The unqualified column name.
-   */
-  private function getUnqualifiedColumnName(string $columnReference): string
-  {
-    if (!str_contains($columnReference, '.')) {
-      return $columnReference;
-    }
-
-    return substr($columnReference, strrpos($columnReference, '.') + 1);
-  }
-
-  /**
-   * Resolves the storage column name for a given entity property.
-   *
-   * Regular column-backed properties default to snake_case when no explicit column name is supplied.
-   * Relation properties continue to return the PHP property name so relation metadata can decide which
-   * join column to use later in the update and condition-building paths.
-   *
-   * @param object $entity The entity that owns the property.
-   * @param string $prop The property name to resolve.
-   * @return string The resolved storage column name or the original relation property name.
-   */
-  private function getColumnNameFromProperty(object $entity, string $prop): string
-  {
-    if (!property_exists($entity, $prop)) {
-      return $prop;
-    }
-
-    $propertyReflection = new ReflectionProperty($entity, $prop);
-    $attributes = $propertyReflection->getAttributes();
-
-    if (empty($attributes)) {
-      return $prop;
-    }
-
-    # Return $prop if no valid Column attribute found
-    $columnClassNames = [Column::class, CreateDateColumn::class, DeleteDateColumn::class, EmailColumn::class, PasswordColumn::class, PrimaryGeneratedColumn::class, UpdateDateColumn::class, URLColumn::class];
-    $columnAttribute = null;
-    foreach ($attributes as $attribute) {
-      if (in_array($attribute->getName(), $columnClassNames)) {
-        $columnAttribute = $attribute;
-      }
-    }
-
-    if (!$columnAttribute) {
-      return $prop;
-    }
-
-    /** @var Column $column */
-    $column = $columnAttribute->newInstance();
-    return empty($column->name) ? strtosnake($prop) : $column->name;
-  }
-
-  /**
-   * Determines if a given column map contains a given column name.
-   *
-   * @param array $columnMap The column map to check.
-   * @param string $columnName The column name to check for.
-   * @return bool Returns true if the column map contains the given column name, otherwise false.
-   */
-  private function mapContainsColumnName(array $columnMap, string $columnName): bool
-  {
-    foreach ($columnMap as $key => $value) {
-      if (str_ends_with($key, $columnName)) {
-        return true;
-      }
-
-      if (str_ends_with($value, $columnName)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Creates a new entity from the given plain php object. If the entity already exist in the database, then
-   * it loads it (and everything related to it), replaces all values with the new ones from the given object
-   * and returns this new entity. This new entity is actually a loaded from the db entity with all properties
-   * replaced from the new object.
-   * @param string $entityClass
-   * @param object $entityLike
-   * @return Entity|null
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function preload(string $entityClass, object $entityLike): ?object
-  {
-    $findOptions = [];
-
-    foreach ($entityLike as $prop => $value) {
-      if (property_exists($entityClass, $prop)) {
-        $findOptions[$prop] = $value;
-      }
-    }
-
-    $entity = $this->find(entityClass: $entityClass, findOptions: FindOptions::fromArray($findOptions));
-
-    if (empty($entity->getData())) {
-      $entity = $this->create(entityClass: $entityClass, entityLike: $entityLike);
-    }
-
-    return $this->merge($entityClass, $entity, $entityLike);
-  }
-
-  /**
-   * Merges multiple entities into a single entity.
-   *
-   * @param string $entityClass
-   * @param mixed ...$entities
-   *
-   * @return Entity Returns a single entity
-   * @throws ClassNotFoundException
-   * @throws ORMException
-   */
-  public function merge(string $entityClass, ...$entities): object
-  {
-    $this->validateEntityName(entityClass: $entityClass);
-
-    $entity = new $entityClass;
-
-    if ($entity instanceof Entity) {
-      $object = $entity;
-
-      foreach ($entities as $item) {
-        if (is_object($item) || is_array($item)) {
-          $object = (object)array_merge((array)$object, (array)$item);
+        foreach ($targetOrEntity as $entity) {
+            $results[] = $this->save(targetOrEntity: $entity, options: $options);
         }
-      }
 
-      foreach ($object as $prop => $value) {
-        if (property_exists($entity, $prop)) {
-          $entity->$prop = $value;
+        return new SQLQueryResult($results);
+    }
+
+    /**
+     * Inserts a given entity into the database.
+     * Unlike the save method executes a primitive operation without
+     * cascades, relations and other operations included.
+     * Executes a fast and efficient `INSERT` query.
+     * Does not check if the entity exist in the database, so the query will fail if
+     * duplicate entity is being inserted.
+     * You can execute bulk inserts using this method.
+     *
+     * @template TEntity of object
+     * @param class-string<TEntity> $entityClass The entity class name.
+     * @param TEntity|array<string, mixed> $entity The entity to insert.
+     * @param InsertOptions|null $options The options to use when inserting the entity.
+     * @return InsertResult<TEntity>
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function insert(string $entityClass, array|object $entity, ?InsertOptions $options = null): InsertResult
+    {
+        # Check if the entity matches the given entity class
+        if (!$this->entityInspector->hasValidEntityStructure(entity: $entity, entityClass: $entityClass)) {
+            return new InsertResult(identifiers: $entity, raw: $this->query->queryString(), generatedMaps: null, errors: [new ORMException("Entity does not match the given entity class.")]);
         }
-      }
-    }
 
-    return $entity;
-  }
+        $instance = $this->create(entityClass: $entityClass, entityLike: (object)$entity);
+        $primaryKey = $this->getPrimaryKeyMetadata($instance);
+        $primaryKeyField = $primaryKey['field'];
+        $columnsMeta = [];
+        $relations = [];
+        $relationProperties = [];
 
-  /**
-   * Inserts a new entity or array of entities unless they already exist in the database, if they do then updates.
-   *
-   * @param string $entityClass The entity class name.
-   * @param object|object[] $entityOrEntities The entity or entities to upsert.
-   * @return InsertResult|UpdateResult Returns an InsertResult or UpdateResult.
-   * @throws ClassNotFoundException
-   * @throws NotImplementedException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function upsert(string $entityClass, object|array $entityOrEntities, array|UpsertOptions $options): InsertResult|UpdateResult
-  {
-    // TODO: #83 Implement EntityManager::upsert @amasiye
-    if (is_array($options)) {
-      $options = array_is_list($options)
-        ? new UpsertOptions(conflictPaths: $options)
-        : UpsertOptions::fromArray($options);
-    }
+        if ($options?->relations) {
+            $relations = is_object($options->relations) ? (array)$options->relations : $options->relations;
+        }
 
-    if (is_array($entityOrEntities)) {
-      $results = [];
-      $errors = [];
-      foreach ($entityOrEntities as $entity) {
-        $result = $this->upsert(entityClass: $entityClass, entityOrEntities: $entity, options: $options);
+        $columns = $this->entityInspector->getColumns(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnsMeta);
+        $values = $this->entityInspector->getValues(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, options: ['relations' => $relations, 'relation_properties' => $relationProperties, 'filter' => true, 'column_types' => $columnsMeta['column_types'] ?? []]);
+
+        $columnCount = count($columns);
+        $valueCount = count($values);
+
+        $this->query->insertInto(tableName: $this->entityInspector->getTableName(entity: $instance))->singleRow(columns: $columns)->values(valuesList: $values);
+
+        if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+            $this->query->appendQueryString('RETURNING ' . $this->buildReturningProjection($instance));
+        }
+
+        if ($this->isDebug || $options?->isDebug) {
+            $this->query->debug();
+        }
+
+        $result = $this->query->execute();
+        $raw = $result->getRaw();
 
         if ($result->isError()) {
-          $errors[] = $result->getErrors();
+            if (!headers_sent()) {
+                http_response_code(500);
+            }
+            $error = new GeneralSQLQueryException($this->query);
+            OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
+
+            return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$error, ...$result->getErrors()]);
         }
 
-        $results[] = $result->getData();
-      }
-
-      $generatedMaps = new stdClass();
-      $generatedMaps->results = $results;
-
-      return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: $entityOrEntities, generatedMaps: $generatedMaps, errors: $errors);
-    }
-
-    $this->validateEntityName(entityClass: $entityClass);
-
-    $entity = $this->create(
-      entityClass: $entityClass,
-      entityLike: is_array($entityOrEntities) ? $entityOrEntities : (object)$entityOrEntities,
-    );
-
-    // TODO: Configure the upsert options
-    $primaryKey = $this->getPrimaryKeyMetadata($entity);
-    $primaryKeyField = $primaryKey['field'];
-    $primaryColumn = $primaryKey['column'];
-
-    $columns = $this->entityInspector->getColumns(entity: $entity);
-    $updateColumns = $this->entityInspector->getColumns(entity: $entity, exclude: $options->readonlyColumns ?? $this->readonlyColumns);
-    $values = $this->entityInspector->getValues(entity: $entity);
-    $tableName = $this->entityInspector->getTableName(entity: $entity);
-
-    return match ($this->query->getDialect()) {
-      SQLDialect::SQLITE => $this->executeSqliteUpsert($tableName, $entity, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
-      SQLDialect::POSTGRESQL => $this->executePostgreSqlUpsert($entityClass, $tableName, $entity, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
-      default => $this->executeMySqlUpsert($entityClass, $tableName, $entity, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
-    };
-  }
-
-  private function executeMySqlUpsert(
-    string $entityClass,
-    string $tableName,
-    object $entityOrEntities,
-    array $columns,
-    array $updateColumns,
-    array $values,
-    UpsertOptions $options,
-    string $primaryKeyField,
-    string $primaryColumn,
-  ): InsertResult
-  {
-    $assignmentList = array_map(function($column): string {
-      $column = $this->stripTableName($column);
-      return "$column=VALUES($column)";
-    }, array_values($updateColumns));
-
-    array_unshift($assignmentList, "$primaryColumn=LAST_INSERT_ID($primaryColumn)");
-
-    $this->query->insertInto(tableName: $tableName)->singleRow(columns: $columns)->values(valuesList: $values)->onDuplicateKeyUpdate(assignmentList: $assignmentList);
-
-    if ($this->isDebug) {
-      $this->query->debug();
-    }
-
-    $result = $this->query->execute();
-    $raw = $result->getRaw();
-
-    $errors = [];
-    if ($result->isError()) {
-      $errors[] = $this->query->getConnection()->errorInfo();
-      $errors[] = new GeneralSQLQueryException($this->query);
-    }
-
-    $identifierValue = $entityOrEntities->{$primaryKeyField} ?? null;
-    $generatedMaps = $entityOrEntities;
-
-    if ($result->isOk()) {
-      $identifierValue = $identifierValue ?: $this->lastInsertId();
-      $lookupConditions = $this->buildUpsertLookupConditions($entityOrEntities, $options, $primaryKeyField);
-
-      if (!empty($identifierValue)) {
-        $lookupConditions = [$primaryKeyField => $identifierValue];
-      }
-
-      if (!empty($lookupConditions)) {
-        $persistedResult = $this->findOne(entityClass: $entityClass, options: new FindOneOptions(where: $lookupConditions));
-        $persistedEntity = $persistedResult->getData();
-
-        if (is_object($persistedEntity)) {
-          $generatedMaps = $persistedEntity;
-          $identifierValue = $persistedEntity->{$primaryKeyField} ?? $identifierValue;
-        }
-      }
-
-      if (!empty($identifierValue)) {
-        $entityOrEntities->{$primaryKeyField} = $identifierValue;
-      }
-    }
-
-    return new InsertResult(
-      identifiers: (object)[$primaryKeyField => $identifierValue],
-      raw: $raw,
-      generatedMaps: $generatedMaps,
-      errors: $errors,
-      affected: $this->query->rowCount() ?? 0,
-    );
-  }
-
-  private function buildUpsertLookupConditions(object $entity, UpsertOptions $options, string $primaryKeyField = 'id'): array
-  {
-    $conditions = [];
-
-    foreach ($options->conflictPaths as $conflictPath) {
-      if (!is_string($conflictPath) || !property_exists($entity, $conflictPath)) {
-        continue;
-      }
-
-      $value = $entity->{$conflictPath};
-
-      if ($value instanceof UnitEnum && property_exists($value, 'value')) {
-        $value = $value->value;
-      }
-
-      if ($value === null) {
-        continue;
-      }
-
-      $conditions[$conflictPath] = $value;
-    }
-
-    if (empty($conditions) && !empty($entity->{$primaryKeyField})) {
-      $conditions[$primaryKeyField] = $entity->{$primaryKeyField};
-    }
-
-    return $conditions;
-  }
-
-  private function executeSqliteUpsert(
-    string $tableName,
-    object $entity,
-    array $columns,
-    array $updateColumns,
-    array $values,
-    UpsertOptions $options,
-    string $primaryKeyField,
-    string $primaryColumn,
-  ): InsertResult
-  {
-    $originalId = $entity->{$primaryKeyField} ?? null;
-    $columns = array_map([$this, 'stripTableName'], array_values($columns));
-    $updateColumns = array_map([$this, 'stripTableName'], array_values($updateColumns));
-    $conflictPaths = $this->resolveUpsertConflictColumns($entity, $options->conflictPaths ?: [$primaryColumn]);
-    [$columns, $values] = $this->filterNullableUpsertColumns($columns, $values, $conflictPaths, $updateColumns);
-
-    $quotedColumns = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $columns));
-    $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
-    $placeholders = array_fill(0, count($values), '?');
-    $valueList = implode(', ', $placeholders);
-    $assignmentList = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()) . '=excluded.' . SqlIdentifier::quote($column, $this->query->getDialect()), $updateColumns));
-    $conflictAction = empty($assignmentList) ? 'DO NOTHING' : "DO UPDATE SET $assignmentList";
-
-    $queryString = 'INSERT INTO ' . $this->query->quoteIdentifier($tableName) . " ($quotedColumns) VALUES ($valueList) ON CONFLICT ($quotedConflictPaths) $conflictAction";
-    $this->query->init();
-    $this->query->insertInto(tableName: $tableName);
-    $this->query->setQueryString($queryString);
-    $this->query->addParams($values);
-
-    if ($this->isDebug) {
-      $this->query->debug();
-    }
-
-    $result = $this->query->execute();
-    $raw = $result->getRaw();
-    $errors = [];
-
-    if ($result->isError()) {
-      $errors[] = $this->query->getConnection()->errorInfo();
-      $errors[] = new GeneralSQLQueryException($this->query);
-    }
-
-    if ($result->isOk()) {
-      $lastInsertId = $this->lastInsertId();
-      if (empty($originalId) && $lastInsertId) {
-        $entity->{$primaryKeyField} = $lastInsertId;
-      }
-    }
-
-    $identifier = $entity->{$primaryKeyField} ?? $originalId ?? $this->lastInsertId();
-
-    return new InsertResult(
-      identifiers: (object)[$primaryKeyField => $identifier],
-      raw: $raw,
-      generatedMaps: $entity,
-      errors: $errors,
-      affected: $this->query->rowCount() ?? 0,
-    );
-  }
-
-  private function executePostgreSqlUpsert(
-    string $entityClass,
-    string $tableName,
-    object $entity,
-    array $columns,
-    array $updateColumns,
-    array $values,
-    UpsertOptions $options,
-    string $primaryKeyField,
-    string $primaryColumn,
-  ): InsertResult
-  {
-    $originalId = $entity->{$primaryKeyField} ?? null;
-    $columns = array_map([$this, 'stripTableName'], array_values($columns));
-    $updateColumns = array_map([$this, 'stripTableName'], array_values($updateColumns));
-    $conflictPaths = $this->resolveUpsertConflictColumns($entity, $options->conflictPaths ?: [$primaryColumn]);
-    [$columns, $values] = $this->filterNullableUpsertColumns($columns, $values, $conflictPaths, $updateColumns);
-
-    $quotedColumns = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $columns));
-    $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
-    $placeholders = array_fill(0, count($values), '?');
-    $valueList = implode(', ', $placeholders);
-    $assignmentList = implode(', ', array_map(
-      fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()) . '=excluded.' . SqlIdentifier::quote($column, $this->query->getDialect()),
-      $updateColumns
-    ));
-    $conflictAction = empty($assignmentList) ? 'DO NOTHING' : "DO UPDATE SET $assignmentList";
-    $returning = $this->query->quoteIdentifier($primaryColumn) . ' AS ' . $this->query->quoteIdentifier($primaryKeyField);
-
-    $queryString = 'INSERT INTO ' . $this->query->quoteIdentifier($tableName)
-      . " ($quotedColumns) VALUES ($valueList) ON CONFLICT ($quotedConflictPaths) $conflictAction RETURNING $returning";
-
-    $this->query->init();
-    $this->query->insertInto(tableName: $tableName);
-    $this->query->setQueryString($queryString);
-    $this->query->addParams($values);
-
-    if ($this->isDebug) {
-      $this->query->debug();
-    }
-
-    $result = $this->query->execute();
-    $raw = $result->getRaw();
-    $errors = [];
-
-    if ($result->isError()) {
-      $errors[] = $this->query->getConnection()->errorInfo();
-      $errors[] = new GeneralSQLQueryException($this->query);
-    }
-
-    $identifierValue = $this->extractReturningIdentifier($result->getData(), $primaryKeyField, $primaryColumn)
-      ?? $originalId
-      ?? $this->lastInsertId();
-    $generatedMaps = $entity;
-
-    if ($result->isOk()) {
-      if ($identifierValue !== null && $identifierValue !== '') {
-        $entity->{$primaryKeyField} = $identifierValue;
-      }
-
-      $lookupConditions = $this->buildUpsertLookupConditions($entity, $options, $primaryKeyField);
-
-      if ($identifierValue !== null && $identifierValue !== '') {
-        $lookupConditions = [$primaryKeyField => $identifierValue];
-      }
-
-      if (!empty($lookupConditions)) {
-        $persistedResult = $this->findOne(entityClass: $entityClass, options: new FindOneOptions(where: $lookupConditions));
-        $persistedEntity = $persistedResult->getData();
-
-        if (is_object($persistedEntity)) {
-          $generatedMaps = $persistedEntity;
-          $identifierValue = $persistedEntity->{$primaryKeyField} ?? $identifierValue;
-        }
-      }
-    }
-
-    return new InsertResult(
-      identifiers: (object)[$primaryKeyField => $identifierValue],
-      raw: $raw,
-      generatedMaps: $generatedMaps,
-      errors: $errors,
-      affected: $this->query->rowCount() ?? 0,
-    );
-  }
-
-  private function resolveUpsertConflictColumns(object $entity, array $conflictPaths): array
-  {
-    $columnMap = [];
-
-    foreach ($this->entityInspector->getColumns($entity) as $field => $column) {
-      $columnName = $this->stripTableName($column);
-
-      if (is_string($field)) {
-        $columnMap[$field] = $columnName;
-      }
-
-      $columnMap[$columnName] = $columnName;
-    }
-
-    $resolved = array_map(function(string $conflictPath) use ($columnMap): string {
-      $conflictPath = $this->stripTableName($conflictPath);
-
-      return $columnMap[$conflictPath] ?? $conflictPath;
-    }, $conflictPaths);
-
-    return array_values(array_unique($resolved));
-  }
-
-  private function filterNullableUpsertColumns(array $columns, array $values, array $conflictPaths, array $updateColumns): array
-  {
-    $filteredColumns = [];
-    $filteredValues = [];
-
-    foreach ($columns as $index => $column) {
-      $value = $values[$index] ?? null;
-
-      if ($value === null && !in_array($column, $conflictPaths, true) && !in_array($column, $updateColumns, true)) {
-        continue;
-      }
-
-      $filteredColumns[] = $column;
-      $filteredValues[] = $value;
-    }
-
-    return [$filteredColumns, $filteredValues];
-  }
-
-  private function extractReturningIdentifier(array $rows, string $primaryKeyField, string $primaryColumn): mixed
-  {
-    $row = $rows[0] ?? null;
-
-    if (!is_array($row)) {
-      return null;
-    }
-
-    foreach ([$primaryKeyField, $primaryColumn, 'id'] as $key) {
-      if (array_key_exists($key, $row)) {
-        return $row[$key];
-      }
-    }
-
-    return null;
-  }
-
-  private function buildReturningProjection(object $entity): string
-  {
-    $projection = [];
-
-    foreach ($this->entityInspector->getColumns(entity: $entity) as $field => $column) {
-      $columnName = $this->stripTableName($column);
-      $alias = is_string($field) ? $field : $columnName;
-
-      $projection[] = $this->query->quoteIdentifier($columnName) . ' AS ' . $this->query->quoteIdentifier($alias);
-    }
-
-    return implode(', ', $projection);
-  }
-
-  private function hydrateGeneratedMaps(string $entityClass, array $rows): ?object
-  {
-    $row = $rows[0] ?? null;
-
-    if (!is_array($row)) {
-      return null;
-    }
-
-    $row = $this->normalizeReturnedRowForEntity($entityClass, $row);
-
-    return $this->create($entityClass, (object)$row);
-  }
-
-  private function normalizeReturnedRowForEntity(string $entityClass, array $row): array
-  {
-    $reflection = new ReflectionClass($entityClass);
-
-    foreach ($row as $property => $value) {
-      if (!is_string($property) || !property_exists($entityClass, $property)) {
-        continue;
-      }
-
-      if ($value === null) {
-        continue;
-      }
-
-      $propertyReflection = $reflection->getProperty($property);
-      $propertyType = $propertyReflection->getType();
-
-      if ($propertyType instanceof ReflectionUnionType || $propertyType === null) {
-        continue;
-      }
-
-      $targetType = $propertyType->getName();
-
-      if (enum_exists($targetType) && is_string($value) && method_exists($targetType, 'from')) {
-        $row[$property] = $targetType::from($value);
-      }
-    }
-
-    return $row;
-  }
-
-  private function sanitizeGeneratedMaps(?object $entity): ?object
-  {
-    if (!$entity) {
-      return null;
-    }
-
-    foreach ($this->getSecure() as $prop) {
-      if (property_exists($entity, $prop)) {
-        unset($entity->{$prop});
-      }
-    }
-
-    return $entity;
-  }
-
-  private function stripTableName(string $column): string
-  {
-    $parts = explode('.', $column);
-    return end($parts);
-  }
-
-  /**
-   * Removes a given entity from the database.
-   *
-   * @param object|object[] $entityOrEntities
-   * @param RemoveOptions|null $removeOptions
-   * @return DeleteResult
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   */
-  public function remove(object|array $entityOrEntities, ?RemoveOptions $removeOptions = null): DeleteResult
-  {
-    if (is_object($entityOrEntities)) {
-      $primaryKey = $this->getPrimaryKeyMetadata($entityOrEntities);
-      $primaryKeyField = $primaryKey['field'];
-      $primaryColumn = $primaryKey['column'];
-      $identifierValue = $entityOrEntities->{$primaryKeyField} ?? 0;
-      $statement = $this->query
-        ->deleteFrom(tableName: $this->entityInspector->getTableName(entity: $entityOrEntities));
-      $condition = $this->buildConditionClause([$primaryKeyField => $identifierValue], $this->query, $entityOrEntities);
-      $statement = $statement->where($condition);
-
-      if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
-        $this->query->appendQueryString('RETURNING ' . $this->query->quoteIdentifier($primaryColumn));
-      }
-
-      if ($this->isDebug) {
-        $statement->debug();
-      }
-
-      $result = $statement->execute();
-      $raw = $result->getRaw();
-
-      if ($result->isError()) {
-        throw new GeneralSQLQueryException($this->query);
-      }
-
-      $affected = $this->query->getDialect() === SQLDialect::POSTGRESQL
-        ? count($result->getData())
-        : $result->getTotalAffectedRows();
-
-      return new DeleteResult(raw: $raw, affected: $affected);
-    }
-
-    $affected = 0;
-    $raw = '';
-    foreach ($entityOrEntities as $entity) {
-      $removeResult = $this->remove(entityOrEntities: $entity, removeOptions: $removeOptions);
-      $affected += $removeResult->affected;
-      $raw .= $removeResult->raw . PHP_EOL;
-    }
-
-    return new DeleteResult(raw: $raw, affected: $affected);
-  }
-
-  /**
-   * Records the deletion date of a given entity.
-   *
-   * @param object|object[] $entityOrEntities
-   * @param RemoveOptions|array|null $removeOptions
-   * @param string $primaryKeyField
-   * @return UpdateResult Returns the removed entities.
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws DateInvalidTimeZoneException
-   * @throws DateMalformedStringException
-   */
-  public function softRemove(
-    object|array $entityOrEntities,
-    RemoveOptions|array|null $removeOptions = null,
-    string $primaryKeyField = 'id'
-  ): UpdateResult
-  {
-    $result = null;
-    $timezone = getenv('TIMEZONE') ?: self::DEFAULT_TIMEZONE;
-    $deletedAtFormat = getenv('DELETED_AT_FORMAT') ?: self::DEFAULT_DELETED_AT_FORMAT;
-    $deletedAt = new DateTimeImmutable('now', new DateTimeZone($timezone));
-    $deletedAt = $deletedAt->format($deletedAtFormat);
-    $primaryColumn = $this->getPrimaryKeyColumnName($entityOrEntities, $primaryKeyField);
-
-    if (is_object($entityOrEntities)) {
-      if (!$entityOrEntities->{$primaryKeyField}) {
-        throw new ORMException("Entity must have an '$primaryKeyField' field to be soft removed.");
-      }
-
-      $primaryKeyFieldValue = $entityOrEntities->{$primaryKeyField};
-      $statement = $this->query
-        ->update(tableName: $this->entityInspector->getTableName(entity: $entityOrEntities))
-        ->set([Filter::getDeleteDateColumnName(entity: $entityOrEntities) => $deletedAt]);
-      $condition = $this->buildConditionClause([$primaryColumn => $primaryKeyFieldValue], $this->query, $entityOrEntities);
-      $statement = $statement->where($condition);
-
-      if ($this->isDebug || $removeOptions?->isDebug) {
-        $statement->debug();
-      }
-
-      $result = $statement->execute();
-
-      if ($result->isError()) {
-        throw new GeneralSQLQueryException($this->query);
-      }
-
-      // TODO: #88 Verify that delete occurred @amasiye
-      $generatedMaps = new stdClass();
-      foreach ($result->value() as $key => $value) {
-        $generatedMaps->$key = $value;
-      }
-
-      return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: (object)$entityOrEntities, generatedMaps: $generatedMaps);
-    }
-
-    $identifiers = new stdClass();
-    $generatedMaps = new stdClass();
-
-    $numberFormatter = new NumberFormatter('en', NumberFormatter::SPELLOUT);
-    foreach ($entityOrEntities as $id => $entity) {
-      $key = is_numeric($id) ? $numberFormatter->format($id) : $id;
-      $result = $this->softRemove(entityOrEntities: $entity, removeOptions: $removeOptions);
-      $identifiers->$key = $result;
-      $generatedMaps->$key = $result->generatedMaps;
-    }
-
-    return new UpdateResult(raw: $result, affected: $this->query->rowCount(), identifiers: $identifiers, generatedMaps: $generatedMaps);
-  }
-
-  /**
-   * Deletes entities by a given condition(s).
-   *
-   * Unlike the save method, it executes a primitive operation without cascades,
-   * relations and other operations included.
-   * Executes a fast and efficient `DELETE` query.
-   * Does not check if the entity exists in the database.
-   * Condition(s) cannot be empty.
-   *
-   * @param string $entityClass
-   * @param int|array|object $conditions The deletion conditions.
-   *
-   * @return DeleteResult Returns the removed entities.
-   * @throws ClassNotFoundException
-   * @throws EmptyCriteriaException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function delete(string $entityClass, int|array|object $conditions): DeleteResult
-  {
-    $this->validateConditions(conditions: $conditions, methodName: __METHOD__);
-
-    $entity = $this->create(entityClass: $entityClass);
-
-    $statement = $this->query
-      ->deleteFrom(tableName: $this->entityInspector->getTableName(entity: $entity));
-    $statement = $statement->where(condition: $this->buildConditionClause($conditions, $this->query, $entity));
-
-    if ($this->isDebug) {
-      $statement->debug();
-    }
-
-    $deletionResult = $statement->execute();
-
-    if ($deletionResult->isError()) {
-      throw new GeneralSQLQueryException($this->query);
-    }
-
-    return new DeleteResult(raw: $deletionResult->value(), affected: $this->query->rowCount());
-  }
-
-  /**
-   * @param int|object|array $conditions
-   *
-   * @return string Returns an SQL condition string
-   */
-  /**
-   * Restores entities by a given condition(s).
-   * Unlike save method executes a primitive operation without cascades, relations and other operations included.
-   * Executes fast and efficient DELETE query.
-   * Does not check if entity exist in the database.
-   * Condition(s) cannot be empty.
-   * @param string $entityClass
-   * @param int|array|object $conditions
-   * @return UpdateResult
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function restore(string $entityClass, int|array|object $conditions): UpdateResult
-  {
-    $entity = $this->create(entityClass: $entityClass);
-
-    $statement = $this->query
-      ->update(tableName: $this->entityInspector->getTableName(entity: $entity))
-      ->set([Filter::getDeleteDateColumnName(entity: $entity) => NULL]);
-    $statement = $statement->where(condition: $this->buildConditionClause($conditions, $this->query, $entity));
-
-    if ($this->isDebug) {
-      $statement->debug();
-    }
-
-    $restoreResult = $statement->execute();
-
-    if ($restoreResult->isError()) {
-      throw new GeneralSQLQueryException($this->query);
-    }
-
-    $generatedMaps = new stdClass();
-
-    foreach ($restoreResult->value() as $key => $value) {
-      $generatedMaps->$key = $value;
-    }
-
-    return new UpdateResult(raw: $restoreResult->value(), affected: $this->query->rowCount(), identifiers: $entity, generatedMaps: $generatedMaps);
-  }
-
-  /**
-   * Finds entities that match given find options.
-   * Also counts all entities that match given conditions,
-   * but ignores pagination settings (from and take options).
-   *
-   * @param string $entityClass
-   * @param FindManyOptions|null $options
-   * @return FindResult
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  #[ArrayShape(['entities' => "array|null", 'count' => "int"])]
-  public function findAndCount(string $entityClass, ?FindManyOptions $options = null): FindResult
-  {
-    $result = $this->find(entityClass: $entityClass, findOptions: $options);
-
-    return new FindResult($result->getRaw(), $result->getTotal(), $result->getErrors(), $result->getTotalAffectedRows());
-  }
-
-  /**
-   * Finds entities that match given WHERE conditions.
-   * Also counts all entities that match given conditions,
-   * but ignores pagination settings (from and take options).
-   * @param string $entityClass
-   * @param FindWhereOptions|array $where
-   * @return FindResult
-   * @throws ClassNotFoundException
-   * @throws GeneralSQLQueryException
-   * @throws ORMException
-   * @throws ReflectionException
-   */
-  public function findAndCountBy(string $entityClass, FindWhereOptions|array $where): FindResult
-  {
-    $result = $this->findBy(entityClass: $entityClass, where: $where);
-
-    return new FindResult($result->getRaw(), $result->getTotal(), $result->getErrors(), $result->getTotalAffectedRows());
-  }
-
-  /**
-   * Sets the list of custom converters to use for type conversion.
-   *
-   * @param array $converters
-   * @return void
-   */
-  public function useConverters(array $converters): void
-  {
-    $this->customConverters = $converters;
-  }
-
-  /**
-   * @param string $entityClassName
-   * @param object $object
-   * @param IFactory|null $factory
-   * @return object
-   * @throws ClassNotFoundException
-   * @throws ORMException
-   * @throws ReflectionException
-   * @throws ContainerException
-   */
-  public function getEntityFromObject(string $entityClassName, object $object, ?IFactory $factory = null): object
-  {
-    self::validateEntityName($entityClassName);
-
-    $provider = new EntityProvider($this, $factory);
-    $entity = $provider->get($entityClassName);
-
-    foreach ($object as $prop => $value) {
-      if (property_exists($entity, $prop)) {
-        $sourceReflection = new ReflectionProperty($object, $prop);
-        $targetReflection = new ReflectionProperty($entity, $prop);
-        $sourceReflectionType = $sourceReflection->getType();
-        $targetReflectionType = $targetReflection->getType();
-
-        if ($sourceReflectionType instanceof ReflectionUnionType) {
-          $this->logger->warning("Source instance of ReflectionUnionType");
-          $sourceType = strval($sourceReflectionType);
-          if ($sourceReflectionType->allowsNull()) {
-            $sourceType = "null|$sourceType";
-          }
-        } else {
-          $sourceType = $sourceReflectionType?->getName() ?? match (gettype($object->$prop)) {
-            'integer' => 'int',
-            'double'  => 'float',
-            'boolean' => 'bool',
-            'NULL'    => null,
-            'object'  => get_class($object->$prop),
-            default   => gettype($object->$prop)
-          };
+        if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+            $generatedMaps = $this->hydrateGeneratedMaps($entityClass, $result->getData()) ?? $instance;
+            $generatedMaps = $this->sanitizeGeneratedMaps($generatedMaps);
+            $identifierValue = $generatedMaps?->{$primaryKeyField} ?? $instance->{$primaryKeyField} ?? $this->lastInsertId();
+
+            if ($identifierValue !== null && $identifierValue !== '') {
+                $instance->{$primaryKeyField} = $identifierValue;
+            }
+
+            return new InsertResult(
+                identifiers: (object)[$primaryKeyField => $identifierValue],
+                raw: $raw,
+                generatedMaps: $generatedMaps,
+                errors: [],
+                affected: $this->query->rowCount() ?? 0,
+            );
         }
 
-        if ($targetReflectionType instanceof ReflectionUnionType) {
-          $this->logger->warning("Target instance of ReflectionUnionType");
-          $targetType = strval($targetReflectionType);
-          if ($targetReflectionType->allowsNull()) {
-            $targetType = "null|$targetType";
-          }
-        } else {
-          $targetType = $targetReflectionType?->getName() ?? match (gettype($entity->$prop)) {
-            'integer' => 'int',
-            'double'  => 'float',
-            'boolean' => 'bool',
-            'NULL'    => null,
-            'object'  => get_class($object->$prop),
-            default   => gettype($entity->$prop)
-          };
+        # Find the record by the resolved primary key and hydrate the entity
+        $identifierCandidates = [];
+        $explicitIdentifierValue = $instance->{$primaryKeyField} ?? null;
+        $lastInsertId = $this->lastInsertId();
+
+        if ($explicitIdentifierValue !== null && $explicitIdentifierValue !== '') {
+            $identifierCandidates[] = $explicitIdentifierValue;
         }
 
-        if (is_null($sourceType) || is_null($targetType)) {
-          continue;
+        if ($lastInsertId !== null && $lastInsertId !== '' && !in_array($lastInsertId, $identifierCandidates, true)) {
+            $identifierCandidates[] = $lastInsertId;
         }
 
-        if ($sourceType !== $targetType && !str_contains($targetType, $sourceType)) {
-          $value = $this->castValue(value: $value, sourceType: $sourceType, targetType: $targetType);
+        if (empty($identifierCandidates)) {
+            $identifierCandidates[] = $explicitIdentifierValue;
         }
 
-        $entity->$prop = $value;
-      }
+        $identifierValue = $identifierCandidates[0] ?? null;
+        $result = null;
+
+        foreach ($identifierCandidates as $candidateIdentifierValue) {
+            $lookupResult = $this->findOne(
+                entityClass: $entityClass,
+                options: new FindOneOptions(where: [$primaryKeyField => $candidateIdentifierValue])
+            );
+
+            $result = $lookupResult;
+
+            if (!$lookupResult->isError() && !$lookupResult->isEmpty()) {
+                $identifierValue = $candidateIdentifierValue;
+                break;
+            }
+        }
+
+        if ($result?->isError()) {
+            if (!headers_sent()) {
+                http_response_code(500);
+            }
+            $error = new GeneralSQLQueryException($this->query);
+            OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
+
+            return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $raw, generatedMaps: null, errors: [$result->getErrors()]);
+        }
+
+        $entity = is_array($result->getData()) && array_is_list($result->getData())
+            ? ($result->getData()[0] ?? null)
+            : $result->getData();
+
+        if (is_object($entity) && isset($entity->{$primaryKeyField}) && $entity->{$primaryKeyField} !== null && $entity->{$primaryKeyField} !== '') {
+            $identifierValue = $entity->{$primaryKeyField};
+        }
+
+        $generatedMaps = (object)array_merge((array)$entity, (array)new stdClass());
+        $generatedMaps->{$primaryKeyField} = $identifierValue;
+
+        foreach ($generatedMaps as $prop => $value) {
+            if (in_array($prop, $this->getSecure())) {
+                unset($generatedMaps->$prop);
+            }
+        }
+
+        $identifiers = is_array($entity) ? (object)$entity : $entity;
+
+        return new InsertResult(identifiers: $identifiers, raw: $raw, generatedMaps: $generatedMaps);
     }
 
-    return $entity;
-  }
+    /**
+     * Creates a new entity instance or instances. Optionally accepts an object literal with entity
+     * properties which will be written into newly created Entity object.
+     *
+     * @param string $entityClass
+     * @param object|array|null $entityLike An entity like object or array literal with entity properties
+     *
+     * @return object Returns a newly created Entity object
+     * @throws ClassNotFoundException
+     * @throws ORMException|ReflectionException
+     */
+    public function create(string $entityClass, null|object|array $entityLike = null): object
+    {
+        $this->validateEntityName(entityClass: $entityClass);
 
-  /**
-   * @param string|null $name
-   * @return array
-   */
-  public function getStore(?string $name = null): array
-  {
-    return $this->entities;
-  }
+        $entity = new $entityClass;
 
-  /**
-   * @param string $key
-   * @return object|null
-   */
-  public function getStoreEntry(string $key): ?object
-  {
-    return $this->hasStoreEntry($key) ? $this->getStoreEntry($key) : null;
-  }
+        if (!empty($entityLike)) {
+            foreach ($entityLike as $entityLikePropertyName => $entityLikePropertyValue) {
+                if (property_exists($entity, $entityLikePropertyName)) {
+                    $entityClassReflectionProperty = new ReflectionProperty($entityClass, $entityLikePropertyName);
 
-  /**
-   * @param string $key
-   * @return bool
-   */
-  public function hasStoreEntry(string $key): bool
-  {
-    return isset($this->entities[$key]);
-  }
+                    if (is_null($entityLikePropertyValue)) {
+                        $entityLikePropertyValue = $this->getDefaultColumnValue($entityClassReflectionProperty);
 
-  /**
-   * @param string $key
-   * @param object $value
-   * @return int
-   */
-  public function addStoreEntry(string $key, object $value): int
-  {
-    return count($this->entities);
-  }
+                        if (!$entityClassReflectionProperty->getType()->allowsNull()) {
+                            continue;
+                        }
+                    }
 
-  /**
-   * @param string $key
-   * @param object $value
-   * @return int
-   */
-  public function removeStoreEntry(string $key, object $value): int
-  {
-    return count($this->entities);
-  }
+                    $entityLikeReflectionPropertyType = is_array($entityLike)
+                        ? strtolower(gettype($entityLikePropertyValue))
+                        : match (true) {
+                            (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType() instanceof ReflectionUnionType => strtolower(gettype($entityLikePropertyValue)),
+                            default => (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType()?->getName()
+                        };
+                    $entityClassReflectionPropertyType = match (true) {
+                        $entityClassReflectionProperty->getType() instanceof ReflectionUnionType => strval($entityClassReflectionProperty->getType()),
+                        default => $entityClassReflectionProperty->getType()?->getName()
+                    };
+                    $typesMatch = ($entityLikeReflectionPropertyType === $entityClassReflectionPropertyType) || ((!empty($entityClassReflectionPropertyType) && !empty($entityLikeReflectionPropertyType)) && str_contains($entityClassReflectionPropertyType, ($entityLikeReflectionPropertyType ?? '')));
 
-  /**
-   * Gets the primary key column name for a given entity class.
-   *
-   * @param object $entity
-   * @param string $primaryKeyField
-   * @return string
-   * @throws ClassNotFoundException
-   * @throws ORMException
-   */
-  private function getPrimaryKeyColumnName(object $entity, string $primaryKeyField = 'id'): string
-  {
-    return $this->getPrimaryKeyMetadata($entity, $primaryKeyField)['column'];
-  }
+                    $sourceType = $entityLikeReflectionPropertyType ?? gettype($entityLikePropertyValue);
+                    $targetType = $entityClassReflectionPropertyType ?? gettype($entityLikePropertyValue);
 
-  /**
-   * @return array{field: string, column: string}
-   * @throws ClassNotFoundException
-   * @throws ORMException
-   */
-  private function getPrimaryKeyMetadata(object $entity, ?string $preferredField = null): array
-  {
-    $this->entityInspector->validateEntityName($entity::class);
-
-    $preferredField = is_string($preferredField) ? $this->stripTableName($preferredField) : null;
-    $reflectionClass = new ReflectionClass($entity);
-    $fallback = null;
-
-    foreach ($reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-      foreach ($property->getAttributes() as $attribute) {
-        $attributeInstance = $attribute->newInstance();
-
-        if (!$attributeInstance instanceof Column || !$attributeInstance->isPrimaryKey) {
-          continue;
+                    $entity->$entityLikePropertyName = $typesMatch ? $entityLikePropertyValue : $this->castValue(value: $entityLikePropertyValue, sourceType: $sourceType, targetType: $targetType) ?? $entityLikePropertyValue;
+                }
+            }
         }
 
-        $columnName = $attributeInstance->name ?: $property->getName();
-        $metadata = [
-          'field' => $property->getName(),
-          'column' => $columnName,
-        ];
+        return $entity;
+    }
 
+    /**
+     * Asserts that the specified class name is a valid entity and throws an exception if it is not.
+     *
+     * @param string $entityClass The name of the class to validate.
+     * @return void
+     * @throws ClassNotFoundException If the class does not exist.
+     * @throws ORMException If the class does not have the required attributes.
+     */
+    public static function validateEntityName(string $entityClass): void
+    {
+        EntityInspector::getInstance()->validateEntityName(entityClass: $entityClass);
+    }
+
+    /**
+     * Returns the default value for a given column. If no default value is specified, returns null.
+     *
+     * @param ReflectionProperty $reflectionProperty The reflection property to get the default value for.
+     * @return mixed Returns the default value for the given column.
+     * @throws ValidationException If the default value is invalid.
+     */
+    private function getDefaultColumnValue(ReflectionProperty $reflectionProperty): mixed
+    {
+        # Load Column attribute for the property
+        $attributes = $reflectionProperty->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            $attributeInstance = $attribute->newInstance();
+
+            if (!property_exists($attributeInstance, 'default')) {
+                continue;
+            }
+
+            try {
+                # Check if a default value is specified
+                if (!is_null($attributeInstance->default)) {
+                    return match (true) {
+                        $attributeInstance->default === 'CURRENT_TIMESTAMP', $attributeInstance->default === 'NOW()' => new DateTime(),
+                        # Match ISO 8601 date format
+                        preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $attributeInstance->default) => new DateTime($attributeInstance->default),
+                        # Match ATOM date format
+                        preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+$/', $attributeInstance->default) => new DateTime($attributeInstance->default),
+                        default => $attributeInstance->default
+                    };
+                }
+            } catch (Exception $exception) {
+                throw new ValidationException($exception);
+            }
+        }
+
+        # If no default value is specified, return null
+        return null;
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws TypeConversionException
+     */
+    private function castValue(mixed $value, string $sourceType, string $targetType): mixed
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        foreach ($this->customConverters as $converter) {
+            $result = $this->typeResolver->resolve(converterHost: $converter, value: $value, fromType: $sourceType, toType: $targetType);
+
+            if (!is_null($result)) {
+                return $result;
+            }
+        }
+
+        foreach ($this->defaultConverters as $converter) {
+            $result = $this->typeResolver->resolve(converterHost: $converter, value: $value, fromType: $sourceType, toType: $targetType);
+
+            if (!is_null($result)) {
+                return $result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{field: string, column: string}
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     */
+    private function getPrimaryKeyMetadata(object $entity, ?string $preferredField = null): array
+    {
+        $this->entityInspector->validateEntityName($entity::class);
+
+        $preferredField = is_string($preferredField) ? $this->stripTableName($preferredField) : null;
+        $reflectionClass = new ReflectionClass($entity);
+        $fallback = null;
+
+        foreach ($reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            foreach ($property->getAttributes() as $attribute) {
+                $attributeInstance = $attribute->newInstance();
+
+                if (!$attributeInstance instanceof Column || !$attributeInstance->isPrimaryKey) {
+                    continue;
+                }
+
+                $columnName = $attributeInstance->name ?: $property->getName();
+                $metadata = [
+                    'field' => $property->getName(),
+                    'column' => $columnName,
+                ];
+
+                if (
+                    $preferredField !== null &&
+                    ($preferredField === $metadata['field'] || $preferredField === $metadata['column'])
+                ) {
+                    return $metadata;
+                }
+
+                $fallback ??= $metadata;
+            }
+        }
+
+        if ($fallback) {
+            return $fallback;
+        }
+
+        throw new ORMException("Entity " . $entity::class . " does not have a primary key column.");
+    }
+
+    private function stripTableName(string $column): string
+    {
+        $parts = explode('.', $column);
+        return end($parts);
+    }
+
+    private function buildReturningProjection(object $entity): string
+    {
+        $projection = [];
+
+        foreach ($this->entityInspector->getColumns(entity: $entity) as $field => $column) {
+            $columnName = $this->stripTableName($column);
+            $alias = is_string($field) ? $field : $columnName;
+
+            $projection[] = $this->query->quoteIdentifier($columnName) . ' AS ' . $this->query->quoteIdentifier($alias);
+        }
+
+        return implode(', ', $projection);
+    }
+
+    private function hydrateGeneratedMaps(string $entityClass, array $rows): ?object
+    {
+        $row = $rows[0] ?? null;
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        $row = $this->normalizeReturnedRowForEntity($entityClass, $row);
+
+        return $this->create($entityClass, (object)$row);
+    }
+
+    private function normalizeReturnedRowForEntity(string $entityClass, array $row): array
+    {
+        $reflection = new ReflectionClass($entityClass);
+
+        foreach ($row as $property => $value) {
+            if (!is_string($property) || !property_exists($entityClass, $property)) {
+                continue;
+            }
+
+            if ($value === null) {
+                continue;
+            }
+
+            $propertyReflection = $reflection->getProperty($property);
+            $propertyType = $propertyReflection->getType();
+
+            if ($propertyType instanceof ReflectionUnionType || $propertyType === null) {
+                continue;
+            }
+
+            $targetType = $propertyType->getName();
+
+            if (enum_exists($targetType) && is_string($value) && method_exists($targetType, 'from')) {
+                $row[$property] = $targetType::from($value);
+            }
+        }
+
+        return $row;
+    }
+
+    private function sanitizeGeneratedMaps(?object $entity): ?object
+    {
+        if (!$entity) {
+            return null;
+        }
+
+        foreach ($this->getSecure() as $prop) {
+            if (property_exists($entity, $prop)) {
+                unset($entity->{$prop});
+            }
+        }
+
+        return $entity;
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function getSecure(): array
+    {
+        return array_merge($this->secure, $this->customSecure);
+    }
+
+    /**
+     * @param array|string[] $secure
+     */
+    public function setSecure(array $secure): void
+    {
+        $this->customSecure = $secure;
+    }
+
+    /**
+     * Returns the id of the last inserted entity.
+     *
+     * @return int|null Returns the id of the last inserted entity.
+     */
+    public function lastInsertId(): ?int
+    {
+        return $this->query->lastInsertId();
+    }
+
+    /**
+     * Finds first entity by a given find options.
+     * If entity was not found in the database - returns null.
+     *
+     * @param string $entityClass
+     * @param FindOptions|FindOneOptions $options
+     * @return FindResult
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function findOne(string $entityClass, FindOptions|FindOneOptions $options): FindResult
+    {
+        $result = $this->find(entityClass: $entityClass, findOptions: $options);
+
+        if ($result->isError()) {
+            return $result;
+        }
+
+        if ($result->getTotal() === 0) {
+            return new FindResult(raw: $result->getRaw(), data: null);
+        }
+
+        /** @var Entity $entityClass */
+        return new FindResult(raw: $result->getRaw(), data: $result->getData()[0] ?? null);
+    }
+
+    /**
+     * Find entities that match the given `FindOptions`.
+     *
+     * @param string $entityClass
+     * @param null|FindOptions $findOptions
+     *
+     * @return FindResult<T>
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function find(string $entityClass, ?FindOptions $findOptions = new FindOptions()): FindResult
+    {
+        $entity = $this->create(entityClass: $entityClass);
+        $conditions = [];
+        $availableRelations = [];
+        $requestedRelations = $this->getRequestedRelationNames($findOptions);
+        $baseExcludeColumns = $this->resolveBaseEntityExcludeColumns($findOptions, $requestedRelations);
+
+        if ($deleteColumnName = $this->getDeleteDateColumnName(entityClass: $entityClass)) {
+            $conditions = array_merge($findOptions->where->conditions ?? $findOptions->where ?? [], [$deleteColumnName => 'NULL']);
+        }
+
+        $columns = $this->entityInspector->getColumns(
+            entity: $entity,
+            exclude: $baseExcludeColumns,
+            relations: $requestedRelations,
+            relationProperties: $availableRelations
+        );
+        $columns = $this->appendRequiredRelationColumns($entity, $columns, $availableRelations);
+
+        $tableName = $this->entityInspector->getTableName(entity: $entity);
+        $statement = $this->query->select()->all(columns: $columns)->from(tableReferences: $tableName);
+
+        if (!empty($findOptions)) {
+            foreach ($requestedRelations as $relationName) {
+                if (!isset($availableRelations[$relationName])) {
+                    if ($this->isDebug) {
+                        throw new ORMException("Relation $relationName does not exist in the entity $entityClass.");
+                    }
+
+                    $this->logger->warning("Relation $relationName does not exist in the entity $entityClass. \n\tThrown in " . __FILE__ . ' on line ' . __LINE__);
+                }
+            }
+
+            # Resolve where conditions
+            if ($conditions) {
+                $findWhereOptions = new FindWhereOptions(conditions: $conditions, entityClass: $entityClass);
+            }
+
+            $statement = $statement->where(condition: $findWhereOptions ?? $findOptions);
+        }
+
+        if ($findOptions->order) {
+            $statement->orderBy($findOptions->order);
+        }
+
+        $limit = $findOptions->limit ?? $_GET['limit'] ?? OrmRuntime::defaultLimit();
+        $skip = $findOptions->skip ?? $_GET['skip'] ?? OrmRuntime::defaultSkip();
+
+        $statement = $statement->limit(limit: $limit, offset: $skip);
+
+        if ($this->isDebug || $findOptions->isDebug) {
+            $statement->debug();
+        }
+
+        $result = $statement->execute();
+
+        if ($result->isError()) {
+            return new FindResult(raw: $result->getRaw(), data: $result->value(), errors: [new GeneralSQLQueryException($this->query), ...$result->getErrors()], affected: $result->getTotalAffectedRows());
+        }
+
+        $loadedRelations = $this->loadRequestedRelations($entityClass, $result->getData(), $findOptions, $availableRelations);
+        $resultSet = $this->processRelations($result->getData(), $entityClass, $findOptions, $availableRelations, $loadedRelations);
+        $resultSet = $this->stripExcludedColumns($resultSet, $findOptions->exclude ?? []);
+
+        if ($findOptions->withRealTotal) {
+            $total = $this->count(entityClass: $entityClass, options: $findOptions);
+
+            if (count($resultSet) === 0) {
+                $total = 0;
+            }
+
+            return new FindResult(raw: $result->getRaw(), data: $resultSet, errors: $result->getErrors(), total: $total);
+        }
+
+        return new FindResult(raw: $result->getRaw(), data: $resultSet, errors: $result->getErrors());
+    }
+
+    /**
+     * @param FindOptions|null $findOptions
+     * @return string[]
+     */
+    protected function getRequestedRelationNames(?FindOptions $findOptions): array
+    {
+        $relations = $findOptions?->relations ?? [];
+
+        if (!is_array($relations)) {
+            $relations = (array)$relations;
+        }
+
+        if (array_is_list($relations)) {
+            return array_values(
+                array_filter(
+                    array_map(
+                        fn($relation) => is_string($relation) ? trim($relation) : null,
+                        $relations
+                    )
+                )
+            );
+        }
+
+        $requestedRelations = [];
+
+        foreach ($relations as $relation => $enabled) {
+            if (!is_string($relation)) {
+                continue;
+            }
+
+            if ($enabled) {
+                $requestedRelations[] = trim($relation);
+            }
+        }
+
+        return $requestedRelations;
+    }
+
+    /**
+     * Keeps relation keys available internally even when callers exclude them from the final payload.
+     *
+     * @param FindOptions|null $findOptions
+     * @param string[] $requestedRelations
+     * @return string[]
+     */
+    private function resolveBaseEntityExcludeColumns(?FindOptions $findOptions, array $requestedRelations): array
+    {
+        $excludeColumns = $findOptions?->exclude ?? [];
+
+        if (empty($excludeColumns) || empty($requestedRelations)) {
+            return $excludeColumns;
+        }
+
+        $requiredColumns = array_unique(array_merge(['id'], $requestedRelations));
+
+        return array_values(
+            array_filter(
+                $excludeColumns,
+                fn(string $column): bool => !in_array($column, $requiredColumns, true)
+            )
+        );
+    }
+
+    /**
+     * @param string|ReflectionClass $entityClass
+     * @return string|null
+     * @throws ReflectionException
+     */
+    private function getDeleteDateColumnName(string|ReflectionClass $entityClass): ?string
+    {
+        # If $entityClass is a string, get a reflection class
+        $reflection = is_string($entityClass) ? new ReflectionClass($entityClass) : $entityClass;
+
+        # Get properties
+        $properties = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
+
+        foreach ($properties as $property) {
+            # Find DeleteDateColumn attribute
+            $deleteDateColumnAttributes = $property->getAttributes(DeleteDateColumn::class);
+
+            if (empty($deleteDateColumnAttributes)) {
+                continue;
+            }
+
+            # If name is specified use name, else use property name
+            $columnInstance = $deleteDateColumnAttributes[0]->newInstance();
+
+            return $columnInstance->name ?? $property->getName();
+        }
+
+        return null;
+    }
+
+    /**
+     * Ensures relation loading can still read required local keys from the root entity rows.
+     *
+     * @param array<int|string, string> $columns
+     * @param array<string, RelationPropertyMetadata> $availableRelations
+     * @return array<int|string, string>
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function appendRequiredRelationColumns(object $entity, array $columns, array $availableRelations): array
+    {
+        foreach ($availableRelations as $relationProperty) {
+            if (!$relationProperty instanceof RelationPropertyMetadata) {
+                continue;
+            }
+
+            $columns = match ($relationProperty->getRelationType()) {
+                RelationType::ONE_TO_ONE => $relationProperty->joinColumn
+                    ? $this->appendJoinColumnSelection(
+                        columns: $columns,
+                        entityClass: $entity::class,
+                        propertyName: $relationProperty->name,
+                        joinColumn: $relationProperty->joinColumn
+                    )
+                    : $this->appendPropertyColumnSelection(
+                        columns: $columns,
+                        entity: $entity,
+                        propertyName: 'id'
+                    ),
+                RelationType::ONE_TO_MANY => $this->appendPropertyColumnSelection(
+                    columns: $columns,
+                    entity: $entity,
+                    propertyName: $relationProperty->relationAttribute->referencedProperty ?? 'id'
+                ),
+                RelationType::MANY_TO_ONE => $this->appendJoinColumnSelection(
+                    columns: $columns,
+                    entityClass: $entity::class,
+                    propertyName: $relationProperty->name,
+                    joinColumn: $relationProperty->joinColumn
+                    ?? $this->entityInspector->getJoinColumnAttribute($entity::class, $relationProperty->name)
+                ),
+                RelationType::MANY_TO_MANY => $this->appendPropertyColumnSelection(
+                    columns: $columns,
+                    entity: $entity,
+                    propertyName: 'id'
+                ),
+                default => $columns,
+            };
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param array<int|string, string> $columns
+     * @return array<int|string, string>
+     * @throws ORMException
+     */
+    private function appendJoinColumnSelection(array $columns, string $entityClass, string $propertyName, JoinColumn $joinColumn): array
+    {
+        $tableName = $this->entityInspector->getTableName($this->create($entityClass));
+        $columnName = $joinColumn->effectiveColumnName ?? $joinColumn->name ?? $propertyName;
+
+        return $this->appendColumnSelection($columns, $propertyName, "$tableName.$columnName");
+    }
+
+    /**
+     * @param array<int|string, string> $columns
+     * @return array<int|string, string>
+     */
+    private function appendColumnSelection(array $columns, ?string $columnAlias, string $columnSelection): array
+    {
         if (
-          $preferredField !== null &&
-          ($preferredField === $metadata['field'] || $preferredField === $metadata['column'])
+            ($columnAlias !== null && array_key_exists($columnAlias, $columns)) ||
+            in_array($columnSelection, $columns, true) ||
+            in_array($columnSelection, array_values($columns), true)
         ) {
-          return $metadata;
+            return $columns;
         }
 
-        $fallback ??= $metadata;
-      }
+        if ($columnAlias === null) {
+            $columns[] = $columnSelection;
+            return $columns;
+        }
+
+        $columns[$columnAlias] = $columnSelection;
+
+        return $columns;
     }
 
-    if ($fallback) {
-      return $fallback;
+    /**
+     * @param array<int|string, string> $columns
+     * @return array<int|string, string>
+     */
+    private function appendPropertyColumnSelection(array $columns, object $entity, string $propertyName): array
+    {
+        if (!property_exists($entity, $propertyName)) {
+            return $columns;
+        }
+
+        $reflectionProperty = new ReflectionProperty($entity, $propertyName);
+
+        foreach ($reflectionProperty->getAttributes() as $attribute) {
+            $attributeInstance = $attribute->newInstance();
+
+            if (!$attributeInstance instanceof Column) {
+                continue;
+            }
+
+            $tableName = $this->entityInspector->getTableName($entity);
+            $columnName = $attributeInstance->name ?? $propertyName;
+            $columnAlias = $attributeInstance->alias ?: ($attributeInstance->name ? $propertyName : null);
+
+            return $this->appendColumnSelection($columns, $columnAlias, "$tableName.$columnName");
+        }
+
+        return $columns;
     }
 
-    throw new ORMException("Entity " . $entity::class . " does not have a primary key column.");
-  }
+    /**
+     * @param array<int, object|array> $data
+     * @param array<string, RelationPropertyMetadata> $availableRelations
+     * @return array<string, array<mixed, mixed>>
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function loadRequestedRelations(string $entityClass, array $data, ?FindOptions $findOptions, array $availableRelations): array
+    {
+        if (!$findOptions || !$findOptions->relations || empty($data)) {
+            return [];
+        }
+
+        $loadedRelations = [];
+        $rows = array_map(
+            fn(object|array $row) => is_array($row) ? (object)$row : $row,
+            $data
+        );
+
+        foreach ($this->getRequestedRelationNames($findOptions) as $relationName) {
+            $relationProperty = $availableRelations[$relationName] ?? null;
+
+            if (!$relationProperty instanceof RelationPropertyMetadata) {
+                continue;
+            }
+
+            $loadedRelations[$relationName] = match ($relationProperty->getRelationType()) {
+                RelationType::ONE_TO_ONE => $this->loadOneToOneRelation($entityClass, $rows, $relationProperty, $findOptions),
+                RelationType::ONE_TO_MANY => $this->loadOneToManyRelation($rows, $relationProperty, $findOptions),
+                RelationType::MANY_TO_ONE => $this->loadManyToOneRelation($rows, $relationProperty, $findOptions),
+                RelationType::MANY_TO_MANY => $this->loadManyToManyRelation($entityClass, $rows, $relationProperty, $findOptions),
+                default => [],
+            };
+        }
+
+        return $loadedRelations;
+    }
+
+    /**
+     * @param object[] $rows
+     * @return array<mixed, object>
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function loadOneToOneRelation(string $entityClass, array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
+    {
+        if ($relationProperty->joinColumn) {
+            return $this->loadManyToOneRelation($rows, $relationProperty, $findOptions);
+        }
+
+        $targetClass = $relationProperty->getEntityClass();
+        if (!$targetClass) {
+            return [];
+        }
+
+        $inverseOwner = $this->resolveInverseOneToOneOwner($entityClass, $relationProperty);
+        if (!$inverseOwner) {
+            return [];
+        }
+
+        $localIds = $this->extractScalarValues($rows, 'id');
+        if (empty($localIds)) {
+            return [];
+        }
+
+        $inversePropertyName = $inverseOwner['property'];
+        $joinColumn = $inverseOwner['joinColumn'];
+        $relatedRows = $this->fetchEntityRows(
+            entityClass: $targetClass,
+            conditionColumn: $joinColumn->effectiveColumnName ?? $joinColumn->name ?? 'id',
+            conditionValues: $localIds,
+            excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions),
+            relations: [$inversePropertyName]
+        );
+
+        $groupedRows = [];
+        foreach ($relatedRows as $relatedRow) {
+            $ownerKey = $relatedRow->{$inversePropertyName} ?? null;
+            unset($relatedRow->{$inversePropertyName});
+
+            if ($ownerKey !== null) {
+                $groupedRows[$ownerKey] = $relatedRow;
+            }
+        }
+
+        return $groupedRows;
+    }
+
+    /**
+     * @param object[] $rows
+     * @return array<mixed, object>
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function loadManyToOneRelation(array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
+    {
+        $targetClass = $relationProperty->getEntityClass();
+
+        if (!$targetClass) {
+            return [];
+        }
+
+        $foreignKeys = $this->extractScalarValues($rows, $relationProperty->name);
+        if (empty($foreignKeys)) {
+            return [];
+        }
+
+        $joinColumn = $relationProperty->joinColumn ?? $this->entityInspector->getJoinColumnAttribute($relationProperty->reflectionProperty->getDeclaringClass()->getName(), $relationProperty->name);
+        $referenceColumn = $joinColumn->effectiveReferencedColumnName ?? 'id';
+        $relatedRows = $this->fetchEntityRows(
+            entityClass: $targetClass,
+            conditionColumn: $referenceColumn,
+            conditionValues: $foreignKeys,
+            excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions)
+        );
+
+        $groupedRows = [];
+        foreach ($relatedRows as $relatedRow) {
+            $key = $relatedRow->{$referenceColumn} ?? null;
+            if ($key !== null) {
+                $groupedRows[$key] = $relatedRow;
+            }
+        }
+
+        return $groupedRows;
+    }
+
+    /**
+     * @param object[] $rows
+     * @return list<mixed>
+     */
+    private function extractScalarValues(array $rows, string $property): array
+    {
+        $values = [];
+
+        foreach ($rows as $row) {
+            $value = $row->{$property} ?? null;
+            if ($value !== null && $value !== '') {
+                $values[] = $value;
+            }
+        }
+
+        return array_values(array_unique($values, SORT_REGULAR));
+    }
+
+    /**
+     * @param string[] $excludeColumns
+     * @param string[] $relations
+     * @return object[]
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function fetchEntityRows(string $entityClass, string $conditionColumn, array $conditionValues, array $excludeColumns = ['password'], array $relations = []): array
+    {
+        if (empty($conditionValues)) {
+            return [];
+        }
+
+        $entity = $this->create($entityClass);
+        $columns = $this->entityInspector->getColumns(entity: $entity, exclude: $excludeColumns, relations: $relations);
+        $tableName = $this->entityInspector->getTableName($entity);
+        $query = SQLQuery::forConnection($this->query->getConnection(), dialect: $this->query->getDialect());
+        $statement = $query
+            ->select()
+            ->all(columns: $columns)
+            ->from(tableReferences: $tableName);
+        $condition = $this->buildInCondition("$tableName.$conditionColumn", $conditionValues, $query);
+
+        if (!$condition) {
+            return [];
+        }
+
+        $result = $statement
+            ->where($condition)
+            ->execute();
+
+        if ($result->isError()) {
+            throw new GeneralSQLQueryException($query, $result->getErrors()[0]);
+        }
+
+        return array_map(
+            fn(object|array $row) => is_array($row) ? (object)$row : $row,
+            $result->getData()
+        );
+    }
+
+    /**
+     * @param list<mixed> $values
+     */
+    private function buildInCondition(string $qualifiedColumn, array $values, ?SQLQuery $query = null): ?string
+    {
+        if (empty($values)) {
+            return null;
+        }
+
+        $query ??= $this->query;
+
+        return SqlIdentifier::quote($qualifiedColumn, $query->getDialect()) . ' IN (' . implode(', ', $query->addParams(array_values($values))) . ')';
+    }
+
+    private function resolveRelationExcludeColumns(RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
+    {
+        $relationOptions = $relationProperty->relationAttribute->options ?? null;
+
+        if ($relationOptions instanceof RelationOptions) {
+            return $relationOptions->exclude;
+        }
+
+        return $findOptions->exclude ?? ['password'];
+    }
+
+    /**
+     * @return array{property: string, joinColumn: JoinColumn}|null
+     * @throws ReflectionException
+     */
+    private function resolveInverseOneToOneOwner(string $entityClass, RelationPropertyMetadata $relationProperty): ?array
+    {
+        $targetClass = $relationProperty->getEntityClass();
+        if (!$targetClass) {
+            return null;
+        }
+
+        $targetReflection = new ReflectionClass($targetClass);
+
+        foreach ($targetReflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $oneToOneAttributes = $property->getAttributes(OneToOne::class);
+            if (empty($oneToOneAttributes)) {
+                continue;
+            }
+
+            /** @var OneToOne $attribute */
+            $attribute = $oneToOneAttributes[0]->newInstance();
+            if ($attribute->type !== $entityClass) {
+                continue;
+            }
+
+            return [
+                'property' => $property->getName(),
+                'joinColumn' => $this->entityInspector->getJoinColumnAttribute($targetClass, $property->getName()),
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param object[] $rows
+     * @return array<mixed, object[]>
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function loadOneToManyRelation(array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
+    {
+        $targetClass = $relationProperty->getEntityClass();
+        $referenceProperty = $relationProperty->relationAttribute->referencedProperty ?? 'id';
+        $inverseProperty = $relationProperty->relationAttribute->inverseSide ?? null;
+
+        if (!$targetClass || !$inverseProperty) {
+            return [];
+        }
+
+        $localKeys = $this->extractScalarValues($rows, $referenceProperty);
+        if (empty($localKeys)) {
+            return [];
+        }
+
+        $joinColumn = $this->entityInspector->getJoinColumnAttribute($targetClass, $inverseProperty);
+        $relatedRows = $this->fetchEntityRows(
+            entityClass: $targetClass,
+            conditionColumn: $joinColumn->effectiveColumnName ?? $joinColumn->name ?? 'id',
+            conditionValues: $localKeys,
+            excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions),
+            relations: [$inverseProperty]
+        );
+
+        $groupedRows = [];
+        foreach ($relatedRows as $relatedRow) {
+            $ownerKey = $relatedRow->{$inverseProperty} ?? null;
+            unset($relatedRow->{$inverseProperty});
+
+            if ($ownerKey === null) {
+                continue;
+            }
+
+            $groupedRows[$ownerKey] ??= [];
+            $groupedRows[$ownerKey][] = $relatedRow;
+        }
+
+        return $groupedRows;
+    }
+
+    /**
+     * @param object[] $rows
+     * @return array<mixed, object[]>
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function loadManyToManyRelation(string $entityClass, array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
+    {
+        $mapping = $this->resolveManyToManyMapping($entityClass, $relationProperty);
+        if (!$mapping) {
+            return [];
+        }
+
+        $localIds = $this->extractScalarValues($rows, 'id');
+        if (empty($localIds)) {
+            return [];
+        }
+
+        $targetClass = $relationProperty->getEntityClass();
+        if (!$targetClass) {
+            return [];
+        }
+
+        $targetEntity = $this->create($targetClass);
+        $targetTable = $this->entityInspector->getTableName($targetEntity);
+        $joinTable = $mapping['joinTable'];
+        $localJoinColumn = $mapping['localJoinColumn'];
+        $targetJoinColumn = $mapping['targetJoinColumn'];
+        $joinTableName = $joinTable->name ?? strtolower($mapping['ownerTable'] . '_' . $mapping['targetTable']);
+
+        $columns = $this->entityInspector->getColumns(
+            entity: $targetEntity,
+            exclude: $this->resolveRelationExcludeColumns($relationProperty, $findOptions)
+        );
+        $columns['__relation_owner_key'] = "$joinTableName.$localJoinColumn";
+
+        $query = SQLQuery::forConnection($this->query->getConnection(), dialect: $this->query->getDialect());
+        $statement = $query
+            ->select()
+            ->all(columns: $columns)
+            ->from(tableReferences: $targetTable)
+            ->join($joinTableName)
+            ->on("$joinTableName.$targetJoinColumn = $targetTable.id");
+        $condition = $this->buildInCondition("$joinTableName.$localJoinColumn", $localIds, $query);
+        if (!$condition) {
+            return [];
+        }
+
+        $result = $statement
+            ->where($condition)
+            ->execute();
+
+        if ($result->isError()) {
+            throw new GeneralSQLQueryException($query, $result->getErrors()[0]);
+        }
+
+        $groupedRows = [];
+        foreach ($result->getData() as $row) {
+            $row = is_array($row) ? (object)$row : $row;
+            $ownerKey = $row->__relation_owner_key ?? null;
+            unset($row->__relation_owner_key);
+
+            if ($ownerKey === null) {
+                continue;
+            }
+
+            $groupedRows[$ownerKey] ??= [];
+            $groupedRows[$ownerKey][] = $row;
+        }
+
+        return $groupedRows;
+    }
+
+    /**
+     * @return array{joinTable: JoinTable, ownerTable: string, targetTable: string, localJoinColumn: string, targetJoinColumn: string}|null
+     * @throws ReflectionException
+     * @throws ORMException
+     * @throws ClassNotFoundException
+     */
+    private function resolveManyToManyMapping(string $entityClass, RelationPropertyMetadata $relationProperty): ?array
+    {
+        $targetClass = $relationProperty->getEntityClass();
+        if (!$targetClass) {
+            return null;
+        }
+
+        $ownerTable = $this->entityInspector->getTableName($this->create($entityClass));
+        $targetTable = $this->entityInspector->getTableName($this->create($targetClass));
+        $joinTable = $relationProperty->joinTable;
+
+        if ($joinTable instanceof JoinTable) {
+            return [
+                'joinTable' => $joinTable,
+                'ownerTable' => $ownerTable,
+                'targetTable' => $targetTable,
+                'localJoinColumn' => $joinTable->joinColumn ?? strtosingular($ownerTable) . '_id',
+                'targetJoinColumn' => $joinTable->inverseJoinColumn ?? strtosingular($targetTable) . '_id',
+            ];
+        }
+
+        $inverseProperty = $relationProperty->relationAttribute->inverseSide ?? null;
+        $ownerProperty = $inverseProperty && property_exists($targetClass, $inverseProperty)
+            ? new ReflectionProperty($targetClass, $inverseProperty)
+            : $this->findManyToManyOwnerProperty($targetClass, $entityClass);
+
+        if (!$ownerProperty) {
+            return null;
+        }
+
+        $joinTableAttributes = $ownerProperty->getAttributes(JoinTable::class);
+        if (empty($joinTableAttributes)) {
+            return null;
+        }
+
+        /** @var JoinTable $joinTable */
+        $joinTable = $joinTableAttributes[0]->newInstance();
+        $inverseOwnerTable = $this->entityInspector->getTableName($this->create($targetClass));
+
+        return [
+            'joinTable' => $joinTable,
+            'ownerTable' => $inverseOwnerTable,
+            'targetTable' => $ownerTable,
+            'localJoinColumn' => $joinTable->inverseJoinColumn ?? strtosingular($ownerTable) . '_id',
+            'targetJoinColumn' => $joinTable->joinColumn ?? strtosingular($inverseOwnerTable) . '_id',
+        ];
+    }
+
+    private function findManyToManyOwnerProperty(string $targetClass, string $entityClass): ?ReflectionProperty
+    {
+        $targetReflection = new ReflectionClass($targetClass);
+
+        foreach ($targetReflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $relationAttributes = $property->getAttributes(\Assegai\Orm\Attributes\Relations\ManyToMany::class);
+            $joinTableAttributes = $property->getAttributes(JoinTable::class);
+
+            if (empty($relationAttributes) || empty($joinTableAttributes)) {
+                continue;
+            }
+
+            /** @var \Assegai\Orm\Attributes\Relations\ManyToMany $attribute */
+            $attribute = $relationAttributes[0]->newInstance();
+            if ($attribute->type === $entityClass) {
+                return $property;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Processes the relations of the given data.
+     *
+     * @param object[] $data The data to process.
+     * @param string $entityClass The entity class name.
+     * @param FindWhereOptions|FindOptions|null $findOptions The find options.
+     * @param RelationPropertyMetadata[] $relationInfo The relation information.
+     * @param array $loadedRelations The loaded relations.
+     * @return object[] Returns the processed data.
+     */
+    private function processRelations(array $data, string $entityClass, FindWhereOptions|FindOptions|null $findOptions, array $relationInfo, array $loadedRelations): array
+    {
+        if (!$findOptions || !$findOptions->relations) {
+            return $data;
+        }
+
+        $results = [];
+        $requestedRelations = $this->getRequestedRelationNames($findOptions);
+
+        foreach ($data as $datum) {
+            if (is_array($datum)) {
+                $datum = (object)$datum;
+            }
+
+            foreach ($requestedRelations as $relation) {
+                if (!isset($relationInfo[$relation])) {
+                    $this->logger->warning("Relation $relation does not exist in the entity $entityClass. \n\tThrown in " . __FILE__ . ' on line ' . __LINE__);
+                    continue;
+                }
+
+                $datum = $this->bindEntityRelations($entityClass, $datum, $relation, $relationInfo[$relation], $loadedRelations);
+            }
+
+            $results[] = $datum;
+        }
+
+        return $results;
+    }
+
+    /**
+     * Binds entity relations to the entity.
+     *
+     * @param string $entityClass The entity class name.
+     * @param object $entity The entity to bind the relations to.
+     * @param string $relationName The name of the relation to bind.
+     * @param RelationPropertyMetadata $relationInfo The relation information.
+     * @param array<string, mixed> $loadedRelations The loaded relations. This list is used to prevent previously loaded relations from being loaded again.
+     * @return object Returns the entity with the relations bound.
+     */
+    private function bindEntityRelations(string $entityClass, object $entity, string $relationName, RelationPropertyMetadata $relationInfo, array $loadedRelations): object
+    {
+        if ($this->isDebug) {
+            $this->logger->debug("Restructuring entity $entityClass with relation $relationName");
+        }
+
+        $entity = is_array($entity) ? (object)$entity : $entity;
+        $relationValue = match ($relationInfo->getRelationType()) {
+            RelationType::ONE_TO_ONE => $this->resolveOneToOneRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
+            RelationType::ONE_TO_MANY => $this->resolveOneToManyRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
+            RelationType::MANY_TO_ONE => $this->resolveManyToOneRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
+            RelationType::MANY_TO_MANY => $this->resolveManyToManyRelationValue($entity, $loadedRelations[$relationName] ?? []),
+            default => null,
+        };
+
+        $entity->$relationName = $relationValue;
+        return $entity;
+    }
+
+    private function resolveOneToOneRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): ?object
+    {
+        $relationKey = $relationInfo->joinColumn
+            ? ($entity->{$relationInfo->name} ?? null)
+            : ($entity->id ?? null);
+
+        if ($relationKey === null) {
+            return null;
+        }
+
+        return $loadedRelations[$relationKey] ?? null;
+    }
+
+    private function resolveOneToManyRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): array
+    {
+        $referenceProperty = $relationInfo->relationAttribute->referencedProperty ?? 'id';
+        $referenceValue = $entity->{$referenceProperty} ?? null;
+
+        if ($referenceValue === null) {
+            return [];
+        }
+
+        return $loadedRelations[$referenceValue] ?? [];
+    }
+
+    private function resolveManyToOneRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): ?object
+    {
+        $foreignKey = $entity->{$relationInfo->name} ?? null;
+
+        if ($foreignKey === null) {
+            return null;
+        }
+
+        return $loadedRelations[$foreignKey] ?? null;
+    }
+
+    private function resolveManyToManyRelationValue(object $entity, array $loadedRelations): array
+    {
+        $referenceValue = $entity->id ?? null;
+
+        if ($referenceValue === null) {
+            return [];
+        }
+
+        return $loadedRelations[$referenceValue] ?? [];
+    }
+
+    /**
+     * @param object[] $rows
+     * @param string[] $excludeColumns
+     * @return object[]
+     */
+    private function stripExcludedColumns(array $rows, array $excludeColumns): array
+    {
+        if (empty($excludeColumns)) {
+            return $rows;
+        }
+
+        return array_map(function (object|array $row) use ($excludeColumns): object {
+            $row = is_array($row) ? (object)$row : $row;
+
+            foreach ($excludeColumns as $column) {
+                unset($row->{$column});
+            }
+
+            return $row;
+        }, $rows);
+    }
+
+    /**
+     * Counts entities that match given options.
+     * Useful for pagination.
+     *
+     * @param string $entityClass
+     * @param FindOptions|null $options
+     * @return int Returns the count of entities that match the given options
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function count(string $entityClass, ?FindOptions $options = null): int
+    {
+        $entity = $this->create(entityClass: $entityClass);
+
+        $statement = $this->query->select()->count()->from(tableReferences: $this->entityInspector->getTableName(entity: $entity));
+
+        if ($options) {
+            $conditions = [];
+
+            if ($deleteColumnName = $this->getDeleteDateColumnName(entityClass: $entityClass)) {
+                $conditions = array_merge($options->where->conditions ?? $options->where ?? [], [$deleteColumnName => 'NULL']);
+            }
+
+            $statement = $statement->where(condition: new FindWhereOptions(conditions: $conditions, entityClass: $entityClass));
+        }
+
+        if ($this->isDebug || $options?->isDebug) {
+            $statement->debug();
+        }
+
+        $result = $statement->execute();
+
+        if ($result->isError()) {
+            throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+        }
+
+        return $result->value()[0]?->total ?? 0;
+    }
+
+    private function normalizeSaveInsertOptions(InsertOptions|UpdateOptions|null $options): InsertOptions
+    {
+        if ($options instanceof InsertOptions) {
+            return $options;
+        }
+
+        if ($options instanceof UpdateOptions) {
+            return new InsertOptions(
+                relations: $options->relations,
+                isDebug: $options->isDebug,
+                readonlyColumns: $options->readonlyColumns,
+                primaryKeyField: $options->primaryKeyField,
+            );
+        }
+
+        return new InsertOptions();
+    }
+
+    /**
+     * Finds entities that match given `FindWhereOptions`.
+     *
+     * @param string $entityClass The entity class name.
+     * @param FindWhereOptions|array $where The find options.
+     * @return FindResult Returns a FindResult object representing the result of the query.
+     * @throws ClassNotFoundException If the given entity class does not exist.
+     * @throws GeneralSQLQueryException If the query fails.
+     * @throws ORMException|ReflectionException If the given entity class does not have the required attributes.
+     */
+    public function findBy(string $entityClass, FindWhereOptions|array $where): FindResult
+    {
+        $entity = $this->create(entityClass: $entityClass);
+        if (is_array($where)) {
+            $where = new FindWhereOptions(
+                conditions: $where['condition'] ?? $where,
+                entityClass: $entityClass
+            );
+        }
+        $statement = $this->query->select()->all(columns: $this->entityInspector->getColumns(entity: $entity, exclude: $where->exclude))->from(tableReferences: $this->entityInspector->getTableName(entity: $entity))->where(condition: $where);
+
+        $limit = $_GET['limit'] ?? 100;
+        $skip = $_GET['skip'] ?? 0;
+
+        $statement = $statement->limit(limit: $limit, offset: $skip);
+
+        if ($this->isDebug) {
+            $statement->debug();
+        }
+
+        $result = $statement->execute();
+
+        if ($result->isError()) {
+            throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+        }
+
+        return new FindResult(raw: $result->getRaw(), data: $result->getData(), errors: $result->getErrors());
+    }
+
+    /**
+     * Updates entity partially. Entity can be found by a given condition(s).
+     * Unlike save method executes a primitive operation without cascades, relations and other operations included.
+     * Executes fast and efficient UPDATE query.
+     * Does not check if entity exist in the database.
+     * Condition(s) cannot be empty.
+     *
+     * @param string $entityClass The entity class name.
+     * @param object|array $partialEntity The entity or entities to update.
+     * @param string|object|array $conditions The condition(s) to find the entity.
+     * @param UpdateOptions|null $options The options to use when updating the entity.
+     * @return UpdateResult
+     * @throws ClassNotFoundException
+     * @throws EmptyCriteriaException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     * @throws ValidationException
+     */
+    public function update(string $entityClass, object|array $partialEntity, string|object|array $conditions, ?UpdateOptions $options = null): UpdateResult
+    {
+        $this->validateConditions(conditions: $conditions, methodName: __METHOD__);
+
+        if (empty($conditions)) {
+            throw new ORMException("Empty criteria(s) are not allowed for the update method.");
+        }
+
+        if (is_array($partialEntity) && array_is_list($partialEntity)) {
+            $raw = '';
+            $affected = 0;
+            $generatedMaps = new stdClass();
+
+            foreach ($partialEntity as $partialItem) {
+                $result = $this->update(entityClass: $entityClass, partialEntity: $partialItem, conditions: $conditions);
+                $generatedMaps = $result->generatedMaps;
+            }
+
+            return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: (object)$partialEntity, generatedMaps: $generatedMaps);
+        }
+
+        $entityInstance = $this->create(entityClass: $entityClass, entityLike: $partialEntity);
+        $assignmentList = [];
+        $columnOptions = [];
+        $relations = [];
+        $relationProperties = [];
+
+        if ($options?->relations) {
+            $relations = is_object($options->relations) ? (array)$options->relations : $options->relations;
+        }
+
+        $columnMap = $this->entityInspector->getColumns(entity: $entityInstance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnOptions);
+
+        foreach ($partialEntity as $prop => $value) {
+            # Get the correct prop name
+            $columnName = $this->getColumnNameFromProperty($entityInstance, $prop);
+
+            if ($this->mapContainsColumnName($columnMap, $columnName)) {
+                if (!is_null($value)) {
+                    if ($value instanceof UnitEnum && property_exists($value, 'value')) {
+                        $value = $value->value;
+                    }
+
+                    if ($value instanceof DateTime) {
+                        $value = $this->entityInspector->convertDateTimeToString($value, $prop, $columnOptions);
+                    }
+
+                    if ($value instanceof stdClass) {
+                        $value = json_encode($value);
+                    }
+
+                    if (isset($columnMap[$columnName])) {
+                        if (isset($relationProperties[$columnName])) {
+                            assert($relationProperties[$columnName] instanceof RelationPropertyMetadata);
+
+                            if (is_object($value) && property_exists($value, $relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName)) {
+                                $value = $value->{$relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName};
+                            }
+
+                            $columnName = $relationProperties[$columnName]->joinColumn->effectiveColumnName;
+                        } else {
+                            $columnName = $this->getUnqualifiedColumnName($columnMap[$columnName]);
+                        }
+                    }
+
+                    $assignmentList[$columnName] = $value;
+                }
+            }
+        }
+
+        if (empty($assignmentList)) {
+            return new UpdateResult(null, 0, $partialEntity, new stdClass());
+        }
+
+        $statement = $this->query
+            ->update(tableName: $this->entityInspector->getTableName(entity: $entityInstance))
+            ->set(assignmentList: $assignmentList);
+        $conditionString = is_string($conditions)
+            ? $conditions
+            : $this->buildConditionClause($conditions, $this->query, $entityInstance);
+        $statement->where(condition: $conditionString);
+
+        if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+            $this->query->appendQueryString('RETURNING ' . $this->buildReturningProjection($entityInstance));
+        }
+
+        if ($this->isDebug || $options?->isDebug) {
+            $this->query->debug();
+        }
+
+        $result = $this->query->execute();
+        $raw = $result->getRaw();
+
+        if ($result->isError()) {
+            throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+        }
+
+        $generatedMaps = null;
+
+        if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+            $generatedMaps = $this->hydrateGeneratedMaps($entityClass, $result->getData());
+        }
+
+        if (!$generatedMaps) {
+            $updatedEntity = $this->findOne(entityClass: $entityClass, options: new FindOptions(where: $conditions));
+            $generatedMaps = $updatedEntity->getData() ?? new stdClass();
+        }
+
+        $generatedMaps = $this->sanitizeGeneratedMaps($generatedMaps);
+
+        $identifiers = is_array($partialEntity) ? (object)$partialEntity : $partialEntity;
+        if ($generatedMaps && is_object($generatedMaps)) {
+            $primaryKeyMetadata = $this->getPrimaryKeyMetadata($entityInstance);
+            $primaryKeyField = $primaryKeyMetadata['field'];
+            $identifierValue = $generatedMaps->{$primaryKeyField} ?? null;
+
+            if ($identifierValue !== null && $identifierValue !== '') {
+                $identifiers = (object)(array_merge((array)$identifiers, [$primaryKeyField => $identifierValue]));
+            }
+        }
+
+        return new UpdateResult(raw: $raw, affected: $this->query->rowCount(), identifiers: $identifiers, generatedMaps: $generatedMaps);
+    }
+
+    /**
+     * Validates the given conditions. If the given conditions are invalid, then a `ValidationException` is thrown.
+     *
+     * @param string|object|array $conditions The conditions to validate.
+     * @param string $methodName The name of the method that called this method.
+     * @return void
+     * @throws ValidationException If the given conditions are invalid.
+     */
+    private function validateConditions(string|object|array $conditions, string $methodName): void
+    {
+        if (empty($conditions)) {
+            throw new EmptyCriteriaException(methodName: $methodName);
+        }
+    }
+
+    /**
+     * Resolves the storage column name for a given entity property.
+     *
+     * Regular column-backed properties default to snake_case when no explicit column name is supplied.
+     * Relation properties continue to return the PHP property name so relation metadata can decide which
+     * join column to use later in the update and condition-building paths.
+     *
+     * @param object $entity The entity that owns the property.
+     * @param string $prop The property name to resolve.
+     * @return string The resolved storage column name or the original relation property name.
+     */
+    private function getColumnNameFromProperty(object $entity, string $prop): string
+    {
+        if (!property_exists($entity, $prop)) {
+            return $prop;
+        }
+
+        $propertyReflection = new ReflectionProperty($entity, $prop);
+        $attributes = $propertyReflection->getAttributes();
+
+        if (empty($attributes)) {
+            return $prop;
+        }
+
+        # Return $prop if no valid Column attribute found
+        $columnClassNames = [Column::class, CreateDateColumn::class, DeleteDateColumn::class, EmailColumn::class, PasswordColumn::class, PrimaryGeneratedColumn::class, UpdateDateColumn::class, URLColumn::class];
+        $columnAttribute = null;
+        foreach ($attributes as $attribute) {
+            if (in_array($attribute->getName(), $columnClassNames)) {
+                $columnAttribute = $attribute;
+            }
+        }
+
+        if (!$columnAttribute) {
+            return $prop;
+        }
+
+        /** @var Column $column */
+        $column = $columnAttribute->newInstance();
+        return empty($column->name) ? strtosnake($prop) : $column->name;
+    }
+
+    /**
+     * Determines if a given column map contains a given column name.
+     *
+     * @param array $columnMap The column map to check.
+     * @param string $columnName The column name to check for.
+     * @return bool Returns true if the column map contains the given column name, otherwise false.
+     */
+    private function mapContainsColumnName(array $columnMap, string $columnName): bool
+    {
+        foreach ($columnMap as $key => $value) {
+            if (str_ends_with($key, $columnName)) {
+                return true;
+            }
+
+            if (str_ends_with($value, $columnName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Removes the table prefix from a column reference when a SQL assignment target must be unqualified.
+     *
+     * @param string $columnReference The column reference to normalize.
+     * @return string The unqualified column name.
+     */
+    private function getUnqualifiedColumnName(string $columnReference): string
+    {
+        if (!str_contains($columnReference, '.')) {
+            return $columnReference;
+        }
+
+        return substr($columnReference, strrpos($columnReference, '.') + 1);
+    }
+
+    /**
+     * @param int|object|array $conditions
+     * @param SQLQuery $query
+     * @param object|null $entity
+     * @return string
+     */
+    private function buildConditionClause(int|object|array $conditions, SQLQuery $query, ?object $entity = null): string
+    {
+        if (is_int($conditions)) {
+            return SqlIdentifier::quote('id', $query->getDialect()) . '=' . $query->addParam($conditions);
+        }
+
+        $parts = [];
+
+        foreach ((array)$conditions as $key => $value) {
+            $columnName = $entity && is_string($key)
+                ? $this->getColumnNameFromProperty($entity, $key)
+                : (string)$key;
+            $identifier = SqlIdentifier::quote($columnName, $query->getDialect());
+
+            if (is_null($value) || $value === 'NULL') {
+                $parts[] = "$identifier IS NULL";
+                continue;
+            }
+
+            if (is_array($value) && array_is_list($value)) {
+                if (empty($value)) {
+                    $parts[] = '1 = 0';
+                    continue;
+                }
+
+                $parts[] = $identifier . ' IN (' . implode(', ', $query->addParams($value)) . ')';
+                continue;
+            }
+
+            $parts[] = $identifier . '=' . $query->addParam($value);
+        }
+
+        return implode(' AND ', $parts);
+    }
+
+    private function normalizeSaveUpdateOptions(InsertOptions|UpdateOptions|null $options): UpdateOptions
+    {
+        if ($options instanceof UpdateOptions) {
+            return $options;
+        }
+
+        if ($options instanceof InsertOptions) {
+            return new UpdateOptions(
+                relations: $options->relations,
+                isDebug: $options->isDebug,
+                readonlyColumns: $options->readonlyColumns,
+                primaryKeyField: $options->primaryKeyField,
+            );
+        }
+
+        return new UpdateOptions();
+    }
+
+    /**
+     * Creates a new entity from the given plain php object. If the entity already exist in the database, then
+     * it loads it (and everything related to it), replaces all values with the new ones from the given object
+     * and returns this new entity. This new entity is actually a loaded from the db entity with all properties
+     * replaced from the new object.
+     * @param string $entityClass
+     * @param object $entityLike
+     * @return Entity|null
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function preload(string $entityClass, object $entityLike): ?object
+    {
+        $findOptions = [];
+
+        foreach ($entityLike as $prop => $value) {
+            if (property_exists($entityClass, $prop)) {
+                $findOptions[$prop] = $value;
+            }
+        }
+
+        $entity = $this->find(entityClass: $entityClass, findOptions: FindOptions::fromArray($findOptions));
+
+        if (empty($entity->getData())) {
+            $entity = $this->create(entityClass: $entityClass, entityLike: $entityLike);
+        }
+
+        return $this->merge($entityClass, $entity, $entityLike);
+    }
+
+    /**
+     * Merges multiple entities into a single entity.
+     *
+     * @param string $entityClass
+     * @param mixed ...$entities
+     *
+     * @return Entity Returns a single entity
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     */
+    public function merge(string $entityClass, ...$entities): object
+    {
+        $this->validateEntityName(entityClass: $entityClass);
+
+        $entity = new $entityClass;
+
+        if ($entity instanceof Entity) {
+            $object = $entity;
+
+            foreach ($entities as $item) {
+                if (is_object($item) || is_array($item)) {
+                    $object = (object)array_merge((array)$object, (array)$item);
+                }
+            }
+
+            foreach ($object as $prop => $value) {
+                if (property_exists($entity, $prop)) {
+                    $entity->$prop = $value;
+                }
+            }
+        }
+
+        return $entity;
+    }
+
+    /**
+     * Inserts a new entity or array of entities unless they already exist in the database, if they do then updates.
+     *
+     * @param string $entityClass The entity class name.
+     * @param object|object[] $entityOrEntities The entity or entities to upsert.
+     * @return InsertResult|UpdateResult Returns an InsertResult or UpdateResult.
+     * @throws ClassNotFoundException
+     * @throws NotImplementedException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function upsert(string $entityClass, object|array $entityOrEntities, array|UpsertOptions $options): InsertResult|UpdateResult
+    {
+        // TODO: #83 Implement EntityManager::upsert @amasiye
+        if (is_array($options)) {
+            $options = array_is_list($options)
+                ? new UpsertOptions(conflictPaths: $options)
+                : UpsertOptions::fromArray($options);
+        }
+
+        if (is_array($entityOrEntities)) {
+            $results = [];
+            $errors = [];
+            foreach ($entityOrEntities as $entity) {
+                $result = $this->upsert(entityClass: $entityClass, entityOrEntities: $entity, options: $options);
+
+                if ($result->isError()) {
+                    $errors[] = $result->getErrors();
+                }
+
+                $results[] = $result->getData();
+            }
+
+            $generatedMaps = new stdClass();
+            $generatedMaps->results = $results;
+
+            return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: $entityOrEntities, generatedMaps: $generatedMaps, errors: $errors);
+        }
+
+        $this->validateEntityName(entityClass: $entityClass);
+
+        $entity = $this->create(
+            entityClass: $entityClass,
+            entityLike: is_array($entityOrEntities) ? $entityOrEntities : (object)$entityOrEntities,
+        );
+
+        // TODO: Configure the upsert options
+        $primaryKey = $this->getPrimaryKeyMetadata($entity);
+        $primaryKeyField = $primaryKey['field'];
+        $primaryColumn = $primaryKey['column'];
+
+        $columns = $this->entityInspector->getColumns(entity: $entity);
+        $updateColumns = $this->entityInspector->getColumns(entity: $entity, exclude: $options->readonlyColumns ?? $this->readonlyColumns);
+        $values = $this->entityInspector->getValues(entity: $entity);
+        $tableName = $this->entityInspector->getTableName(entity: $entity);
+
+        return match ($this->query->getDialect()) {
+            SQLDialect::SQLITE => $this->executeSqliteUpsert($tableName, $entity, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
+            SQLDialect::POSTGRESQL => $this->executePostgreSqlUpsert($entityClass, $tableName, $entity, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
+            default => $this->executeMySqlUpsert($entityClass, $tableName, $entity, $columns, $updateColumns, $values, $options, $primaryKeyField, $primaryColumn),
+        };
+    }
+
+    private function executeSqliteUpsert(
+        string        $tableName,
+        object        $entity,
+        array         $columns,
+        array         $updateColumns,
+        array         $values,
+        UpsertOptions $options,
+        string        $primaryKeyField,
+        string        $primaryColumn,
+    ): InsertResult
+    {
+        $originalId = $entity->{$primaryKeyField} ?? null;
+        $columns = array_map([$this, 'stripTableName'], array_values($columns));
+        $updateColumns = array_map([$this, 'stripTableName'], array_values($updateColumns));
+        $conflictPaths = $this->resolveUpsertConflictColumns($entity, $options->conflictPaths ?: [$primaryColumn]);
+        [$columns, $values] = $this->filterNullableUpsertColumns($columns, $values, $conflictPaths, $updateColumns);
+
+        $quotedColumns = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $columns));
+        $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
+        $placeholders = array_fill(0, count($values), '?');
+        $valueList = implode(', ', $placeholders);
+        $assignmentList = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()) . '=excluded.' . SqlIdentifier::quote($column, $this->query->getDialect()), $updateColumns));
+        $conflictAction = empty($assignmentList) ? 'DO NOTHING' : "DO UPDATE SET $assignmentList";
+
+        $queryString = 'INSERT INTO ' . $this->query->quoteIdentifier($tableName) . " ($quotedColumns) VALUES ($valueList) ON CONFLICT ($quotedConflictPaths) $conflictAction";
+        $this->query->init();
+        $this->query->insertInto(tableName: $tableName);
+        $this->query->setQueryString($queryString);
+        $this->query->addParams($values);
+
+        if ($this->isDebug) {
+            $this->query->debug();
+        }
+
+        $result = $this->query->execute();
+        $raw = $result->getRaw();
+        $errors = [];
+
+        if ($result->isError()) {
+            $errors[] = $this->query->getConnection()->errorInfo();
+            $errors[] = new GeneralSQLQueryException($this->query);
+            $errors = [...$errors, ...$result->getErrors()];
+        }
+
+        if ($result->isOk()) {
+            $lastInsertId = $this->lastInsertId();
+            if (empty($originalId) && $lastInsertId) {
+                $entity->{$primaryKeyField} = $lastInsertId;
+            }
+        }
+
+        $identifier = $entity->{$primaryKeyField} ?? $originalId ?? $this->lastInsertId();
+
+        return new InsertResult(
+            identifiers: (object)[$primaryKeyField => $identifier],
+            raw: $raw,
+            generatedMaps: $entity,
+            errors: $errors,
+            affected: $this->query->rowCount() ?? 0,
+        );
+    }
+
+    private function resolveUpsertConflictColumns(object $entity, array $conflictPaths): array
+    {
+        $columnMap = [];
+
+        foreach ($this->entityInspector->getColumns($entity) as $field => $column) {
+            $columnName = $this->stripTableName($column);
+
+            if (is_string($field)) {
+                $columnMap[$field] = $columnName;
+            }
+
+            $columnMap[$columnName] = $columnName;
+        }
+
+        $resolved = array_map(function (string $conflictPath) use ($columnMap): string {
+            $conflictPath = $this->stripTableName($conflictPath);
+
+            return $columnMap[$conflictPath] ?? $conflictPath;
+        }, $conflictPaths);
+
+        return array_values(array_unique($resolved));
+    }
+
+    private function filterNullableUpsertColumns(array $columns, array $values, array $conflictPaths, array $updateColumns): array
+    {
+        $filteredColumns = [];
+        $filteredValues = [];
+
+        foreach ($columns as $index => $column) {
+            $value = $values[$index] ?? null;
+
+            if ($value === null && !in_array($column, $conflictPaths, true) && !in_array($column, $updateColumns, true)) {
+                continue;
+            }
+
+            $filteredColumns[] = $column;
+            $filteredValues[] = $value;
+        }
+
+        return [$filteredColumns, $filteredValues];
+    }
+
+    private function executePostgreSqlUpsert(
+        string        $entityClass,
+        string        $tableName,
+        object        $entity,
+        array         $columns,
+        array         $updateColumns,
+        array         $values,
+        UpsertOptions $options,
+        string        $primaryKeyField,
+        string        $primaryColumn,
+    ): InsertResult
+    {
+        $originalId = $entity->{$primaryKeyField} ?? null;
+        $columns = array_map([$this, 'stripTableName'], array_values($columns));
+        $updateColumns = array_map([$this, 'stripTableName'], array_values($updateColumns));
+        $conflictPaths = $this->resolveUpsertConflictColumns($entity, $options->conflictPaths ?: [$primaryColumn]);
+        [$columns, $values] = $this->filterNullableUpsertColumns($columns, $values, $conflictPaths, $updateColumns);
+
+        $quotedColumns = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $columns));
+        $quotedConflictPaths = implode(', ', array_map(fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()), $conflictPaths));
+        $placeholders = array_fill(0, count($values), '?');
+        $valueList = implode(', ', $placeholders);
+        $assignmentList = implode(', ', array_map(
+            fn(string $column): string => SqlIdentifier::quote($column, $this->query->getDialect()) . '=excluded.' . SqlIdentifier::quote($column, $this->query->getDialect()),
+            $updateColumns
+        ));
+        $conflictAction = empty($assignmentList) ? 'DO NOTHING' : "DO UPDATE SET $assignmentList";
+        $returning = $this->query->quoteIdentifier($primaryColumn) . ' AS ' . $this->query->quoteIdentifier($primaryKeyField);
+
+        $queryString = 'INSERT INTO ' . $this->query->quoteIdentifier($tableName)
+            . " ($quotedColumns) VALUES ($valueList) ON CONFLICT ($quotedConflictPaths) $conflictAction RETURNING $returning";
+
+        $this->query->init();
+        $this->query->insertInto(tableName: $tableName);
+        $this->query->setQueryString($queryString);
+        $this->query->addParams($values);
+
+        if ($this->isDebug) {
+            $this->query->debug();
+        }
+
+        $result = $this->query->execute();
+        $raw = $result->getRaw();
+        $errors = [];
+
+        if ($result->isError()) {
+            $errors[] = $this->query->getConnection()->errorInfo();
+            $errors[] = new GeneralSQLQueryException($this->query);
+            $errors = [...$errors, ...$result->getErrors()];
+        }
+
+        $identifierValue = $this->extractReturningIdentifier($result->getData(), $primaryKeyField, $primaryColumn)
+            ?? $originalId
+            ?? $this->lastInsertId();
+        $generatedMaps = $entity;
+
+        if ($result->isOk()) {
+            if ($identifierValue !== null && $identifierValue !== '') {
+                $entity->{$primaryKeyField} = $identifierValue;
+            }
+
+            $lookupConditions = $this->buildUpsertLookupConditions($entity, $options, $primaryKeyField);
+
+            if ($identifierValue !== null && $identifierValue !== '') {
+                $lookupConditions = [$primaryKeyField => $identifierValue];
+            }
+
+            if (!empty($lookupConditions)) {
+                $persistedResult = $this->findOne(entityClass: $entityClass, options: new FindOneOptions(where: $lookupConditions));
+                $persistedEntity = $persistedResult->getData();
+
+                if (is_object($persistedEntity)) {
+                    $generatedMaps = $persistedEntity;
+                    $identifierValue = $persistedEntity->{$primaryKeyField} ?? $identifierValue;
+                }
+            }
+        }
+
+        return new InsertResult(
+            identifiers: (object)[$primaryKeyField => $identifierValue],
+            raw: $raw,
+            generatedMaps: $generatedMaps,
+            errors: $errors,
+            affected: $this->query->rowCount() ?? 0,
+        );
+    }
+
+    private function extractReturningIdentifier(array $rows, string $primaryKeyField, string $primaryColumn): mixed
+    {
+        $row = $rows[0] ?? null;
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        foreach ([$primaryKeyField, $primaryColumn, 'id'] as $key) {
+            if (array_key_exists($key, $row)) {
+                return $row[$key];
+            }
+        }
+
+        return null;
+    }
+
+    private function buildUpsertLookupConditions(object $entity, UpsertOptions $options, string $primaryKeyField = 'id'): array
+    {
+        $conditions = [];
+
+        foreach ($options->conflictPaths as $conflictPath) {
+            if (!is_string($conflictPath) || !property_exists($entity, $conflictPath)) {
+                continue;
+            }
+
+            $value = $entity->{$conflictPath};
+
+            if ($value instanceof UnitEnum && property_exists($value, 'value')) {
+                $value = $value->value;
+            }
+
+            if ($value === null) {
+                continue;
+            }
+
+            $conditions[$conflictPath] = $value;
+        }
+
+        if (empty($conditions) && !empty($entity->{$primaryKeyField})) {
+            $conditions[$primaryKeyField] = $entity->{$primaryKeyField};
+        }
+
+        return $conditions;
+    }
+
+    private function executeMySqlUpsert(
+        string        $entityClass,
+        string        $tableName,
+        object        $entityOrEntities,
+        array         $columns,
+        array         $updateColumns,
+        array         $values,
+        UpsertOptions $options,
+        string        $primaryKeyField,
+        string        $primaryColumn,
+    ): InsertResult
+    {
+        $assignmentList = array_map(function ($column): string {
+            $column = $this->stripTableName($column);
+            return "$column=VALUES($column)";
+        }, array_values($updateColumns));
+
+        array_unshift($assignmentList, "$primaryColumn=LAST_INSERT_ID($primaryColumn)");
+
+        $this->query->insertInto(tableName: $tableName)->singleRow(columns: $columns)->values(valuesList: $values)->onDuplicateKeyUpdate(assignmentList: $assignmentList);
+
+        if ($this->isDebug) {
+            $this->query->debug();
+        }
+
+        $result = $this->query->execute();
+        $raw = $result->getRaw();
+
+        $errors = [];
+        if ($result->isError()) {
+            $errors[] = $this->query->getConnection()->errorInfo();
+            $errors[] = new GeneralSQLQueryException($this->query);
+            $errors = [...$errors, ...$result->getErrors()];
+        }
+
+        $identifierValue = $entityOrEntities->{$primaryKeyField} ?? null;
+        $generatedMaps = $entityOrEntities;
+
+        if ($result->isOk()) {
+            $identifierValue = $identifierValue ?: $this->lastInsertId();
+            $lookupConditions = $this->buildUpsertLookupConditions($entityOrEntities, $options, $primaryKeyField);
+
+            if (!empty($identifierValue)) {
+                $lookupConditions = [$primaryKeyField => $identifierValue];
+            }
+
+            if (!empty($lookupConditions)) {
+                $persistedResult = $this->findOne(entityClass: $entityClass, options: new FindOneOptions(where: $lookupConditions));
+                $persistedEntity = $persistedResult->getData();
+
+                if (is_object($persistedEntity)) {
+                    $generatedMaps = $persistedEntity;
+                    $identifierValue = $persistedEntity->{$primaryKeyField} ?? $identifierValue;
+                }
+            }
+
+            if (!empty($identifierValue)) {
+                $entityOrEntities->{$primaryKeyField} = $identifierValue;
+            }
+        }
+
+        return new InsertResult(
+            identifiers: (object)[$primaryKeyField => $identifierValue],
+            raw: $raw,
+            generatedMaps: $generatedMaps,
+            errors: $errors,
+            affected: $this->query->rowCount() ?? 0,
+        );
+    }
+
+    /**
+     * Removes a given entity from the database.
+     *
+     * @param object|object[] $entityOrEntities
+     * @param RemoveOptions|null $removeOptions
+     * @return DeleteResult
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     */
+    public function remove(object|array $entityOrEntities, ?RemoveOptions $removeOptions = null): DeleteResult
+    {
+        if (is_object($entityOrEntities)) {
+            $primaryKey = $this->getPrimaryKeyMetadata($entityOrEntities);
+            $primaryKeyField = $primaryKey['field'];
+            $primaryColumn = $primaryKey['column'];
+            $identifierValue = $entityOrEntities->{$primaryKeyField} ?? 0;
+            $statement = $this->query
+                ->deleteFrom(tableName: $this->entityInspector->getTableName(entity: $entityOrEntities));
+            $condition = $this->buildConditionClause([$primaryKeyField => $identifierValue], $this->query, $entityOrEntities);
+            $statement = $statement->where($condition);
+
+            if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+                $this->query->appendQueryString('RETURNING ' . $this->query->quoteIdentifier($primaryColumn));
+            }
+
+            if ($this->isDebug) {
+                $statement->debug();
+            }
+
+            $result = $statement->execute();
+            $raw = $result->getRaw();
+
+            if ($result->isError()) {
+                throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+            }
+
+            $affected = $this->query->getDialect() === SQLDialect::POSTGRESQL
+                ? count($result->getData())
+                : $result->getTotalAffectedRows();
+
+            return new DeleteResult(raw: $raw, affected: $affected);
+        }
+
+        $affected = 0;
+        $raw = '';
+        foreach ($entityOrEntities as $entity) {
+            $removeResult = $this->remove(entityOrEntities: $entity, removeOptions: $removeOptions);
+            $affected += $removeResult->affected;
+            $raw .= $removeResult->raw . PHP_EOL;
+        }
+
+        return new DeleteResult(raw: $raw, affected: $affected);
+    }
+
+    /**
+     * Records the deletion date of a given entity.
+     *
+     * @param object|object[] $entityOrEntities
+     * @param RemoveOptions|array|null $removeOptions
+     * @param string $primaryKeyField
+     * @return UpdateResult Returns the removed entities.
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws DateInvalidTimeZoneException
+     * @throws DateMalformedStringException
+     */
+    public function softRemove(
+        object|array             $entityOrEntities,
+        RemoveOptions|array|null $removeOptions = null,
+        string                   $primaryKeyField = 'id'
+    ): UpdateResult
+    {
+        $result = null;
+        $timezone = getenv('TIMEZONE') ?: self::DEFAULT_TIMEZONE;
+        $deletedAtFormat = getenv('DELETED_AT_FORMAT') ?: self::DEFAULT_DELETED_AT_FORMAT;
+        $deletedAt = new DateTimeImmutable('now', new DateTimeZone($timezone));
+        $deletedAt = $deletedAt->format($deletedAtFormat);
+        $primaryColumn = $this->getPrimaryKeyColumnName($entityOrEntities, $primaryKeyField);
+
+        if (is_object($entityOrEntities)) {
+            if (!$entityOrEntities->{$primaryKeyField}) {
+                throw new ORMException("Entity must have an '$primaryKeyField' field to be soft removed.");
+            }
+
+            $primaryKeyFieldValue = $entityOrEntities->{$primaryKeyField};
+            $statement = $this->query
+                ->update(tableName: $this->entityInspector->getTableName(entity: $entityOrEntities))
+                ->set([Filter::getDeleteDateColumnName(entity: $entityOrEntities) => $deletedAt]);
+            $condition = $this->buildConditionClause([$primaryColumn => $primaryKeyFieldValue], $this->query, $entityOrEntities);
+            $statement = $statement->where($condition);
+
+            if ($this->isDebug || $removeOptions?->isDebug) {
+                $statement->debug();
+            }
+
+            $result = $statement->execute();
+
+            if ($result->isError()) {
+                throw new GeneralSQLQueryException($this->query, $result->getErrors()[0]);
+            }
+
+            // TODO: #88 Verify that delete occurred @amasiye
+            $generatedMaps = new stdClass();
+            foreach ($result->value() as $key => $value) {
+                $generatedMaps->$key = $value;
+            }
+
+            return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: (object)$entityOrEntities, generatedMaps: $generatedMaps);
+        }
+
+        $identifiers = new stdClass();
+        $generatedMaps = new stdClass();
+
+        $numberFormatter = new NumberFormatter('en', NumberFormatter::SPELLOUT);
+        foreach ($entityOrEntities as $id => $entity) {
+            $key = is_numeric($id) ? $numberFormatter->format($id) : $id;
+            $result = $this->softRemove(entityOrEntities: $entity, removeOptions: $removeOptions);
+            $identifiers->$key = $result;
+            $generatedMaps->$key = $result->generatedMaps;
+        }
+
+        return new UpdateResult(raw: $result, affected: $this->query->rowCount(), identifiers: $identifiers, generatedMaps: $generatedMaps);
+    }
+
+    /**
+     * Gets the primary key column name for a given entity class.
+     *
+     * @param object $entity
+     * @param string $primaryKeyField
+     * @return string
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     */
+    private function getPrimaryKeyColumnName(object $entity, string $primaryKeyField = 'id'): string
+    {
+        return $this->getPrimaryKeyMetadata($entity, $primaryKeyField)['column'];
+    }
+
+    /**
+     * @param int|object|array $conditions
+     *
+     * @return string Returns an SQL condition string
+     */
+
+    /**
+     * Deletes entities by a given condition(s).
+     *
+     * Unlike the save method, it executes a primitive operation without cascades,
+     * relations and other operations included.
+     * Executes a fast and efficient `DELETE` query.
+     * Does not check if the entity exists in the database.
+     * Condition(s) cannot be empty.
+     *
+     * @param string $entityClass
+     * @param int|array|object $conditions The deletion conditions.
+     *
+     * @return DeleteResult Returns the removed entities.
+     * @throws ClassNotFoundException
+     * @throws EmptyCriteriaException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function delete(string $entityClass, int|array|object $conditions): DeleteResult
+    {
+        $this->validateConditions(conditions: $conditions, methodName: __METHOD__);
+
+        $entity = $this->create(entityClass: $entityClass);
+
+        $statement = $this->query
+            ->deleteFrom(tableName: $this->entityInspector->getTableName(entity: $entity));
+        $statement = $statement->where(condition: $this->buildConditionClause($conditions, $this->query, $entity));
+
+        if ($this->isDebug) {
+            $statement->debug();
+        }
+
+        $deletionResult = $statement->execute();
+
+        if ($deletionResult->isError()) {
+            throw new GeneralSQLQueryException($this->query, $deletionResult->getErrors()[0]);
+        }
+
+        return new DeleteResult(raw: $deletionResult->value(), affected: $this->query->rowCount(), errors: $deletionResult->getErrors());
+    }
+
+    /**
+     * Restores entities by a given condition(s).
+     * Unlike save method executes a primitive operation without cascades, relations and other operations included.
+     * Executes fast and efficient DELETE query.
+     * Does not check if entity exist in the database.
+     * Condition(s) cannot be empty.
+     * @param string $entityClass
+     * @param int|array|object $conditions
+     * @return UpdateResult
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function restore(string $entityClass, int|array|object $conditions): UpdateResult
+    {
+        $entity = $this->create(entityClass: $entityClass);
+
+        $statement = $this->query
+            ->update(tableName: $this->entityInspector->getTableName(entity: $entity))
+            ->set([Filter::getDeleteDateColumnName(entity: $entity) => NULL]);
+        $statement = $statement->where(condition: $this->buildConditionClause($conditions, $this->query, $entity));
+
+        if ($this->isDebug) {
+            $statement->debug();
+        }
+
+        $restoreResult = $statement->execute();
+
+        if ($restoreResult->isError()) {
+            throw new GeneralSQLQueryException($this->query, $restoreResult->getErrors()[0]);
+        }
+
+        $generatedMaps = new stdClass();
+
+        foreach ($restoreResult->value() as $key => $value) {
+            $generatedMaps->$key = $value;
+        }
+
+        return new UpdateResult(raw: $restoreResult->value(), affected: $this->query->rowCount(), identifiers: $entity, generatedMaps: $generatedMaps, errors: $restoreResult->getErrors());
+    }
+
+    /**
+     * Finds entities that match given find options.
+     * Also counts all entities that match given conditions,
+     * but ignores pagination settings (from and take options).
+     *
+     * @param string $entityClass
+     * @param FindManyOptions|null $options
+     * @return FindResult
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    #[ArrayShape(['entities' => "array|null", 'count' => "int"])]
+    public function findAndCount(string $entityClass, ?FindManyOptions $options = null): FindResult
+    {
+        $result = $this->find(entityClass: $entityClass, findOptions: $options);
+
+        return new FindResult($result->getRaw(), $result->getTotal(), $result->getErrors(), $result->getTotalAffectedRows());
+    }
+
+    /**
+     * Finds entities that match given WHERE conditions.
+     * Also counts all entities that match given conditions,
+     * but ignores pagination settings (from and take options).
+     * @param string $entityClass
+     * @param FindWhereOptions|array $where
+     * @return FindResult
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    public function findAndCountBy(string $entityClass, FindWhereOptions|array $where): FindResult
+    {
+        $result = $this->findBy(entityClass: $entityClass, where: $where);
+
+        return new FindResult($result->getRaw(), $result->getTotal(), $result->getErrors(), $result->getTotalAffectedRows());
+    }
+
+    /**
+     * Sets the list of custom converters to use for type conversion.
+     *
+     * @param array $converters
+     * @return void
+     */
+    public function useConverters(array $converters): void
+    {
+        $this->customConverters = $converters;
+    }
+
+    /**
+     * @param string $entityClassName
+     * @param object $object
+     * @param IFactory|null $factory
+     * @return object
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     * @throws ReflectionException
+     * @throws ContainerException
+     */
+    public function getEntityFromObject(string $entityClassName, object $object, ?IFactory $factory = null): object
+    {
+        self::validateEntityName($entityClassName);
+
+        $provider = new EntityProvider($this, $factory);
+        $entity = $provider->get($entityClassName);
+
+        foreach ($object as $prop => $value) {
+            if (property_exists($entity, $prop)) {
+                $sourceReflection = new ReflectionProperty($object, $prop);
+                $targetReflection = new ReflectionProperty($entity, $prop);
+                $sourceReflectionType = $sourceReflection->getType();
+                $targetReflectionType = $targetReflection->getType();
+
+                if ($sourceReflectionType instanceof ReflectionUnionType) {
+                    $this->logger->warning("Source instance of ReflectionUnionType");
+                    $sourceType = strval($sourceReflectionType);
+                    if ($sourceReflectionType->allowsNull()) {
+                        $sourceType = "null|$sourceType";
+                    }
+                } else {
+                    $sourceType = $sourceReflectionType?->getName() ?? match (gettype($object->$prop)) {
+                        'integer' => 'int',
+                        'double' => 'float',
+                        'boolean' => 'bool',
+                        'NULL' => null,
+                        'object' => get_class($object->$prop),
+                        default => gettype($object->$prop)
+                    };
+                }
+
+                if ($targetReflectionType instanceof ReflectionUnionType) {
+                    $this->logger->warning("Target instance of ReflectionUnionType");
+                    $targetType = strval($targetReflectionType);
+                    if ($targetReflectionType->allowsNull()) {
+                        $targetType = "null|$targetType";
+                    }
+                } else {
+                    $targetType = $targetReflectionType?->getName() ?? match (gettype($entity->$prop)) {
+                        'integer' => 'int',
+                        'double' => 'float',
+                        'boolean' => 'bool',
+                        'NULL' => null,
+                        'object' => get_class($object->$prop),
+                        default => gettype($entity->$prop)
+                    };
+                }
+
+                if (is_null($sourceType) || is_null($targetType)) {
+                    continue;
+                }
+
+                if ($sourceType !== $targetType && !str_contains($targetType, $sourceType)) {
+                    $value = $this->castValue(value: $value, sourceType: $sourceType, targetType: $targetType);
+                }
+
+                $entity->$prop = $value;
+            }
+        }
+
+        return $entity;
+    }
+
+    /**
+     * @param string|null $name
+     * @return array
+     */
+    public function getStore(?string $name = null): array
+    {
+        return $this->entities;
+    }
+
+    /**
+     * @param string $key
+     * @return object|null
+     */
+    public function getStoreEntry(string $key): ?object
+    {
+        return $this->hasStoreEntry($key) ? $this->getStoreEntry($key) : null;
+    }
+
+    /**
+     * @param string $key
+     * @return bool
+     */
+    public function hasStoreEntry(string $key): bool
+    {
+        return isset($this->entities[$key]);
+    }
+
+    /**
+     * @param string $key
+     * @param object $value
+     * @return int
+     */
+    public function addStoreEntry(string $key, object $value): int
+    {
+        return count($this->entities);
+    }
+
+    /**
+     * @param string $key
+     * @param object $value
+     * @return int
+     */
+    public function removeStoreEntry(string $key, object $value): int
+    {
+        return count($this->entities);
+    }
+
+    /**
+     * Generates an alias for a given table name.
+     *
+     * @param string $tableName The table name to generate an alias for.
+     * @param array $knownAliases The list of known aliases.
+     * @return string Returns the generated alias.
+     */
+    private function generateAlias(string $tableName, array &$knownAliases): string
+    {
+        $tableNameLetters = str_split($tableName);
+        $alias = '';
+
+        foreach ($tableNameLetters as $letter) {
+            $alias .= $letter;
+            if (!in_array($alias, $knownAliases)) {
+                $knownAliases[] = $alias;
+                return $alias;
+            }
+        }
+
+        return $alias;
+    }
 }

--- a/src/Management/Options/UpsertOptions.php
+++ b/src/Management/Options/UpsertOptions.php
@@ -37,6 +37,7 @@ readonly class UpsertOptions
             conflictPaths: $options['conflictPaths'] ?? [],
             skipUpdateIfNoValuesChanged: $options['skipUpdateIfNoValuesChanged'] ?? true,
             upsertType: $options['upsertType'] ?? UpsertType::UPSERT,
+            readonlyColumns: $options['readonlyColumns'] ?? null,
         );
     }
 }

--- a/src/Queries/Sql/SQLAssignmentList.php
+++ b/src/Queries/Sql/SQLAssignmentList.php
@@ -31,6 +31,10 @@ class SQLAssignmentList
     {
       $identifier = $this->query->quoteIdentifier((string)$key);
 
+      if ($value instanceof SQLExpression) {
+        $queryString .= $identifier . "={$value}{$separator}";
+        continue;
+      }
       if (in_array($key, $this->query->passwordHashFields(), true))
       {
         $value = password_hash($value, $this->query->passwordHashAlgorithm());

--- a/src/Queries/Sql/SQLExpression.php
+++ b/src/Queries/Sql/SQLExpression.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Assegai\Orm\Queries\Sql;
+
+/**
+ * Represents a raw SQL expression that should be rendered directly by a query builder.
+ */
+final readonly class SQLExpression
+{
+    public function __construct(private string $expression)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->expression;
+    }
+}

--- a/src/Queries/Sql/SQLInsertIntoMultipleStatement.php
+++ b/src/Queries/Sql/SQLInsertIntoMultipleStatement.php
@@ -134,6 +134,10 @@ class SQLInsertIntoMultipleStatement
    */
   protected function buildValueExpression(int|string $index, mixed $value): string
   {
+    if ($value instanceof SQLExpression) {
+      return (string)$value;
+    }
+
     if (in_array($index, $this->hashableIndexes, true)) {
       $value = password_hash($value, $this->query->passwordHashAlgorithm());
     }

--- a/src/Queries/Sql/SQLInsertIntoStatement.php
+++ b/src/Queries/Sql/SQLInsertIntoStatement.php
@@ -123,6 +123,10 @@ class SQLInsertIntoStatement
    */
   protected function buildValueExpression(int|string $index, mixed $value): string
   {
+    if ($value instanceof SQLExpression) {
+      return (string)$value;
+    }
+
     if (in_array($index, $this->hashableIndexes, true)) {
       $value = password_hash($value, $this->query->passwordHashAlgorithm());
     }

--- a/tests/PHPUnit/Unit/EntityManagerOnUpdateTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerOnUpdateTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\PHPUnit\Unit;
+
+use Assegai\Orm\Attributes\Columns\Column;
+use Assegai\Orm\Attributes\Columns\PrimaryGeneratedColumn;
+use Assegai\Orm\Attributes\Entity;
+use Assegai\Orm\DataSource\DataSource;
+use Assegai\Orm\DataSource\DataSourceOptions;
+use Assegai\Orm\Enumerations\DataSourceType;
+use Assegai\Orm\Enumerations\SQLDialect;
+use Assegai\Orm\Management\EntityManager;
+use Assegai\Orm\Management\Options\UpdateOptions;
+use Assegai\Orm\Queries\Sql\ColumnType;
+use Assegai\Orm\Queries\Sql\SQLQuery;
+use Assegai\Orm\Traits\ChangeRecorderTrait;
+use DateTime;
+use DateTimeZone;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class EntityManagerOnUpdateTest extends TestCase
+{
+    private const INITIAL_UPDATED_AT = '2000-01-01 00:00:00';
+
+    private ?DataSource $dataSource = null;
+    private string $databasePath;
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/assegai-on-update-' . uniqid('', true) . '.sqlite';
+        $this->cleanupSqliteFiles($this->databasePath);
+        $this->dataSource = new DataSource(new DataSourceOptions(
+            entities: [OnUpdateManagedEntity::class],
+            name: $this->databasePath,
+            type: DataSourceType::SQLITE,
+        ));
+
+        $this->dataSource->getClient()->exec(
+            'CREATE TABLE on_update_entities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                deleted_at TEXT NULL
+            )'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dataSource?->disconnect();
+        $this->cleanupSqliteFiles($this->databasePath);
+    }
+
+    public function testUpdateAppliesOnUpdateColumnWhenCallerOmitsIt(): void
+    {
+        $this->insertFixture('Ada', 'Before update');
+
+        $result = $this->createManager()->update(
+            OnUpdateManagedEntity::class,
+            ['description' => 'After update'],
+            ['name' => 'Ada'],
+        );
+
+        $row = $this->fetchRow('Ada');
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('"updated_at"=CURRENT_TIMESTAMP', $result->getRaw());
+        self::assertSame('After update', $row['description']);
+        self::assertNotSame(self::INITIAL_UPDATED_AT, $row['updated_at']);
+    }
+
+    public function testUpdateKeepsExplicitOnUpdateColumnAssignment(): void
+    {
+        $this->insertFixture('Grace', 'Before explicit update');
+
+        $result = $this->createManager()->update(
+            OnUpdateManagedEntity::class,
+            [
+                'description' => 'After explicit update',
+                'updatedAt' => new DateTime('2026-01-02 03:04:05', new DateTimeZone('UTC')),
+            ],
+            ['name' => 'Grace'],
+            new UpdateOptions(readonlyColumns: ['id', 'createdAt', 'deletedAt']),
+        );
+
+        $row = $this->fetchRow('Grace');
+
+        self::assertTrue($result->isOk());
+        self::assertStringNotContainsString('"updated_at"=CURRENT_TIMESTAMP', $result->getRaw());
+        self::assertSame('After explicit update', $row['description']);
+        self::assertSame('2026-01-02 03:04:05', $row['updated_at']);
+    }
+
+    public function testSqliteUpsertAppliesOnUpdateColumnOnConflict(): void
+    {
+        $this->insertFixture('Linus', 'Before upsert');
+
+        $entity = new OnUpdateManagedEntity();
+        $entity->name = 'Linus';
+        $entity->description = 'After upsert';
+
+        $result = $this->createManager()->upsert(OnUpdateManagedEntity::class, $entity, ['name']);
+        $row = $this->fetchRow('Linus');
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('ON CONFLICT ("name") DO UPDATE SET', $result->getRaw());
+        self::assertStringContainsString('"updated_at"=CURRENT_TIMESTAMP', $result->getRaw());
+        self::assertSame('After upsert', $row['description']);
+        self::assertNotSame(self::INITIAL_UPDATED_AT, $row['updated_at']);
+    }
+
+    private function createManager(): EntityManager
+    {
+        return new EntityManager(
+            connection: $this->dataSource,
+            query: new SQLQuery(
+                db: $this->dataSource->getClient(),
+                fetchClass: OnUpdateManagedEntity::class,
+                fetchMode: PDO::FETCH_CLASS,
+                dialect: SQLDialect::SQLITE,
+            ),
+        );
+    }
+
+    private function insertFixture(string $name, string $description): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO on_update_entities (name, description, created_at, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP, ?)'
+        );
+        $statement->execute([$name, $description, self::INITIAL_UPDATED_AT]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchRow(string $name): array
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT name, description, updated_at FROM on_update_entities WHERE name = ?'
+        );
+        $statement->execute([$name]);
+
+        return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+
+    private function cleanupSqliteFiles(string $path): void
+    {
+        foreach ([$path, $path . '-wal', $path . '-shm'] as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+}
+
+#[Entity(table: 'on_update_entities')]
+class OnUpdateManagedEntity
+{
+    use ChangeRecorderTrait;
+
+    #[PrimaryGeneratedColumn]
+    public ?int $id = null;
+
+    #[Column(type: ColumnType::VARCHAR, nullable: false)]
+    public string $name = '';
+
+    #[Column(type: ColumnType::TEXT, nullable: false)]
+    public string $description = '';
+}

--- a/tests/PHPUnit/Unit/EntityManagerOnUpdateTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerOnUpdateTest.php
@@ -4,6 +4,7 @@ namespace Tests\PHPUnit\Unit;
 
 use Assegai\Orm\Attributes\Columns\Column;
 use Assegai\Orm\Attributes\Columns\PrimaryGeneratedColumn;
+use Assegai\Orm\Attributes\Columns\UpdateDateColumn;
 use Assegai\Orm\Attributes\Entity;
 use Assegai\Orm\DataSource\DataSource;
 use Assegai\Orm\DataSource\DataSourceOptions;
@@ -13,7 +14,6 @@ use Assegai\Orm\Management\EntityManager;
 use Assegai\Orm\Management\Options\UpdateOptions;
 use Assegai\Orm\Queries\Sql\ColumnType;
 use Assegai\Orm\Queries\Sql\SQLQuery;
-use Assegai\Orm\Traits\ChangeRecorderTrait;
 use DateTime;
 use DateTimeZone;
 use PDO;
@@ -159,8 +159,6 @@ final class EntityManagerOnUpdateTest extends TestCase
 #[Entity(table: 'on_update_entities')]
 class OnUpdateManagedEntity
 {
-    use ChangeRecorderTrait;
-
     #[PrimaryGeneratedColumn]
     public ?int $id = null;
 
@@ -169,4 +167,7 @@ class OnUpdateManagedEntity
 
     #[Column(type: ColumnType::TEXT, nullable: false)]
     public string $description = '';
+
+    #[UpdateDateColumn]
+    public ?DateTime $updatedAt = null;
 }

--- a/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
@@ -25,9 +25,24 @@ final class EntityManagerSqlErrorTest extends TestCase
     {
         $syntheticError = new ORMException('General SQL error.');
         $driverError = new PDOException('Driver failed.');
-        $exception = self::createGeneralSqlQueryException(new SQLQueryResult([], [$syntheticError, $driverError]));
 
-        self::assertSame($driverError, $exception->getPrevious());
+        self::withEnvironment('development', function () use ($syntheticError, $driverError): void {
+            $exception = self::createGeneralSqlQueryException(new SQLQueryResult([], [$syntheticError, $driverError]));
+
+            self::assertSame($driverError, $exception->getPrevious());
+        });
+    }
+
+    public function testProductionSqlErrorsPreserveSanitizedOrmExceptionInsteadOfDriverException(): void
+    {
+        $syntheticError = new ORMException('General SQL error - Internal server error.');
+        $driverError = new PDOException('Driver failed with private connection details.');
+
+        self::withEnvironment('production', function () use ($syntheticError, $driverError): void {
+            $exception = self::createGeneralSqlQueryException(new SQLQueryResult([], [$syntheticError, $driverError]));
+
+            self::assertSame($syntheticError, $exception->getPrevious());
+        });
     }
 
     public function testNonThrowableSqlErrorShapesAreNotPassedAsPreviousExceptions(): void
@@ -52,5 +67,32 @@ final class EntityManagerSqlErrorTest extends TestCase
         self::assertInstanceOf(GeneralSQLQueryException::class, $exception);
 
         return $exception;
+    }
+
+    private static function withEnvironment(string $environment, callable $callback): void
+    {
+        $hadEnv = array_key_exists('ENV', $_ENV);
+        $previousEnv = $_ENV['ENV'] ?? null;
+        $hadServerEnv = array_key_exists('ENV', $_SERVER);
+        $previousServerEnv = $_SERVER['ENV'] ?? null;
+
+        $_ENV['ENV'] = $environment;
+        unset($_SERVER['ENV']);
+
+        try {
+            $callback();
+        } finally {
+            if ($hadEnv) {
+                $_ENV['ENV'] = $previousEnv;
+            } else {
+                unset($_ENV['ENV']);
+            }
+
+            if ($hadServerEnv) {
+                $_SERVER['ENV'] = $previousServerEnv;
+            } else {
+                unset($_SERVER['ENV']);
+            }
+        }
     }
 }

--- a/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
@@ -45,6 +45,46 @@ final class EntityManagerSqlErrorTest extends TestCase
         });
     }
 
+    public function testDevelopmentPublicResultErrorsKeepDriverExceptions(): void
+    {
+        $syntheticError = new ORMException('General SQL error.');
+        $driverError = new PDOException('Driver failed.');
+
+        self::withEnvironment('development', function () use ($syntheticError, $driverError): void {
+            $errors = self::publicResultErrors(new SQLQueryResult([], [$syntheticError, $driverError]));
+
+            self::assertSame([$syntheticError, $driverError], $errors);
+        });
+    }
+
+    public function testProductionPublicResultErrorsRemoveDriverExceptions(): void
+    {
+        $syntheticError = new ORMException('General SQL error - Internal server error.');
+        $driverError = new PDOException('Driver failed with private connection details.');
+
+        self::withEnvironment('production', function () use ($syntheticError, $driverError): void {
+            $errors = self::publicResultErrors(new SQLQueryResult([], [$syntheticError, $driverError]));
+
+            self::assertSame([$syntheticError], $errors);
+            self::assertNotContains($driverError, $errors);
+        });
+    }
+
+    public function testProductionInsertStyleErrorsDoNotExposeDriverExceptions(): void
+    {
+        $syntheticError = new ORMException('General SQL error - Internal server error.');
+        $driverError = new PDOException('Driver failed with private connection details.');
+
+        self::withEnvironment('production', function () use ($syntheticError, $driverError): void {
+            $result = new SQLQueryResult([], [$syntheticError, $driverError]);
+            $generalSqlError = self::createGeneralSqlQueryException($result);
+            $errors = [$generalSqlError, ...self::publicResultErrors($result)];
+
+            self::assertSame([$generalSqlError, $syntheticError], $errors);
+            self::assertNotContains($driverError, $errors);
+        });
+    }
+
     public function testNonThrowableSqlErrorShapesAreNotPassedAsPreviousExceptions(): void
     {
         $exception = self::createGeneralSqlQueryException(new SQLQueryResult([], [
@@ -67,6 +107,18 @@ final class EntityManagerSqlErrorTest extends TestCase
         self::assertInstanceOf(GeneralSQLQueryException::class, $exception);
 
         return $exception;
+    }
+
+    private static function publicResultErrors(SQLQueryResult $result): array
+    {
+        $reflection = new ReflectionClass(EntityManager::class);
+        $entityManager = $reflection->newInstanceWithoutConstructor();
+        $method = $reflection->getMethod('publicResultErrors');
+        $errors = $method->invoke($entityManager, $result);
+
+        self::assertIsArray($errors);
+
+        return $errors;
     }
 
     private static function withEnvironment(string $environment, callable $callback): void

--- a/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\PHPUnit\Unit;
+
+use Assegai\Orm\Exceptions\GeneralSQLQueryException;
+use Assegai\Orm\Management\EntityManager;
+use Assegai\Orm\Queries\Sql\SQLQueryResult;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+
+final class EntityManagerSqlErrorTest extends TestCase
+{
+    public function testThrowableSqlErrorsArePreservedAsPreviousExceptions(): void
+    {
+        $previous = new RuntimeException('Driver failed.');
+        $exception = self::createGeneralSqlQueryException(new SQLQueryResult([], [$previous]));
+
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testNonThrowableSqlErrorShapesAreNotPassedAsPreviousExceptions(): void
+    {
+        $exception = self::createGeneralSqlQueryException(new SQLQueryResult([], [
+            [
+                'code' => 'HY000',
+                'info' => ['driver reported execute=false'],
+            ],
+        ]));
+
+        self::assertNull($exception->getPrevious());
+    }
+
+    private static function createGeneralSqlQueryException(SQLQueryResult $result): GeneralSQLQueryException
+    {
+        $reflection = new ReflectionClass(EntityManager::class);
+        $entityManager = $reflection->newInstanceWithoutConstructor();
+        $method = $reflection->getMethod('newGeneralSqlQueryException');
+        $exception = $method->invoke($entityManager, null, $result);
+
+        self::assertInstanceOf(GeneralSQLQueryException::class, $exception);
+
+        return $exception;
+    }
+}

--- a/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
@@ -3,8 +3,10 @@
 namespace Tests\PHPUnit\Unit;
 
 use Assegai\Orm\Exceptions\GeneralSQLQueryException;
+use Assegai\Orm\Exceptions\ORMException;
 use Assegai\Orm\Management\EntityManager;
 use Assegai\Orm\Queries\Sql\SQLQueryResult;
+use PDOException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
@@ -17,6 +19,15 @@ final class EntityManagerSqlErrorTest extends TestCase
         $exception = self::createGeneralSqlQueryException(new SQLQueryResult([], [$previous]));
 
         self::assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testDriverSqlExceptionsArePreferredOverSyntheticOrmErrors(): void
+    {
+        $syntheticError = new ORMException('General SQL error.');
+        $driverError = new PDOException('Driver failed.');
+        $exception = self::createGeneralSqlQueryException(new SQLQueryResult([], [$syntheticError, $driverError]));
+
+        self::assertSame($driverError, $exception->getPrevious());
     }
 
     public function testNonThrowableSqlErrorShapesAreNotPassedAsPreviousExceptions(): void

--- a/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerSqlErrorTest.php
@@ -61,12 +61,17 @@ final class EntityManagerSqlErrorTest extends TestCase
     {
         $syntheticError = new ORMException('General SQL error - Internal server error.');
         $driverError = new PDOException('Driver failed with private connection details.');
+        $driverPayload = [
+            'code' => 'HY000',
+            'info' => ['driver reported execute=false'],
+        ];
 
-        self::withEnvironment('production', function () use ($syntheticError, $driverError): void {
-            $errors = self::publicResultErrors(new SQLQueryResult([], [$syntheticError, $driverError]));
+        self::withEnvironment('production', function () use ($syntheticError, $driverError, $driverPayload): void {
+            $errors = self::publicResultErrors(new SQLQueryResult([], [$syntheticError, $driverError, $driverPayload]));
 
             self::assertSame([$syntheticError], $errors);
             self::assertNotContains($driverError, $errors);
+            self::assertNotContains($driverPayload, $errors);
         });
     }
 
@@ -74,14 +79,30 @@ final class EntityManagerSqlErrorTest extends TestCase
     {
         $syntheticError = new ORMException('General SQL error - Internal server error.');
         $driverError = new PDOException('Driver failed with private connection details.');
+        $driverPayload = [
+            'code' => 'HY000',
+            'info' => ['driver reported execute=false'],
+        ];
+        $connectionErrorInfo = ['HY000', 1, 'private driver detail'];
 
-        self::withEnvironment('production', function () use ($syntheticError, $driverError): void {
-            $result = new SQLQueryResult([], [$syntheticError, $driverError]);
+        self::withEnvironment('production', function () use ($syntheticError, $driverError, $driverPayload, $connectionErrorInfo): void {
+            $result = new SQLQueryResult([], [$syntheticError, $driverError, $driverPayload]);
             $generalSqlError = self::createGeneralSqlQueryException($result);
-            $errors = [$generalSqlError, ...self::publicResultErrors($result)];
+            $errors = [...self::publicDriverErrorPayload($connectionErrorInfo), $generalSqlError, ...self::publicResultErrors($result)];
 
             self::assertSame([$generalSqlError, $syntheticError], $errors);
             self::assertNotContains($driverError, $errors);
+            self::assertNotContains($driverPayload, $errors);
+            self::assertNotContains($connectionErrorInfo, $errors);
+        });
+    }
+
+    public function testDevelopmentPublicDriverErrorPayloadKeepsConnectionDiagnostics(): void
+    {
+        $connectionErrorInfo = ['HY000', 1, 'driver detail'];
+
+        self::withEnvironment('development', function () use ($connectionErrorInfo): void {
+            self::assertSame([$connectionErrorInfo], self::publicDriverErrorPayload($connectionErrorInfo));
         });
     }
 
@@ -115,6 +136,18 @@ final class EntityManagerSqlErrorTest extends TestCase
         $entityManager = $reflection->newInstanceWithoutConstructor();
         $method = $reflection->getMethod('publicResultErrors');
         $errors = $method->invoke($entityManager, $result);
+
+        self::assertIsArray($errors);
+
+        return $errors;
+    }
+
+    private static function publicDriverErrorPayload(mixed $error): array
+    {
+        $reflection = new ReflectionClass(EntityManager::class);
+        $entityManager = $reflection->newInstanceWithoutConstructor();
+        $method = $reflection->getMethod('publicDriverErrorPayload');
+        $errors = $method->invoke($entityManager, $error);
 
         self::assertIsArray($errors);
 

--- a/tests/PHPUnit/Unit/UpsertOptionsTest.php
+++ b/tests/PHPUnit/Unit/UpsertOptionsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\PHPUnit\Unit;
+
+use Assegai\Orm\Management\Options\UpsertOptions;
+use PHPUnit\Framework\TestCase;
+
+final class UpsertOptionsTest extends TestCase
+{
+    public function testFromArrayPreservesReadonlyColumns(): void
+    {
+        $options = UpsertOptions::fromArray([
+            'conflictPaths' => ['name'],
+            'readonlyColumns' => ['id', 'createdAt', 'deletedAt'],
+        ]);
+
+        self::assertSame(['name'], $options->conflictPaths);
+        self::assertSame(['id', 'createdAt', 'deletedAt'], $options->readonlyColumns);
+    }
+}


### PR DESCRIPTION
## Milestone
0.9.2

## Type
refactor

## Why this belongs in this milestone
Improves error reporting

## What changed
- Improved error throwing so previous errors don't get consumed

## What did not change
- N/A

## Verification
- `composer test`
- `composer test:sqlite`
- `composer analyze`

## User impact
- N/A
