### PR TITLE
Add release notes for version 0.9.2 with timestamp and error reporting updates

### DIFF
--- a/docs/release-notes/0.9.2.md
+++ b/docs/release-notes/0.9.2.md
@@ -1,0 +1,53 @@
+# Assegai ORM 0.9.2 Release Notes
+
+Assegai ORM 0.9.2 improves update behavior for managed timestamp columns and tightens SQL error reporting across EntityManager result paths.
+
+## Highlights
+
+- `Column(onUpdate: ...)` is now applied by the ORM during `update()` and `upsert()` calls when the caller does not explicitly provide that column.
+- SQLite projects now get a framework-level fallback for managed update timestamps, including `UpdateDateColumn`, even though SQLite does not support `ON UPDATE` column clauses at the database level.
+- SQL failures now preserve more useful exception context for development and diagnostics while keeping production-facing result errors sanitized.
+
+## What Changed
+
+### Managed `onUpdate` Columns
+
+The ORM now detects public entity columns with an `onUpdate` expression and adds the corresponding assignment to update statements when needed.
+
+This applies to:
+
+- direct `EntityManager::update()` calls
+- repository update calls that use the EntityManager path
+- SQLite upserts
+- PostgreSQL upserts
+- MySQL and MariaDB upserts
+
+Explicit caller-provided values still win. If an update payload includes the managed column, the ORM will not replace that value with the automatic `onUpdate` expression.
+
+### SQL Expression Handling
+
+The SQL builders now support ORM-managed raw SQL expressions through a dedicated expression value. This allows generated values such as `CURRENT_TIMESTAMP` to be rendered as SQL expressions where appropriate while ordinary user-provided strings remain parameterized.
+
+### Error Reporting
+
+`GeneralSQLQueryException` now preserves a safe previous exception when SQL execution fails, so debugging and logging can retain the useful exception chain.
+
+Production result payloads now filter driver-level diagnostics consistently. Public result errors no longer expose raw `PDOException` instances, driver `errorInfo()` arrays, or execute-false driver payloads in production.
+
+Development behavior remains more diagnostic, so local and test environments can still inspect detailed driver error information.
+
+### Upsert Options
+
+`UpsertOptions::fromArray()` now preserves `readonlyColumns`, matching the behavior of constructing `UpsertOptions` directly.
+
+## Upgrade Notes
+
+No application code changes are required.
+
+Projects with `UpdateDateColumn` or `Column(onUpdate: ...)` may now see those columns updated automatically during ORM update and upsert operations. If your application was manually setting those values, your explicit values continue to take precedence.
+
+## Verification
+
+- `composer test`
+- Focused EntityManager SQL error tests
+- Focused EntityManager `onUpdate` update and upsert tests


### PR DESCRIPTION
This pull request adds release notes for Assegai ORM version 0.9.2, summarizing key improvements to update behavior for managed timestamp columns and enhanced SQL error reporting. The notes detail how the ORM now handles `onUpdate` columns, improves SQL expression handling, and tightens error reporting, especially for SQLite projects and upsert operations.

Key changes documented in the release notes:

Managed update columns and timestamps:
* The ORM now applies `Column(onUpdate: ...)` automatically during `update()` and `upsert()` calls when the column is not explicitly set by the caller. This includes a framework-level fallback for managed update timestamps in SQLite, which does not natively support `ON UPDATE` clauses.

SQL expression and error handling:
* SQL builders now support ORM-managed raw SQL expressions, allowing values like `CURRENT_TIMESTAMP` to be rendered as SQL expressions in generated queries.
* Improved error reporting: `GeneralSQLQueryException` now preserves the previous exception for better debugging, and production result errors are sanitized to avoid exposing raw driver errors or diagnostic information.

Upsert options:
* `UpsertOptions::fromArray()` now preserves `readonlyColumns`, ensuring consistency with direct construction.

Upgrade and verification notes:
* No application code changes are required for this upgrade, and existing explicit value assignments will continue to take precedence