### PR TITLE
Enhance OneToMany relation handling and dynamic reference resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Relations follow the same ownership ideas you would expect from TypeORM:
 - `ManyToOne` and `OneToMany`: the foreign key lives on the `ManyToOne` side
 - `ManyToMany`: the owner side has `#[JoinTable(...)]`
 
-Load relations explicitly in `find()` and `findOne()` calls, and prefer writing through the owner side of the relation.
+Load relations explicitly in `find()` and `findOne()` calls, and prefer writing through the owner side of the relation. `OneToMany` collections do not need a reference-column argument; the ORM derives that from the owning `ManyToOne`/`JoinColumn` metadata.
 
 If you want to use SQLite directly through the ORM, create a `DataSource`, ensure the table exists, and then work with
 the repository:

--- a/src/Attributes/Relations/OneToMany.php
+++ b/src/Attributes/Relations/OneToMany.php
@@ -7,52 +7,60 @@ use Assegai\Orm\Relations\RelationOptions;
 use Attribute;
 
 /**
- * A one-to-many relation means "this entity owns a list of those entities".
+ * A one-to-many relation means "this entity has a collection of related entities".
  *
- * Example:
- * `OrganizationEntity` can have many `RestaurantEntity` records.
+ * The foreign key lives on the related entity's ManyToOne side. In most cases the
+ * inverse side is enough here; the referenced column is resolved from JoinColumn
+ * metadata on the owning side.
  *
  * ```php
- * #[OneToMany(RestaurantEntity::class, 'id', 'organization')]
- * public ?array $restaurants = null;
+ * #[OneToMany(type: RestaurantEntity::class, inverseSide: 'organization')]
+ * public array $restaurants = [];
  * ```
- *
- * Read that example like this:
- * - `RestaurantEntity::class`: each item in the list is a restaurant
- * - `'id'`: use the organization's `id` when matching child rows
- * - `'organization'`: each restaurant points back through its `organization` property
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class OneToMany
 {
   /**
+   * @var string|null Legacy override for the local property to match against. New code should omit this.
+   */
+  public readonly ?string $referencedProperty;
+
+  /**
+   * @var string|null Property on the related entity that points back to this entity.
+   */
+  public readonly ?string $inverseSide;
+
+  /**
    * OneToMany constructor.
    *
    * @param class-string $type The entity class for the items in this collection.
-   * Example: if this property stores restaurants, use `RestaurantEntity::class`.
-   * @param string $referencedProperty The property on the current entity that Assegai should use
-   * when looking for children. In plain terms: "which value from this parent object should be matched
-   * against the child rows?" Most of the time this is simply `'id'`.
-   * Example: `#[OneToMany(RestaurantEntity::class, 'id', 'organization')]`
-   * means "take `OrganizationEntity::$id` and use it to find matching restaurants".
-   * @param string $inverseSide The property on the child entity that points back to this parent.
-   * Example: if `RestaurantEntity` has `public ?OrganizationEntity $organization = null;`
-   * then the inverse side is `'organization'`.
+   * @param string|null $referencedProperty Legacy local property override. If $inverseSide is omitted,
+   * this positional argument is treated as the inverse side for TypeORM-style usage.
+   * @param string|null $inverseSide The property on the child entity that points back to this parent.
+   * When omitted, Assegai will infer it if the target entity has exactly one ManyToOne back to this entity.
    * @param string|null $name Optional custom relation name. Most applications can leave this as `null`.
    * @param string|null $alias Optional alias for custom query or mapping scenarios.
-   * Most applications can leave this as `null`.
    * @param RelationOptions|null $options Extra relation behavior such as excluded fields.
    * @throws ClassNotFoundException
    */
   public function __construct(
     public readonly string $type,
-    public readonly string $referencedProperty,
-    public readonly string $inverseSide,
+    ?string $referencedProperty = null,
+    ?string $inverseSide = null,
     public readonly ?string $name = null,
     public readonly ?string $alias = null,
     public ?RelationOptions $options = null
   )
   {
+    if ($inverseSide === null && $referencedProperty !== null) {
+      $this->referencedProperty = null;
+      $this->inverseSide = $referencedProperty;
+    } else {
+      $this->referencedProperty = $referencedProperty;
+      $this->inverseSide = $inverseSide;
+    }
+
     if (is_null($this->options)) {
       $this->options = new RelationOptions();
     }

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -1158,12 +1158,12 @@ class EntityManager implements IEntityStoreOwner
                         propertyName: $relationProperty->name,
                         joinColumn: $relationProperty->joinColumn
                     )
-                    : $this->appendPropertyColumnSelection(
+                    : $this->appendRequiredPropertyColumnSelection(
                         columns: $columns,
                         entity: $entity,
                         propertyName: 'id'
                     ),
-                RelationType::ONE_TO_MANY => $this->appendPropertyColumnSelection(
+                RelationType::ONE_TO_MANY => $this->appendRequiredPropertyColumnSelection(
                     columns: $columns,
                     entity: $entity,
                     propertyName: $this->resolveOneToManyReferencePropertyForRelation($relationProperty)
@@ -1175,7 +1175,7 @@ class EntityManager implements IEntityStoreOwner
                     joinColumn: $relationProperty->joinColumn
                     ?? $this->entityInspector->getJoinColumnAttribute($entity::class, $relationProperty->name)
                 ),
-                RelationType::MANY_TO_MANY => $this->appendPropertyColumnSelection(
+                RelationType::MANY_TO_MANY => $this->appendRequiredPropertyColumnSelection(
                     columns: $columns,
                     entity: $entity,
                     propertyName: 'id'
@@ -1254,6 +1254,44 @@ class EntityManager implements IEntityStoreOwner
     }
 
     /**
+     * Required relation keys may be hidden from the final payload. Select them
+     * under the entity property name unless a public result key is already selected.
+     *
+     * @param array<int|string, string> $columns
+     * @return array<int|string, string>
+     */
+    private function appendRequiredPropertyColumnSelection(array $columns, object $entity, string $propertyName): array
+    {
+        if (!property_exists($entity, $propertyName)) {
+            return $columns;
+        }
+
+        foreach ($this->resolveColumnReadKeys($entity::class, $propertyName) as $readKey) {
+            if (array_key_exists($readKey, $columns)) {
+                return $columns;
+            }
+        }
+
+        $reflectionProperty = new ReflectionProperty($entity, $propertyName);
+
+        foreach ($reflectionProperty->getAttributes() as $attribute) {
+            $attributeInstance = $attribute->newInstance();
+
+            if (!$attributeInstance instanceof Column) {
+                continue;
+            }
+
+            $tableName = $this->entityInspector->getTableName($entity);
+            $columnName = $attributeInstance->name ?: strtosnake($propertyName);
+            $columns[$propertyName] = "$tableName.$columnName";
+
+            return $columns;
+        }
+
+        return $columns;
+    }
+
+    /**
      * @param array<int, object|array> $data
      * @param array<string, RelationPropertyMetadata> $availableRelations
      * @return array<string, array<mixed, mixed>>
@@ -1317,7 +1355,7 @@ class EntityManager implements IEntityStoreOwner
             return [];
         }
 
-        $localIds = $this->extractScalarValues($rows, 'id');
+        $localIds = $this->extractScalarValues($rows, $this->resolveColumnReadKeys($entityClass, 'id'));
         if (empty($localIds)) {
             return [];
         }
@@ -1372,12 +1410,15 @@ class EntityManager implements IEntityStoreOwner
             entityClass: $targetClass,
             conditionColumn: $referenceColumn,
             conditionValues: $foreignKeys,
-            excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions)
+            excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions),
+            additionalColumns: ['__relation_reference_key' => $referenceColumn]
         );
 
         $groupedRows = [];
         foreach ($relatedRows as $relatedRow) {
-            $key = $relatedRow->{$referenceColumn} ?? null;
+            $key = $relatedRow->__relation_reference_key ?? null;
+            unset($relatedRow->__relation_reference_key);
+
             if ($key !== null) {
                 $groupedRows[$key] = $relatedRow;
             }
@@ -1388,20 +1429,37 @@ class EntityManager implements IEntityStoreOwner
 
     /**
      * @param object[] $rows
+     * @param string|list<string> $properties
      * @return list<mixed>
      */
-    private function extractScalarValues(array $rows, string $property): array
+    private function extractScalarValues(array $rows, string|array $properties): array
     {
         $values = [];
+        $properties = is_array($properties) ? $properties : [$properties];
 
         foreach ($rows as $row) {
-            $value = $row->{$property} ?? null;
+            $value = $this->readFirstAvailableProperty($row, $properties);
+
             if ($value !== null && $value !== '') {
                 $values[] = $value;
             }
         }
 
         return array_values(array_unique($values, SORT_REGULAR));
+    }
+
+    /**
+     * @param list<string> $properties
+     */
+    private function readFirstAvailableProperty(object $row, array $properties): mixed
+    {
+        foreach ($properties as $property) {
+            if (property_exists($row, $property)) {
+                return $row->{$property};
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -1538,7 +1596,11 @@ class EntityManager implements IEntityStoreOwner
         $joinColumn = $this->entityInspector->getJoinColumnAttribute($targetClass, $inverseProperty);
         $referenceProperty = $this->resolveOneToManyReferenceProperty($relationProperty, $joinColumn);
 
-        $localKeys = $this->extractScalarValues($rows, $referenceProperty);
+        $referenceKeys = $this->resolveColumnReadKeys(
+            $relationProperty->reflectionProperty->getDeclaringClass()->getName(),
+            $referenceProperty
+        );
+        $localKeys = $this->extractScalarValues($rows, $referenceKeys);
         if (empty($localKeys)) {
             return [];
         }
@@ -1697,11 +1759,41 @@ class EntityManager implements IEntityStoreOwner
             $mappedColumnName = $column->name ?: strtosnake($propertyName);
 
             if ($propertyName === $columnName || $mappedColumnName === $columnName) {
-                return $column->alias ?: $propertyName;
+                return $propertyName;
             }
         }
 
         return null;
+    }
+
+    /**
+     * Returns the row keys that can contain a selected entity property.
+     *
+     * @return list<string>
+     * @throws ReflectionException
+     */
+    private function resolveColumnReadKeys(string $entityClass, string $propertyName): array
+    {
+        $keys = [$propertyName];
+
+        if (!property_exists($entityClass, $propertyName)) {
+            return $keys;
+        }
+
+        $property = new ReflectionProperty($entityClass, $propertyName);
+
+        foreach ($property->getAttributes(Column::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            /** @var Column $column */
+            $column = $attribute->newInstance();
+
+            if ($column->alias !== '') {
+                $keys[] = $column->alias;
+            }
+
+            break;
+        }
+
+        return array_values(array_unique($keys));
     }
 
     /**
@@ -1719,7 +1811,7 @@ class EntityManager implements IEntityStoreOwner
             return [];
         }
 
-        $localIds = $this->extractScalarValues($rows, 'id');
+        $localIds = $this->extractScalarValues($rows, $this->resolveColumnReadKeys($entityClass, 'id'));
         if (empty($localIds)) {
             return [];
         }
@@ -1912,10 +2004,10 @@ class EntityManager implements IEntityStoreOwner
 
         $entity = is_array($entity) ? (object)$entity : $entity;
         $relationValue = match ($relationInfo->getRelationType()) {
-            RelationType::ONE_TO_ONE => $this->resolveOneToOneRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
+            RelationType::ONE_TO_ONE => $this->resolveOneToOneRelationValue($entityClass, $entity, $relationInfo, $loadedRelations[$relationName] ?? []),
             RelationType::ONE_TO_MANY => $this->resolveOneToManyRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
             RelationType::MANY_TO_ONE => $this->resolveManyToOneRelationValue($entity, $relationInfo, $loadedRelations[$relationName] ?? []),
-            RelationType::MANY_TO_MANY => $this->resolveManyToManyRelationValue($entity, $loadedRelations[$relationName] ?? []),
+            RelationType::MANY_TO_MANY => $this->resolveManyToManyRelationValue($entityClass, $entity, $loadedRelations[$relationName] ?? []),
             default => null,
         };
 
@@ -1923,11 +2015,11 @@ class EntityManager implements IEntityStoreOwner
         return $entity;
     }
 
-    private function resolveOneToOneRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): ?object
+    private function resolveOneToOneRelationValue(string $entityClass, object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): ?object
     {
         $relationKey = $relationInfo->joinColumn
             ? ($entity->{$relationInfo->name} ?? null)
-            : ($entity->id ?? null);
+            : $this->readFirstAvailableProperty($entity, $this->resolveColumnReadKeys($entityClass, 'id'));
 
         if ($relationKey === null) {
             return null;
@@ -1943,7 +2035,10 @@ class EntityManager implements IEntityStoreOwner
     private function resolveOneToManyRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): array
     {
         $referenceProperty = $this->resolveOneToManyReferencePropertyForRelation($relationInfo);
-        $referenceValue = $entity->{$referenceProperty} ?? null;
+        $referenceValue = $this->readFirstAvailableProperty(
+            $entity,
+            $this->resolveColumnReadKeys($relationInfo->reflectionProperty->getDeclaringClass()->getName(), $referenceProperty)
+        );
 
         if ($referenceValue === null) {
             return [];
@@ -1963,9 +2058,9 @@ class EntityManager implements IEntityStoreOwner
         return $loadedRelations[$foreignKey] ?? null;
     }
 
-    private function resolveManyToManyRelationValue(object $entity, array $loadedRelations): array
+    private function resolveManyToManyRelationValue(string $entityClass, object $entity, array $loadedRelations): array
     {
-        $referenceValue = $entity->id ?? null;
+        $referenceValue = $this->readFirstAvailableProperty($entity, $this->resolveColumnReadKeys($entityClass, 'id'));
 
         if ($referenceValue === null) {
             return [];

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -1600,11 +1600,13 @@ class EntityManager implements IEntityStoreOwner
     private function resolveOneToManyReferenceProperty(RelationPropertyMetadata $relationProperty, JoinColumn $joinColumn): string
     {
         $entityClass = $relationProperty->reflectionProperty->getDeclaringClass()->getName();
-        $referencedColumnName = $joinColumn->effectiveReferencedColumnName ?? $joinColumn->referencedColumnName ?? 'id';
-        $resolvedProperty = $this->resolveColumnPropertyName($entityClass, $referencedColumnName);
 
-        if ($resolvedProperty !== null) {
-            return $resolvedProperty;
+        if ($joinColumn->referencedColumnName !== null && $joinColumn->referencedColumnName !== '') {
+            $resolvedProperty = $this->resolveColumnPropertyName($entityClass, $joinColumn->referencedColumnName);
+
+            if ($resolvedProperty !== null) {
+                return $resolvedProperty;
+            }
         }
 
         $configuredReference = $relationProperty->relationAttribute->referencedProperty ?? null;
@@ -1615,6 +1617,13 @@ class EntityManager implements IEntityStoreOwner
             $this->isMappedColumnProperty($entityClass, $configuredReference)
         ) {
             return $configuredReference;
+        }
+
+        $referencedColumnName = $joinColumn->effectiveReferencedColumnName ?? 'id';
+        $resolvedProperty = $this->resolveColumnPropertyName($entityClass, $referencedColumnName);
+
+        if ($resolvedProperty !== null) {
+            return $resolvedProperty;
         }
 
         return 'id';

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -13,6 +13,7 @@ use Assegai\Orm\Attributes\Columns\URLColumn;
 use Assegai\Orm\Attributes\Entity;
 use Assegai\Orm\Attributes\Relations\JoinColumn;
 use Assegai\Orm\Attributes\Relations\JoinTable;
+use Assegai\Orm\Attributes\Relations\ManyToOne;
 use Assegai\Orm\Attributes\Relations\OneToOne;
 use Assegai\Orm\DataSource\DataSource;
 use Assegai\Orm\Enumerations\RelationType;
@@ -65,6 +66,7 @@ use NumberFormatter;
 use PDOException;
 use PDOStatement;
 use Psr\Log\LoggerInterface;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionProperty;
@@ -1164,7 +1166,7 @@ class EntityManager implements IEntityStoreOwner
                 RelationType::ONE_TO_MANY => $this->appendPropertyColumnSelection(
                     columns: $columns,
                     entity: $entity,
-                    propertyName: $relationProperty->relationAttribute->referencedProperty ?? 'id'
+                    propertyName: $this->resolveOneToManyReferencePropertyForRelation($relationProperty)
                 ),
                 RelationType::MANY_TO_ONE => $this->appendJoinColumnSelection(
                     columns: $columns,
@@ -1242,7 +1244,7 @@ class EntityManager implements IEntityStoreOwner
             }
 
             $tableName = $this->entityInspector->getTableName($entity);
-            $columnName = $attributeInstance->name ?? $propertyName;
+            $columnName = $attributeInstance->name ?: strtosnake($propertyName);
             $columnAlias = $attributeInstance->alias ?: ($attributeInstance->name ? $propertyName : null);
 
             return $this->appendColumnSelection($columns, $columnAlias, "$tableName.$columnName");
@@ -1405,21 +1407,27 @@ class EntityManager implements IEntityStoreOwner
     /**
      * @param string[] $excludeColumns
      * @param string[] $relations
+     * @param array<string, string> $additionalColumns
      * @return object[]
      * @throws ClassNotFoundException
      * @throws GeneralSQLQueryException
      * @throws ORMException
      * @throws ReflectionException
      */
-    private function fetchEntityRows(string $entityClass, string $conditionColumn, array $conditionValues, array $excludeColumns = ['password'], array $relations = []): array
+    private function fetchEntityRows(string $entityClass, string $conditionColumn, array $conditionValues, array $excludeColumns = ['password'], array $relations = [], array $additionalColumns = []): array
     {
         if (empty($conditionValues)) {
             return [];
         }
 
         $entity = $this->create($entityClass);
-        $columns = $this->entityInspector->getColumns(entity: $entity, exclude: $excludeColumns, relations: $relations);
         $tableName = $this->entityInspector->getTableName($entity);
+        $columns = $this->entityInspector->getColumns(entity: $entity, exclude: $excludeColumns, relations: $relations);
+
+        foreach ($additionalColumns as $alias => $columnName) {
+            $columns[$alias] = str_contains($columnName, '.') ? $columnName : "$tableName.$columnName";
+        }
+
         $query = SQLQuery::forConnection($this->query->getConnection(), dialect: $this->query->getDialect());
         $statement = $query
             ->select()
@@ -1515,31 +1523,39 @@ class EntityManager implements IEntityStoreOwner
     private function loadOneToManyRelation(array $rows, RelationPropertyMetadata $relationProperty, FindOptions $findOptions): array
     {
         $targetClass = $relationProperty->getEntityClass();
-        $referenceProperty = $relationProperty->relationAttribute->referencedProperty ?? 'id';
-        $inverseProperty = $relationProperty->relationAttribute->inverseSide ?? null;
 
-        if (!$targetClass || !$inverseProperty) {
+        if (!$targetClass) {
             return [];
         }
+
+        $inverseProperty = $relationProperty->relationAttribute->inverseSide
+            ?? $this->resolveOneToManyInverseProperty($relationProperty);
+
+        if (!$inverseProperty) {
+            return [];
+        }
+
+        $joinColumn = $this->entityInspector->getJoinColumnAttribute($targetClass, $inverseProperty);
+        $referenceProperty = $this->resolveOneToManyReferenceProperty($relationProperty, $joinColumn);
 
         $localKeys = $this->extractScalarValues($rows, $referenceProperty);
         if (empty($localKeys)) {
             return [];
         }
 
-        $joinColumn = $this->entityInspector->getJoinColumnAttribute($targetClass, $inverseProperty);
+        $joinColumnName = $joinColumn->effectiveColumnName ?? $joinColumn->name ?? 'id';
         $relatedRows = $this->fetchEntityRows(
             entityClass: $targetClass,
-            conditionColumn: $joinColumn->effectiveColumnName ?? $joinColumn->name ?? 'id',
+            conditionColumn: $joinColumnName,
             conditionValues: $localKeys,
             excludeColumns: $this->resolveRelationExcludeColumns($relationProperty, $findOptions),
-            relations: [$inverseProperty]
+            additionalColumns: ['__relation_owner_key' => $joinColumnName]
         );
 
         $groupedRows = [];
         foreach ($relatedRows as $relatedRow) {
-            $ownerKey = $relatedRow->{$inverseProperty} ?? null;
-            unset($relatedRow->{$inverseProperty});
+            $ownerKey = $relatedRow->__relation_owner_key ?? null;
+            unset($relatedRow->__relation_owner_key, $relatedRow->{$inverseProperty});
 
             if ($ownerKey === null) {
                 continue;
@@ -1550,6 +1566,133 @@ class EntityManager implements IEntityStoreOwner
         }
 
         return $groupedRows;
+    }
+
+    /**
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function resolveOneToManyReferencePropertyForRelation(RelationPropertyMetadata $relationProperty): string
+    {
+        $targetClass = $relationProperty->getEntityClass();
+
+        if (!$targetClass) {
+            return $relationProperty->relationAttribute->referencedProperty ?? 'id';
+        }
+
+        $inverseProperty = $relationProperty->relationAttribute->inverseSide
+            ?? $this->resolveOneToManyInverseProperty($relationProperty);
+
+        if (!$inverseProperty) {
+            return $relationProperty->relationAttribute->referencedProperty ?? 'id';
+        }
+
+        $joinColumn = $this->entityInspector->getJoinColumnAttribute($targetClass, $inverseProperty);
+
+        return $this->resolveOneToManyReferenceProperty($relationProperty, $joinColumn);
+    }
+
+    /**
+     * The owning ManyToOne side defines the database reference.
+     *
+     * @throws ReflectionException
+     */
+    private function resolveOneToManyReferenceProperty(RelationPropertyMetadata $relationProperty, JoinColumn $joinColumn): string
+    {
+        $entityClass = $relationProperty->reflectionProperty->getDeclaringClass()->getName();
+        $referencedColumnName = $joinColumn->effectiveReferencedColumnName ?? $joinColumn->referencedColumnName ?? 'id';
+        $resolvedProperty = $this->resolveColumnPropertyName($entityClass, $referencedColumnName);
+
+        if ($resolvedProperty !== null) {
+            return $resolvedProperty;
+        }
+
+        $configuredReference = $relationProperty->relationAttribute->referencedProperty ?? null;
+
+        if (
+            is_string($configuredReference) &&
+            $configuredReference !== '' &&
+            $this->isMappedColumnProperty($entityClass, $configuredReference)
+        ) {
+            return $configuredReference;
+        }
+
+        return 'id';
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    private function resolveOneToManyInverseProperty(RelationPropertyMetadata $relationProperty): ?string
+    {
+        $targetClass = $relationProperty->getEntityClass();
+
+        if (!$targetClass) {
+            return null;
+        }
+
+        $entityClass = $relationProperty->reflectionProperty->getDeclaringClass()->getName();
+        $targetReflection = new ReflectionClass($targetClass);
+        $matches = [];
+
+        foreach ($targetReflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $manyToOneAttributes = $property->getAttributes(ManyToOne::class);
+
+            if (empty($manyToOneAttributes)) {
+                continue;
+            }
+
+            /** @var ManyToOne $attribute */
+            $attribute = $manyToOneAttributes[0]->newInstance();
+
+            if ($attribute->type === $entityClass) {
+                $matches[] = $property->getName();
+            }
+        }
+
+        return count($matches) === 1 ? $matches[0] : null;
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    private function isMappedColumnProperty(string $entityClass, string $propertyName): bool
+    {
+        if (!property_exists($entityClass, $propertyName)) {
+            return false;
+        }
+
+        $property = new ReflectionProperty($entityClass, $propertyName);
+
+        return !empty($property->getAttributes(Column::class, ReflectionAttribute::IS_INSTANCEOF));
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    private function resolveColumnPropertyName(string $entityClass, string $columnName): ?string
+    {
+        $reflectionClass = new ReflectionClass($entityClass);
+
+        foreach ($reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $columnAttributes = $property->getAttributes(Column::class, ReflectionAttribute::IS_INSTANCEOF);
+
+            if (empty($columnAttributes)) {
+                continue;
+            }
+
+            /** @var Column $column */
+            $column = $columnAttributes[0]->newInstance();
+            $propertyName = $property->getName();
+
+            $mappedColumnName = $column->name ?: strtosnake($propertyName);
+
+            if ($propertyName === $columnName || $mappedColumnName === $columnName) {
+                return $column->alias ?: $propertyName;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -1784,9 +1927,13 @@ class EntityManager implements IEntityStoreOwner
         return $loadedRelations[$relationKey] ?? null;
     }
 
+    /**
+     * @throws ORMException
+     * @throws ReflectionException
+     */
     private function resolveOneToManyRelationValue(object $entity, RelationPropertyMetadata $relationInfo, array $loadedRelations): array
     {
-        $referenceProperty = $relationInfo->relationAttribute->referencedProperty ?? 'id';
+        $referenceProperty = $this->resolveOneToManyReferencePropertyForRelation($relationInfo);
         $referenceValue = $entity->{$referenceProperty} ?? null;
 
         if ($referenceValue === null) {

--- a/tests/SQLite/Fixtures/RelationFixtures.php
+++ b/tests/SQLite/Fixtures/RelationFixtures.php
@@ -114,3 +114,33 @@ class RelationIssue
   #[JoinColumn(name: 'publisher_code', referencedColumnName: 'code')]
   public ?RelationPublisher $publisher = null;
 }
+
+#[Entity(table: 'relation_legacy_parents', database: 'relation-test', driver: DataSourceType::SQLITE)]
+class RelationLegacyParent
+{
+  #[PrimaryGeneratedColumn]
+  public ?int $id = null;
+
+  #[Column(type: ColumnType::VARCHAR, nullable: false)]
+  public string $uuid = '';
+
+  #[Column(type: ColumnType::VARCHAR, nullable: false)]
+  public string $name = '';
+
+  #[OneToMany(RelationLegacyChild::class, 'uuid', 'parent')]
+  public array $children = [];
+}
+
+#[Entity(table: 'relation_legacy_children', database: 'relation-test', driver: DataSourceType::SQLITE)]
+class RelationLegacyChild
+{
+  #[PrimaryGeneratedColumn]
+  public ?int $id = null;
+
+  #[Column(type: ColumnType::VARCHAR, nullable: false)]
+  public string $label = '';
+
+  #[ManyToOne(type: RelationLegacyParent::class)]
+  #[JoinColumn(name: 'parent_uuid')]
+  public ?RelationLegacyParent $parent = null;
+}

--- a/tests/SQLite/Fixtures/RelationFixtures.php
+++ b/tests/SQLite/Fixtures/RelationFixtures.php
@@ -91,7 +91,7 @@ class RelationPublisher
   #[PrimaryGeneratedColumn]
   public ?int $id = null;
 
-  #[Column(type: ColumnType::VARCHAR, nullable: false)]
+  #[Column(alias: 'publicCode', type: ColumnType::VARCHAR, nullable: false)]
   public string $code = '';
 
   #[Column(type: ColumnType::VARCHAR, nullable: false)]
@@ -121,7 +121,7 @@ class RelationLegacyParent
   #[PrimaryGeneratedColumn]
   public ?int $id = null;
 
-  #[Column(type: ColumnType::VARCHAR, nullable: false)]
+  #[Column(alias: 'publicUuid', type: ColumnType::VARCHAR, nullable: false)]
   public string $uuid = '';
 
   #[Column(type: ColumnType::VARCHAR, nullable: false)]

--- a/tests/SQLite/Fixtures/RelationFixtures.php
+++ b/tests/SQLite/Fixtures/RelationFixtures.php
@@ -50,7 +50,7 @@ class RelationAuthor
   #[Column(type: ColumnType::VARCHAR, nullable: false)]
   public string $name = '';
 
-  #[OneToMany(type: RelationPost::class, referencedProperty: 'id', inverseSide: 'author')]
+  #[OneToMany(type: RelationPost::class)]
   public array $posts = [];
 }
 
@@ -77,9 +77,40 @@ class RelationPost
   public string $title = '';
 
   #[ManyToOne(type: RelationAuthor::class)]
+  #[JoinColumn(name: 'author_id', referencedColumnName: 'id')]
   public ?RelationAuthor $author = null;
 
   #[ManyToMany(type: RelationTag::class, inverseSide: 'posts')]
   #[JoinTable(name: 'relation_posts_tags', joinColumn: 'post_id', inverseJoinColumn: 'tag_id')]
   public array $tags = [];
+}
+
+#[Entity(table: 'relation_publishers', database: 'relation-test', driver: DataSourceType::SQLITE)]
+class RelationPublisher
+{
+  #[PrimaryGeneratedColumn]
+  public ?int $id = null;
+
+  #[Column(type: ColumnType::VARCHAR, nullable: false)]
+  public string $code = '';
+
+  #[Column(type: ColumnType::VARCHAR, nullable: false)]
+  public string $name = '';
+
+  #[OneToMany(type: RelationIssue::class)]
+  public array $issues = [];
+}
+
+#[Entity(table: 'relation_issues', database: 'relation-test', driver: DataSourceType::SQLITE)]
+class RelationIssue
+{
+  #[PrimaryGeneratedColumn]
+  public ?int $id = null;
+
+  #[Column(type: ColumnType::VARCHAR, nullable: false)]
+  public string $title = '';
+
+  #[ManyToOne(type: RelationPublisher::class)]
+  #[JoinColumn(name: 'publisher_code', referencedColumnName: 'code')]
+  public ?RelationPublisher $publisher = null;
 }

--- a/tests/SQLite/RelationsCest.php
+++ b/tests/SQLite/RelationsCest.php
@@ -10,6 +10,8 @@ use Assegai\Orm\Management\Options\FindOneOptions;
 use Assegai\Orm\Management\Options\InsertOptions;
 use Tests\SQLite\Fixtures\RelationAuthor;
 use Tests\SQLite\Fixtures\RelationIssue;
+use Tests\SQLite\Fixtures\RelationLegacyChild;
+use Tests\SQLite\Fixtures\RelationLegacyParent;
 use Tests\SQLite\Fixtures\RelationPost;
 use Tests\SQLite\Fixtures\RelationPublisher;
 use Tests\SQLite\Fixtures\RelationProfile;
@@ -39,6 +41,8 @@ class RelationsCest
         RelationTag::class,
         RelationPublisher::class,
         RelationIssue::class,
+        RelationLegacyParent::class,
+        RelationLegacyChild::class,
       ],
       name: $this->dbPath,
       type: DataSourceType::SQLITE,
@@ -49,6 +53,8 @@ class RelationsCest
 
     $db->exec('DROP TABLE IF EXISTS relation_posts_tags');
     $db->exec('DROP TABLE IF EXISTS relation_issues');
+    $db->exec('DROP TABLE IF EXISTS relation_legacy_children');
+    $db->exec('DROP TABLE IF EXISTS relation_legacy_parents');
     $db->exec('DROP TABLE IF EXISTS relation_publishers');
     $db->exec('DROP TABLE IF EXISTS relation_posts');
     $db->exec('DROP TABLE IF EXISTS relation_tags');
@@ -64,6 +70,8 @@ class RelationsCest
     $db->exec('CREATE TABLE relation_posts_tags (post_id INTEGER NOT NULL, tag_id INTEGER NOT NULL)');
     $db->exec('CREATE TABLE relation_publishers (id INTEGER PRIMARY KEY AUTOINCREMENT, code TEXT NOT NULL, name TEXT NOT NULL)');
     $db->exec('CREATE TABLE relation_issues (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, publisher_code TEXT NOT NULL)');
+    $db->exec('CREATE TABLE relation_legacy_parents (id INTEGER PRIMARY KEY AUTOINCREMENT, uuid TEXT NOT NULL, name TEXT NOT NULL)');
+    $db->exec('CREATE TABLE relation_legacy_children (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT NOT NULL, parent_uuid TEXT NOT NULL)');
 
     $db->exec("INSERT INTO relation_profiles (id, bio) VALUES (1, 'Builder'), (2, 'Explorer')");
     $db->exec("INSERT INTO relation_users (id, name, profileId) VALUES (1, 'Alice', 1), (2, 'Bob', 2)");
@@ -73,6 +81,8 @@ class RelationsCest
     $db->exec('INSERT INTO relation_posts_tags (post_id, tag_id) VALUES (1, 1), (1, 2), (2, 2), (2, 3)');
     $db->exec("INSERT INTO relation_publishers (id, code, name) VALUES (1, 'tech', 'Tech Press'), (2, 'news', 'News Desk')");
     $db->exec("INSERT INTO relation_issues (id, title, publisher_code) VALUES (1, 'Framework Notes', 'tech'), (2, 'ORM Notes', 'tech'), (3, 'Daily Brief', 'news')");
+    $db->exec("INSERT INTO relation_legacy_parents (id, uuid, name) VALUES (1, 'parent-alpha', 'Legacy Alpha'), (2, 'parent-beta', 'Legacy Beta')");
+    $db->exec("INSERT INTO relation_legacy_children (id, label, parent_uuid) VALUES (1, 'First Child', 'parent-alpha'), (2, 'Second Child', 'parent-alpha'), (3, 'Other Child', 'parent-beta')");
   }
 
   public function _after(UnitTester $I): void
@@ -148,6 +158,22 @@ class RelationsCest
     $I->assertNotNull($issue->publisher);
     $I->assertSame('tech', $issue->publisher->code);
     $I->assertSame('Tech Press', $issue->publisher->name);
+  }
+
+  public function honorsLegacyOneToManyReferencedPropertyWhenJoinColumnUsesDefaultReference(UnitTester $I): void
+  {
+    $parent = $this->manager->findOne(
+      RelationLegacyParent::class,
+      new FindOneOptions(where: ['id' => 1], relations: ['children'], exclude: ['uuid'])
+    )->getData();
+
+    $I->assertSame('Legacy Alpha', $parent->name);
+    $I->assertFalse(array_key_exists('uuid', get_object_vars($parent)));
+    $I->assertCount(2, $parent->children);
+
+    $labels = array_map(fn(object $item) => $item->label, $parent->children);
+    sort($labels);
+    $I->assertSame(['First Child', 'Second Child'], array_values($labels));
   }
 
   public function loadsManyToManyRelationsOnOwnerAndInverseSides(UnitTester $I): void

--- a/tests/SQLite/RelationsCest.php
+++ b/tests/SQLite/RelationsCest.php
@@ -9,7 +9,9 @@ use Assegai\Orm\Management\EntityManager;
 use Assegai\Orm\Management\Options\FindOneOptions;
 use Assegai\Orm\Management\Options\InsertOptions;
 use Tests\SQLite\Fixtures\RelationAuthor;
+use Tests\SQLite\Fixtures\RelationIssue;
 use Tests\SQLite\Fixtures\RelationPost;
+use Tests\SQLite\Fixtures\RelationPublisher;
 use Tests\SQLite\Fixtures\RelationProfile;
 use Tests\SQLite\Fixtures\RelationTag;
 use Tests\SQLite\Fixtures\RelationUser;
@@ -35,6 +37,8 @@ class RelationsCest
         RelationAuthor::class,
         RelationPost::class,
         RelationTag::class,
+        RelationPublisher::class,
+        RelationIssue::class,
       ],
       name: $this->dbPath,
       type: DataSourceType::SQLITE,
@@ -44,6 +48,8 @@ class RelationsCest
     $db = $this->dataSource->getClient();
 
     $db->exec('DROP TABLE IF EXISTS relation_posts_tags');
+    $db->exec('DROP TABLE IF EXISTS relation_issues');
+    $db->exec('DROP TABLE IF EXISTS relation_publishers');
     $db->exec('DROP TABLE IF EXISTS relation_posts');
     $db->exec('DROP TABLE IF EXISTS relation_tags');
     $db->exec('DROP TABLE IF EXISTS relation_authors');
@@ -56,6 +62,8 @@ class RelationsCest
     $db->exec('CREATE TABLE relation_tags (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT NOT NULL)');
     $db->exec('CREATE TABLE relation_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, author_id INTEGER)');
     $db->exec('CREATE TABLE relation_posts_tags (post_id INTEGER NOT NULL, tag_id INTEGER NOT NULL)');
+    $db->exec('CREATE TABLE relation_publishers (id INTEGER PRIMARY KEY AUTOINCREMENT, code TEXT NOT NULL, name TEXT NOT NULL)');
+    $db->exec('CREATE TABLE relation_issues (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, publisher_code TEXT NOT NULL)');
 
     $db->exec("INSERT INTO relation_profiles (id, bio) VALUES (1, 'Builder'), (2, 'Explorer')");
     $db->exec("INSERT INTO relation_users (id, name, profileId) VALUES (1, 'Alice', 1), (2, 'Bob', 2)");
@@ -63,6 +71,8 @@ class RelationsCest
     $db->exec("INSERT INTO relation_tags (id, label) VALUES (1, 'php'), (2, 'orm'), (3, 'nest')");
     $db->exec("INSERT INTO relation_posts (id, title, author_id) VALUES (1, 'Hello ORM', 1), (2, 'Deep Dive', 1), (3, 'Other Post', 2)");
     $db->exec('INSERT INTO relation_posts_tags (post_id, tag_id) VALUES (1, 1), (1, 2), (2, 2), (2, 3)');
+    $db->exec("INSERT INTO relation_publishers (id, code, name) VALUES (1, 'tech', 'Tech Press'), (2, 'news', 'News Desk')");
+    $db->exec("INSERT INTO relation_issues (id, title, publisher_code) VALUES (1, 'Framework Notes', 'tech'), (2, 'ORM Notes', 'tech'), (3, 'Daily Brief', 'news')");
   }
 
   public function _after(UnitTester $I): void
@@ -113,6 +123,31 @@ class RelationsCest
     $titles = array_map(fn(object $item) => $item->title, $author->posts);
     sort($titles);
     $I->assertSame(['Deep Dive', 'Hello ORM'], array_values($titles));
+  }
+
+  public function loadsOneToManyRelationsFromOwningReferencedColumn(UnitTester $I): void
+  {
+    $publisher = $this->manager->findOne(
+      RelationPublisher::class,
+      new FindOneOptions(where: ['id' => 1], relations: ['issues'], exclude: ['code'])
+    )->getData();
+
+    $issue = $this->manager->findOne(
+      RelationIssue::class,
+      new FindOneOptions(where: ['id' => 1], relations: ['publisher'])
+    )->getData();
+
+    $I->assertSame('Tech Press', $publisher->name);
+    $I->assertFalse(array_key_exists('code', get_object_vars($publisher)));
+    $I->assertCount(2, $publisher->issues);
+    $titles = array_map(fn(object $item) => $item->title, $publisher->issues);
+    sort($titles);
+    $I->assertSame(['Framework Notes', 'ORM Notes'], array_values($titles));
+
+    $I->assertSame('Framework Notes', $issue->title);
+    $I->assertNotNull($issue->publisher);
+    $I->assertSame('tech', $issue->publisher->code);
+    $I->assertSame('Tech Press', $issue->publisher->name);
   }
 
   public function loadsManyToManyRelationsOnOwnerAndInverseSides(UnitTester $I): void

--- a/tests/SQLite/RelationsCest.php
+++ b/tests/SQLite/RelationsCest.php
@@ -149,6 +149,7 @@ class RelationsCest
 
     $I->assertSame('Tech Press', $publisher->name);
     $I->assertFalse(array_key_exists('code', get_object_vars($publisher)));
+    $I->assertFalse(array_key_exists('publicCode', get_object_vars($publisher)));
     $I->assertCount(2, $publisher->issues);
     $titles = array_map(fn(object $item) => $item->title, $publisher->issues);
     sort($titles);
@@ -156,7 +157,8 @@ class RelationsCest
 
     $I->assertSame('Framework Notes', $issue->title);
     $I->assertNotNull($issue->publisher);
-    $I->assertSame('tech', $issue->publisher->code);
+    $I->assertFalse(array_key_exists('code', get_object_vars($issue->publisher)));
+    $I->assertSame('tech', $issue->publisher->publicCode);
     $I->assertSame('Tech Press', $issue->publisher->name);
   }
 
@@ -168,6 +170,24 @@ class RelationsCest
     )->getData();
 
     $I->assertSame('Legacy Alpha', $parent->name);
+    $I->assertFalse(array_key_exists('uuid', get_object_vars($parent)));
+    $I->assertFalse(array_key_exists('publicUuid', get_object_vars($parent)));
+    $I->assertCount(2, $parent->children);
+
+    $labels = array_map(fn(object $item) => $item->label, $parent->children);
+    sort($labels);
+    $I->assertSame(['First Child', 'Second Child'], array_values($labels));
+  }
+
+  public function loadsLegacyOneToManyReferencedPropertyFromSelectedColumnAlias(UnitTester $I): void
+  {
+    $parent = $this->manager->findOne(
+      RelationLegacyParent::class,
+      new FindOneOptions(where: ['id' => 1], relations: ['children'])
+    )->getData();
+
+    $I->assertSame('Legacy Alpha', $parent->name);
+    $I->assertSame('parent-alpha', $parent->publicUuid);
     $I->assertFalse(array_key_exists('uuid', get_object_vars($parent)));
     $I->assertCount(2, $parent->children);
 


### PR DESCRIPTION
This pull request significantly improves the handling of `OneToMany` relations in the ORM, making them more robust and intuitive. The changes clarify that the ORM should infer the reference column for `OneToMany` collections based on the owning `ManyToOne`/`JoinColumn` metadata, reducing the need for manual configuration. The update also introduces comprehensive logic for resolving reference and inverse properties, and adds new test fixtures and cases to ensure correct behavior, especially for non-`id` foreign keys.

**Improvements to OneToMany Relation Handling:**

* The `OneToMany` attribute (`src/Attributes/Relations/OneToMany.php`) is refactored to clarify that the reference column is inferred from the owning `ManyToOne`/`JoinColumn` metadata. The constructor now supports legacy and new argument styles, and documentation is updated for clarity.
* The `EntityManager` (`src/Management/EntityManager.php`) now includes logic to automatically resolve the reference and inverse properties for `OneToMany` relations. This includes new helper methods for property resolution, and ensures the correct property and column names are used throughout the codebase. [[1]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1L1167-R1169) [[2]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1L1518-R1558) [[3]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R1571-R1697) [[4]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R1930-R1936)
* The README is updated to clarify that `OneToMany` collections do not require a reference-column argument, as the ORM can infer it.

**Testing and Fixtures:**

* New test entities (`RelationPublisher` and `RelationIssue`) are added to cover cases where the foreign key is not the default `id`, and corresponding test data is seeded in the SQLite test setup. [[1]](diffhunk://#diff-6c5e71d608b3cc212e81fbf133cb51f0b8af3b252b3275fbb010a0d20450f744R80-R116) [[2]](diffhunk://#diff-69113044099c9ce59f6a32745485a798252f6677f3592029f42703a336cb5848R40-R41) [[3]](diffhunk://#diff-69113044099c9ce59f6a32745485a798252f6677f3592029f42703a336cb5848R51-R52) [[4]](diffhunk://#diff-69113044099c9ce59f6a32745485a798252f6677f3592029f42703a336cb5848R65-R75)
* A new test verifies that `OneToMany` relations are correctly loaded when the foreign key is a non-`id` column, ensuring the new logic works as intended.

**Code Quality and Consistency:**

* Minor improvements to column aliasing and naming in the `EntityManager` to ensure consistency and correct SQL generation.
* Test fixtures are updated to use the new simplified `OneToMany` attribute syntax, reflecting the improved API.

These changes collectively make the ORM's relation handling more automatic, less error-prone, and better tested for real-world scenarios involving custom foreign keys.