### PR TITLE
Add release notes for version 0.9.3 on OneToMany improvements

### DIFF
--- a/docs/release-notes/0.9.3.md
+++ b/docs/release-notes/0.9.3.md
@@ -1,0 +1,60 @@
+# Assegai ORM 0.9.3 Release Notes
+
+Assegai ORM 0.9.3 improves relation loading, with a focus on `OneToMany` collections and relation key handling. This release makes relationship metadata easier to express in TypeORM-style entity models while preserving compatibility with existing mappings.
+
+## Highlights
+
+- `OneToMany` collections can now derive their local reference key from the owning `ManyToOne` / `JoinColumn` metadata.
+- The inverse side of a `OneToMany` relation can be inferred when the target entity has exactly one `ManyToOne` relation back to the parent entity.
+- Existing legacy `OneToMany(type, referencedProperty, inverseSide)` mappings remain supported, including non-`id` reference properties.
+- Relation loading now keeps required internal key columns selectable even when callers exclude them from the public result payload.
+- Relation hydration now handles column aliases more reliably, so expanded relations do not resolve to empty collections just because a required key is exposed under a public alias.
+
+## What Changed
+
+### OneToMany Relation Metadata
+
+`OneToMany` now follows the ownership model more closely: the foreign key lives on the related entity's owning `ManyToOne` side, and the ORM uses that owning side to resolve how child rows should be matched to parent rows.
+
+New code can usually declare a collection like this:
+
+```php
+#[OneToMany(type: PostEntity::class, inverseSide: 'author')]
+public array $posts = [];
+```
+
+When the target entity has exactly one `ManyToOne` relation back to the current entity, the ORM can infer `inverseSide` as well.
+
+### Legacy Mapping Compatibility
+
+Existing mappings that pass an explicit local reference property still work:
+
+```php
+#[OneToMany(PostEntity::class, 'uuid', 'author')]
+public array $posts = [];
+```
+
+The ORM now honors that explicit reference property before falling back to default `id` behavior, even when the owning `JoinColumn` only defines the foreign-key column name.
+
+### Alias-Safe Relation Loading
+
+Relation loaders now distinguish between public result aliases and internal entity property names when selecting required keys.
+
+This matters when a required relation key uses `Column(alias: ...)` or when callers exclude fields from the root entity payload. The ORM can still select the key needed for hydration internally, then keep the final result shaped according to the requested options.
+
+### Expanded Relation Results
+
+`find()` and `findOne()` calls with expanded relations now handle more parent-key shapes correctly across `OneToMany`, `ManyToOne`, and inverse `OneToOne` paths. This prevents valid related rows from being grouped under the wrong key or omitted from the hydrated result.
+
+## Upgrade Notes
+
+No application code changes are required.
+
+Existing `OneToMany` declarations continue to work. For new code, prefer declaring the owning relationship on the `ManyToOne` side with `JoinColumn`, then keep the inverse `OneToMany` declaration minimal.
+
+If a target entity has more than one `ManyToOne` relation back to the same parent entity, specify `inverseSide` explicitly so the ORM does not have to guess.
+
+## Verification
+
+- `composer test:sqlite`
+- Focused SQLite relation-loading tests for inferred, legacy, alias-backed, and excluded-key relation scenarios


### PR DESCRIPTION
This pull request adds detailed release notes for Assegai ORM 0.9.3, focusing on improved relation loading, especially for `OneToMany` collections and relation key handling. The notes cover enhancements to metadata inference, compatibility with legacy mappings, more reliable relation hydration, and expanded relation result handling, all while maintaining backward compatibility.

Key documentation updates:

**Relation Loading Improvements:**
* `OneToMany` collections can now automatically derive their local reference key from the owning `ManyToOne` or `JoinColumn` metadata, reducing the need for explicit configuration.
* The inverse side of a `OneToMany` relation can be inferred when the target entity has a single `ManyToOne` relation back to the parent, simplifying entity model declarations.
* Expanded relation results in `find()` and `findOne()` now handle a broader set of parent-key shapes, ensuring related rows are correctly grouped and hydrated.

**Metadata and Compatibility:**
* Legacy `OneToMany(type, referencedProperty, inverseSide)` mappings remain supported, including those using non-`id` reference properties, preserving backward compatibility.
* The ORM prioritizes explicit reference properties in legacy mappings before defaulting to `id`, even when the owning `JoinColumn` only specifies the foreign-key column name. (F1952fa5