### PR TITLE
Add release notes for versions 0.9.3 and 0.9.4 with relation improvements

### DIFF
--- a/docs/release-notes/0.9.3.md
+++ b/docs/release-notes/0.9.3.md
@@ -1,0 +1,60 @@
+# Assegai ORM 0.9.3 Release Notes
+
+Assegai ORM 0.9.3 improves relation loading, with a focus on `OneToMany` collections and relation key handling. This release makes relationship metadata easier to express in TypeORM-style entity models while preserving compatibility with existing mappings.
+
+## Highlights
+
+- `OneToMany` collections can now derive their local reference key from the owning `ManyToOne` / `JoinColumn` metadata.
+- The inverse side of a `OneToMany` relation can be inferred when the target entity has exactly one `ManyToOne` relation back to the parent entity.
+- Existing legacy `OneToMany(type, referencedProperty, inverseSide)` mappings remain supported, including non-`id` reference properties.
+- Relation loading now keeps required internal key columns selectable even when callers exclude them from the public result payload.
+- Relation hydration now handles column aliases more reliably, so expanded relations do not resolve to empty collections just because a required key is exposed under a public alias.
+
+## What Changed
+
+### OneToMany Relation Metadata
+
+`OneToMany` now follows the ownership model more closely: the foreign key lives on the related entity's owning `ManyToOne` side, and the ORM uses that owning side to resolve how child rows should be matched to parent rows.
+
+New code can usually declare a collection like this:
+
+```php
+#[OneToMany(type: PostEntity::class, inverseSide: 'author')]
+public array $posts = [];
+```
+
+When the target entity has exactly one `ManyToOne` relation back to the current entity, the ORM can infer `inverseSide` as well.
+
+### Legacy Mapping Compatibility
+
+Existing mappings that pass an explicit local reference property still work:
+
+```php
+#[OneToMany(PostEntity::class, 'uuid', 'author')]
+public array $posts = [];
+```
+
+The ORM now honors that explicit reference property before falling back to default `id` behavior, even when the owning `JoinColumn` only defines the foreign-key column name.
+
+### Alias-Safe Relation Loading
+
+Relation loaders now distinguish between public result aliases and internal entity property names when selecting required keys.
+
+This matters when a required relation key uses `Column(alias: ...)` or when callers exclude fields from the root entity payload. The ORM can still select the key needed for hydration internally, then keep the final result shaped according to the requested options.
+
+### Expanded Relation Results
+
+`find()` and `findOne()` calls with expanded relations now handle more parent-key shapes correctly across `OneToMany`, `ManyToOne`, and inverse `OneToOne` paths. This prevents valid related rows from being grouped under the wrong key or omitted from the hydrated result.
+
+## Upgrade Notes
+
+No application code changes are required.
+
+Existing `OneToMany` declarations continue to work. For new code, prefer declaring the owning relationship on the `ManyToOne` side with `JoinColumn`, then keep the inverse `OneToMany` declaration minimal.
+
+If a target entity has more than one `ManyToOne` relation back to the same parent entity, specify `inverseSide` explicitly so the ORM does not have to guess.
+
+## Verification
+
+- `composer test:sqlite`
+- Focused SQLite relation-loading tests for inferred, legacy, alias-backed, and excluded-key relation scenarios

--- a/docs/release-notes/0.9.4.md
+++ b/docs/release-notes/0.9.4.md
@@ -1,0 +1,89 @@
+# Assegai ORM 0.9.4 Release Notes
+
+Assegai ORM 0.9.4 improves write behavior for relation-backed foreign keys and partial update payloads. This release lets applications write foreign-key values through relation ID aliases without adding duplicate public scalar properties to their entities.
+
+## Highlights
+
+- `insert()`, `update()`, and `upsert()` now understand relation ID write aliases derived from `ManyToOne` / owning `JoinColumn` metadata.
+- DTOs and arrays can write a relation foreign key with aliases such as `categoryId` while the returned entity shape remains driven by the entity's declared public properties.
+- Entity write validation now accepts valid relation ID aliases while continuing to reject unrelated unknown fields.
+- Object-based partial updates keep nullable columns unchanged by default, with an explicit `UpdateOptions::writeNulls` opt-in for nullable assignments.
+- Duplicate writes to the same join column are deduplicated when they agree and now fail clearly when they conflict.
+- `Repository::insert()` now forwards `InsertOptions` to the underlying `EntityManager`.
+
+## What Changed
+
+### Relation ID Write Aliases
+
+The ORM now derives write-only relation ID aliases from owning relation metadata.
+
+For an entity like this:
+
+```php
+#[ManyToOne(type: CategoryEntity::class)]
+#[JoinColumn(name: 'category_id', referencedColumnName: 'id')]
+public ?CategoryEntity $category = null;
+```
+
+write payloads can set the foreign key directly:
+
+```php
+$manager->update(ProductEntity::class, ['categoryId' => 12], ['id' => 99]);
+```
+
+The entity does not need a separate `#[Column(name: 'category_id')] public ?int $categoryId` property just to support writes. If the join column references a non-`id` column, the generated alias follows the referenced column name, such as `categoryUuid` for `referencedColumnName: 'uuid'`.
+
+The raw database column name, such as `category_id`, is also accepted for array-style payloads.
+
+### Entity Shape Stays Clean
+
+Relation ID aliases are write aliases, not new entity properties. They can be accepted in DTOs or arrays for `insert()`, `update()`, and `upsert()` calls, but they are not added to generated entity maps unless the entity itself declares that public property.
+
+This keeps API results from exposing duplicate fields such as both `categoryId` and `category` when the entity model only declares the relation.
+
+### Partial Null Updates
+
+Array partial updates continue to treat `null` as an explicit value:
+
+```php
+$manager->update(ProductEntity::class, ['description' => null], ['id' => 99]);
+```
+
+Object DTO partial updates now preserve existing nullable values by default when a property is `null`. To explicitly write nulls from an object payload, pass `UpdateOptions::writeNulls`:
+
+```php
+$manager->update(
+    ProductEntity::class,
+    $payload,
+    ['id' => 99],
+    new UpdateOptions(writeNulls: ['description'])
+);
+```
+
+Pass `writeNulls: true` to write every mapped null property from the object payload.
+
+### Safer Duplicate Column Writes
+
+When a scalar column and a relation both map to the same database column, the ORM now collapses matching write values into a single column assignment. If the values conflict, the write fails with a clear `ORMException` instead of silently choosing one path.
+
+This applies to insert and update assignment generation, including relation-backed foreign keys.
+
+### Repository Insert Options
+
+`Repository::insert()` now passes its `InsertOptions` through to `EntityManager::insert()`. Repository insert calls can therefore honor the same relation and read-only column behavior as direct EntityManager insert calls.
+
+## Upgrade Notes
+
+No database migration is required.
+
+Applications that added public scalar foreign-key properties only to make relation writes possible can remove those duplicate properties and write through the relation ID alias instead. Keep scalar properties if they are intentionally part of the public entity shape.
+
+If an object DTO previously relied on `null` properties clearing nullable database columns during partial updates, pass `new UpdateOptions(writeNulls: true)` or list the specific properties to clear. Array payloads are unchanged and still write explicit `null` values.
+
+Unknown write fields remain invalid unless they correspond to a derived relation ID alias or mapped database column.
+
+## Verification
+
+- `composer test`
+- `composer test:sqlite`
+- Focused EntityManager partial-write tests for relation ID aliases, nullable updates, repository inserts, upserts, and duplicate join-column writes

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -2289,7 +2289,8 @@ class EntityManager implements IEntityStoreOwner
         $assignmentList = $this->applyOnUpdateColumnAssignments($entityInstance, $assignmentList);
 
         if (empty($assignmentList)) {
-            return new UpdateResult(null, 0, $partialEntity, new stdClass());
+            $identifiers = is_array($partialEntity) ? (object)$partialEntity : $partialEntity;
+            return new UpdateResult(null, 0, $identifiers, new stdClass());
         }
 
         $statement = $this->query
@@ -2408,15 +2409,18 @@ class EntityManager implements IEntityStoreOwner
      */
     private function mapContainsColumnName(array $columnMap, string $columnName): bool
     {
+        $normalizedColumnName = $this->normalizeColumnNameForComparison($columnName);
+
         foreach ($columnMap as $key => $value) {
-            if (str_ends_with($key, $columnName)) {
+            if (is_string($key) && $this->normalizeColumnNameForComparison($key) === $normalizedColumnName) {
                 return true;
             }
 
-            if (str_ends_with($value, $columnName)) {
+            if ($this->normalizeColumnNameForComparison($value) === $normalizedColumnName) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -339,10 +339,11 @@ class EntityManager implements IEntityStoreOwner
      * Executes a fast and efficient `INSERT` query.
      * Does not check if the entity exist in the database, so the query will fail if
      * duplicate entity is being inserted.
+     * You can execute bulk inserts by passing a list of entity-like rows.
      *
      * @template TEntity of object
      * @param class-string<TEntity> $entityClass The entity class name.
-     * @param TEntity|array<string, mixed> $entity The entity to insert.
+     * @param TEntity|array<string, mixed>|list<TEntity|array<string, mixed>> $entity The entity or entities to insert.
      * @param InsertOptions|null $options The options to use when inserting the entity.
      * @return InsertResult<TEntity>
      * @throws ClassNotFoundException
@@ -352,26 +353,20 @@ class EntityManager implements IEntityStoreOwner
      */
     public function insert(string $entityClass, array|object $entity, ?InsertOptions $options = null): InsertResult
     {
+        if (is_array($entity) && array_is_list($entity)) {
+            return $this->insertMany(entityClass: $entityClass, entities: $entity, options: $options);
+        }
+
         # Check if the entity matches the given entity class
         if (!$this->hasValidEntityWriteStructure(entity: $entity, entityClass: $entityClass)) {
             return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $this->query->queryString(), generatedMaps: null, errors: [new ORMException("Entity does not match the given entity class.")]);
         }
 
-        $instance = $this->create(entityClass: $entityClass, entityLike: (object)$entity);
-        $primaryKey = $this->getPrimaryKeyMetadata($instance);
-        $primaryKeyField = $primaryKey['field'];
-        $columnsMeta = [];
-        $relations = [];
-        $relationProperties = [];
-
-        if ($options?->relations) {
-            $relations = is_object($options->relations) ? (array)$options->relations : $options->relations;
-        }
-
-        $columns = $this->entityInspector->getColumns(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnsMeta);
-        $values = $this->entityInspector->getValues(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, options: ['relations' => $relations, 'relation_properties' => $relationProperties, 'filter' => true, 'column_types' => $columnsMeta['column_types'] ?? []]);
-        [$columns, $values] = $this->appendRelationIdWriteColumnsAndValues($instance, $entity, $columns, $values, $options->readonlyColumns ?? $this->readonlyColumns);
-        [$columns, $values] = $this->deduplicateWriteColumnsAndValues($columns, $values);
+        $insertWrite = $this->prepareInsertWrite(entityClass: $entityClass, entity: $entity, options: $options);
+        $instance = $insertWrite['instance'];
+        $primaryKeyField = $insertWrite['primaryKeyField'];
+        $columns = $insertWrite['columns'];
+        $values = $insertWrite['values'];
 
         $columnCount = count($columns);
         $valueCount = count($values);
@@ -482,6 +477,164 @@ class EntityManager implements IEntityStoreOwner
         $identifiers = is_array($entity) ? (object)$entity : $entity;
 
         return new InsertResult(identifiers: $identifiers, raw: $raw, generatedMaps: $generatedMaps, affected: $affected);
+    }
+
+    /**
+     * @param list<object|array<string, mixed>|array<int, mixed>> $entities
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function insertMany(string $entityClass, array $entities, ?InsertOptions $options = null): InsertResult
+    {
+        if (empty($entities)) {
+            return new InsertResult(
+                identifiers: (object)['results' => []],
+                raw: $this->query->queryString(),
+                generatedMaps: (object)['results' => []],
+            );
+        }
+
+        foreach ($entities as $entity) {
+            if (!is_array($entity) && !is_object($entity)) {
+                return $this->invalidInsertStructureResult();
+            }
+
+            if (!$this->hasValidEntityWriteStructure(entity: $entity, entityClass: $entityClass)) {
+                return $this->invalidInsertStructureResult();
+            }
+        }
+
+        $preparedRows = [];
+        $columnMap = [];
+
+        foreach ($entities as $entity) {
+            $insertWrite = $this->prepareInsertWrite(entityClass: $entityClass, entity: $entity, options: $options);
+            $preparedRows[] = $insertWrite;
+
+            foreach ($insertWrite['columns'] as $column) {
+                $normalizedColumnName = $this->normalizeColumnNameForComparison($column);
+                $columnMap[$normalizedColumnName] ??= $column;
+            }
+        }
+
+        $rowsList = [];
+
+        foreach ($preparedRows as $insertWrite) {
+            $rowValues = [];
+            $valueList = array_values($insertWrite['values']);
+            $index = 0;
+
+            foreach ($insertWrite['columns'] as $column) {
+                $rowValues[$this->normalizeColumnNameForComparison($column)] = $valueList[$index] ?? null;
+                $index++;
+            }
+
+            $row = [];
+
+            foreach (array_keys($columnMap) as $normalizedColumnName) {
+                $row[] = $rowValues[$normalizedColumnName] ?? null;
+            }
+
+            $rowsList[] = $row;
+        }
+
+        $firstInsert = $preparedRows[0];
+        $tableName = $this->entityInspector->getTableName(entity: $firstInsert['instance']);
+        $primaryKeyField = $firstInsert['primaryKeyField'];
+
+        $this->query
+            ->insertInto(tableName: $tableName)
+            ->multipleRows(columns: array_values($columnMap))
+            ->rows(rowsList: $rowsList);
+
+        if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+            $this->query->appendQueryString('RETURNING ' . $this->buildReturningProjection($firstInsert['instance']));
+        }
+
+        if ($this->isDebug || $options?->isDebug) {
+            $this->query->debug();
+        }
+
+        $result = $this->query->execute();
+        $raw = $result->getRaw();
+        $affected = $this->query->rowCount() ?? 0;
+
+        if ($result->isError()) {
+            if (!headers_sent()) {
+                http_response_code(500);
+            }
+
+            $error = $this->newGeneralSqlQueryException($this->query, $result);
+            OrmRuntime::log('error', self::LOG_TAG, $error->getMessage());
+
+            return new InsertResult(
+                identifiers: (object)['results' => []],
+                raw: $raw,
+                generatedMaps: null,
+                errors: [$error, ...$this->publicResultErrors($result)],
+            );
+        }
+
+        $generatedMaps = $this->query->getDialect() === SQLDialect::POSTGRESQL
+            ? $this->hydrateGeneratedMapList($entityClass, $result->getData())
+            : array_map(
+                fn(array $insertWrite): ?object => $this->sanitizeGeneratedMaps($insertWrite['instance']),
+                $preparedRows
+            );
+        $identifiers = array_map(
+            fn(?object $generatedMap): object => (object)[$primaryKeyField => $generatedMap->{$primaryKeyField} ?? null],
+            $generatedMaps
+        );
+
+        return new InsertResult(
+            identifiers: (object)['results' => $identifiers],
+            raw: $raw,
+            generatedMaps: (object)['results' => $generatedMaps],
+            affected: $affected,
+        );
+    }
+
+    private function invalidInsertStructureResult(): InsertResult
+    {
+        return new InsertResult(
+            identifiers: (object)['results' => []],
+            raw: $this->query->queryString(),
+            generatedMaps: null,
+            errors: [new ORMException("Entity does not match the given entity class.")],
+        );
+    }
+
+    /**
+     * @return array{instance: object, primaryKeyField: string, columns: array<int|string, string>, values: array<int|string, mixed>}
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function prepareInsertWrite(string $entityClass, object|array $entity, ?InsertOptions $options = null): array
+    {
+        $instance = $this->create(entityClass: $entityClass, entityLike: (object)$entity);
+        $primaryKey = $this->getPrimaryKeyMetadata($instance);
+        $columnsMeta = [];
+        $relations = [];
+        $relationProperties = [];
+
+        if ($options?->relations) {
+            $relations = is_object($options->relations) ? (array)$options->relations : $options->relations;
+        }
+
+        $columns = $this->entityInspector->getColumns(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnsMeta);
+        $values = $this->entityInspector->getValues(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, options: ['relations' => $relations, 'relation_properties' => $relationProperties, 'filter' => true, 'column_types' => $columnsMeta['column_types'] ?? []]);
+        [$columns, $values] = $this->appendRelationIdWriteColumnsAndValues($instance, $entity, $columns, $values, $options->readonlyColumns ?? $this->readonlyColumns);
+        [$columns, $values] = $this->deduplicateWriteColumnsAndValues($columns, $values);
+
+        return [
+            'instance' => $instance,
+            'primaryKeyField' => $primaryKey['field'],
+            'columns' => $columns,
+            'values' => $values,
+        ];
     }
 
     /**
@@ -852,6 +1005,29 @@ class EntityManager implements IEntityStoreOwner
         $row = $this->normalizeReturnedRowForEntity($entityClass, $row);
 
         return $this->create($entityClass, (object)$row);
+    }
+
+    /**
+     * @return object[]
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function hydrateGeneratedMapList(string $entityClass, array $rows): array
+    {
+        $generatedMaps = [];
+
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $row = $this->normalizeReturnedRowForEntity($entityClass, $row);
+            $generatedMap = $this->create($entityClass, (object)$row);
+            $generatedMaps[] = $this->sanitizeGeneratedMaps($generatedMap) ?? $generatedMap;
+        }
+
+        return $generatedMaps;
     }
 
     private function normalizeReturnedRowForEntity(string $entityClass, array $row): array

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -543,6 +543,7 @@ class EntityManager implements IEntityStoreOwner
         $firstInsert = $preparedRows[0];
         $tableName = $this->entityInspector->getTableName(entity: $firstInsert['instance']);
         $primaryKeyField = $firstInsert['primaryKeyField'];
+        $primaryColumn = $firstInsert['primaryColumn'];
 
         $this->query
             ->insertInto(tableName: $tableName)
@@ -579,10 +580,7 @@ class EntityManager implements IEntityStoreOwner
 
         $generatedMaps = $this->query->getDialect() === SQLDialect::POSTGRESQL
             ? $this->hydrateGeneratedMapList($entityClass, $result->getData())
-            : array_map(
-                fn(array $insertWrite): ?object => $this->sanitizeGeneratedMaps($insertWrite['instance']),
-                $preparedRows
-            );
+            : $this->hydrateBulkGeneratedMapsWithoutReturning($preparedRows, $primaryKeyField, $primaryColumn);
         $identifiers = array_map(
             fn(?object $generatedMap): object => (object)[$primaryKeyField => $generatedMap->{$primaryKeyField} ?? null],
             $generatedMaps
@@ -596,6 +594,138 @@ class EntityManager implements IEntityStoreOwner
         );
     }
 
+    /**
+     * @param list<array{instance: object, primaryKeyField: string, primaryColumn: string, columns: array<int|string, string>, values: array<int|string, mixed>}> $preparedRows
+     * @return list<object|null>
+     */
+    private function hydrateBulkGeneratedMapsWithoutReturning(array $preparedRows, string $primaryKeyField, string $primaryColumn): array
+    {
+        $generatedMaps = array_map(
+            fn(array $insertWrite): ?object => $this->sanitizeGeneratedMaps($insertWrite['instance']),
+            $preparedRows
+        );
+        $generatedPrimaryKeyIndexes = [];
+
+        foreach ($preparedRows as $index => $insertWrite) {
+            if ($this->bulkInsertRowNeedsGeneratedPrimaryKey($insertWrite, $primaryKeyField, $primaryColumn)) {
+                $generatedPrimaryKeyIndexes[] = $index;
+            }
+        }
+
+        if (empty($generatedPrimaryKeyIndexes)) {
+            return $generatedMaps;
+        }
+
+        $generatedPrimaryKeys = $this->resolveNonReturningBulkGeneratedPrimaryKeys(
+            generatedRowCount: count($generatedPrimaryKeyIndexes),
+            totalRowCount: count($preparedRows),
+        );
+
+        foreach ($generatedPrimaryKeyIndexes as $offset => $rowIndex) {
+            if (!array_key_exists($offset, $generatedPrimaryKeys) || !$generatedMaps[$rowIndex]) {
+                continue;
+            }
+
+            $generatedMaps[$rowIndex]->{$primaryKeyField} = $generatedPrimaryKeys[$offset];
+        }
+
+        return $generatedMaps;
+    }
+
+    /**
+     * @param array{columns: array<int|string, string>, values: array<int|string, mixed>} $insertWrite
+     */
+    private function bulkInsertRowNeedsGeneratedPrimaryKey(array $insertWrite, string $primaryKeyField, string $primaryColumn): bool
+    {
+        $primaryKeyValue = $this->extractPreparedPrimaryKeyValue($insertWrite, $primaryKeyField, $primaryColumn);
+
+        return $primaryKeyValue === null || $primaryKeyValue === '';
+    }
+
+    /**
+     * @param array{columns: array<int|string, string>, values: array<int|string, mixed>} $insertWrite
+     */
+    private function extractPreparedPrimaryKeyValue(array $insertWrite, string $primaryKeyField, string $primaryColumn): mixed
+    {
+        $values = array_values($insertWrite['values']);
+
+        foreach (array_values($insertWrite['columns']) as $index => $column) {
+            $normalizedColumn = $this->normalizeColumnNameForComparison($column);
+
+            if (
+                $normalizedColumn === $this->normalizeColumnNameForComparison($primaryKeyField) ||
+                $normalizedColumn === $this->normalizeColumnNameForComparison($primaryColumn)
+            ) {
+                return $values[$index] ?? null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function resolveNonReturningBulkGeneratedPrimaryKeys(int $generatedRowCount, int $totalRowCount): array
+    {
+        if ($generatedRowCount <= 0) {
+            return [];
+        }
+
+        $lastInsertId = $this->lastInsertId();
+
+        if (!$lastInsertId || $generatedRowCount !== $totalRowCount) {
+            return [];
+        }
+
+        return match ($this->query->getDialect()) {
+            SQLDialect::SQLITE => $this->resolveSqliteBulkGeneratedPrimaryKeys($lastInsertId, $generatedRowCount),
+            SQLDialect::MYSQL, SQLDialect::MARIADB => $this->resolveMySqlBulkGeneratedPrimaryKeys($lastInsertId, $generatedRowCount),
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function resolveSqliteBulkGeneratedPrimaryKeys(int $lastInsertId, int $generatedRowCount): array
+    {
+        $firstInsertId = $lastInsertId - $generatedRowCount + 1;
+
+        if ($firstInsertId <= 0) {
+            return [];
+        }
+
+        return range($firstInsertId, $lastInsertId);
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function resolveMySqlBulkGeneratedPrimaryKeys(int $firstInsertId, int $generatedRowCount): array
+    {
+        $step = $this->resolveMySqlAutoIncrementStep();
+        $generatedPrimaryKeys = [];
+
+        for ($index = 0; $index < $generatedRowCount; $index++) {
+            $generatedPrimaryKeys[] = $firstInsertId + ($index * $step);
+        }
+
+        return $generatedPrimaryKeys;
+    }
+
+    private function resolveMySqlAutoIncrementStep(): int
+    {
+        try {
+            $statement = $this->query->getConnection()->query('SELECT @@auto_increment_increment');
+            $value = $statement !== false ? $statement->fetchColumn() : null;
+        } catch (Throwable) {
+            return 1;
+        }
+
+        return is_numeric($value) && (int)$value > 0 ? (int)$value : 1;
+    }
+
     private function invalidInsertStructureResult(): InsertResult
     {
         return new InsertResult(
@@ -607,7 +737,7 @@ class EntityManager implements IEntityStoreOwner
     }
 
     /**
-     * @return array{instance: object, primaryKeyField: string, columns: array<int|string, string>, values: array<int|string, mixed>}
+     * @return array{instance: object, primaryKeyField: string, primaryColumn: string, columns: array<int|string, string>, values: array<int|string, mixed>}
      * @throws ClassNotFoundException
      * @throws ORMException
      * @throws ReflectionException
@@ -632,6 +762,7 @@ class EntityManager implements IEntityStoreOwner
         return [
             'instance' => $instance,
             'primaryKeyField' => $primaryKey['field'],
+            'primaryColumn' => $primaryKey['column'],
             'columns' => $columns,
             'values' => $values,
         ];

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -2249,7 +2249,9 @@ class EntityManager implements IEntityStoreOwner
             $columnName = $this->getColumnNameFromProperty($entityInstance, $prop);
 
             if ($this->mapContainsColumnName($columnMap, $columnName)) {
-                if (is_null($value) && !$this->shouldWriteNullAssignment($partialEntity, $prop, $columnName, $options)) {
+                $writeColumnName = $this->resolveMappedWriteColumnName($columnMap, $relationProperties, $columnName);
+
+                if (is_null($value) && !$this->shouldWriteNullAssignment($partialEntity, $prop, $writeColumnName, $options)) {
                     continue;
                 }
 
@@ -2265,24 +2267,18 @@ class EntityManager implements IEntityStoreOwner
                     $value = json_encode($value);
                 }
 
-                if (isset($columnMap[$columnName])) {
-                    if (isset($relationProperties[$columnName])) {
-                        assert($relationProperties[$columnName] instanceof RelationPropertyMetadata);
+                if (isset($relationProperties[$columnName])) {
+                    assert($relationProperties[$columnName] instanceof RelationPropertyMetadata);
 
-                        if (
-                            is_object($value) &&
-                            property_exists($value, $relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName)
-                        ) {
-                            $value = $value->{$relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName};
-                        }
-
-                        $columnName = $relationProperties[$columnName]->joinColumn->effectiveColumnName;
-                    } else {
-                        $columnName = $this->getUnqualifiedColumnName($columnMap[$columnName]);
+                    if (
+                        is_object($value) &&
+                        property_exists($value, $relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName)
+                    ) {
+                        $value = $value->{$relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName};
                     }
                 }
 
-                $this->putAssignmentValue($assignmentList, $columnName, $value);
+                $this->putAssignmentValue($assignmentList, $writeColumnName, $value);
             }
         }
 
@@ -2426,6 +2422,24 @@ class EntityManager implements IEntityStoreOwner
         /** @var Column $column */
         $column = $columnAttribute->newInstance();
         return empty($column->name) ? strtosnake($prop) : $column->name;
+    }
+
+    /**
+     * @param array<int|string, string> $columnMap
+     * @param array<string, RelationPropertyMetadata> $relationProperties
+     */
+    private function resolveMappedWriteColumnName(array $columnMap, array $relationProperties, string $columnName): string
+    {
+        if (isset($relationProperties[$columnName])) {
+            assert($relationProperties[$columnName] instanceof RelationPropertyMetadata);
+            return $relationProperties[$columnName]->joinColumn->effectiveColumnName;
+        }
+
+        if (isset($columnMap[$columnName])) {
+            return $this->getUnqualifiedColumnName($columnMap[$columnName]);
+        }
+
+        return $columnName;
     }
 
     /**
@@ -3074,6 +3088,11 @@ class EntityManager implements IEntityStoreOwner
             }
 
             $columnMap[$columnName] = $columnName;
+        }
+
+        foreach ($this->getRelationIdWriteColumnMetadataMap($entity) as $alias => $metadata) {
+            $columnMap[$alias] = $metadata['column'];
+            $columnMap[$metadata['column']] = $metadata['column'];
         }
 
         $resolved = array_map(function (string $conflictPath) use ($columnMap): string {

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -544,13 +544,14 @@ class EntityManager implements IEntityStoreOwner
         $tableName = $this->entityInspector->getTableName(entity: $firstInsert['instance']);
         $primaryKeyField = $firstInsert['primaryKeyField'];
         $primaryColumn = $firstInsert['primaryColumn'];
+        $bulkInsertUsesReturning = in_array($this->query->getDialect(), [SQLDialect::POSTGRESQL, SQLDialect::SQLITE], true);
 
         $this->query
             ->insertInto(tableName: $tableName)
             ->multipleRows(columns: array_values($columnMap))
             ->rows(rowsList: $rowsList);
 
-        if ($this->query->getDialect() === SQLDialect::POSTGRESQL) {
+        if ($bulkInsertUsesReturning) {
             $this->query->appendQueryString('RETURNING ' . $this->buildReturningProjection($firstInsert['instance']));
         }
 
@@ -561,6 +562,9 @@ class EntityManager implements IEntityStoreOwner
         $result = $this->query->execute();
         $raw = $result->getRaw();
         $affected = $this->query->rowCount() ?? 0;
+        if ($bulkInsertUsesReturning && $affected === 0) {
+            $affected = count($result->getData());
+        }
 
         if ($result->isError()) {
             if (!headers_sent()) {
@@ -578,7 +582,7 @@ class EntityManager implements IEntityStoreOwner
             );
         }
 
-        $generatedMaps = $this->query->getDialect() === SQLDialect::POSTGRESQL
+        $generatedMaps = $bulkInsertUsesReturning
             ? $this->hydrateGeneratedMapList($entityClass, $result->getData())
             : $this->hydrateBulkGeneratedMapsWithoutReturning($preparedRows, $primaryKeyField, $primaryColumn);
         $identifiers = array_map(
@@ -674,12 +678,14 @@ class EntityManager implements IEntityStoreOwner
 
         $lastInsertId = $this->lastInsertId();
 
-        if (!$lastInsertId || $generatedRowCount !== $totalRowCount) {
+        if (!$lastInsertId) {
             return [];
         }
 
         return match ($this->query->getDialect()) {
-            SQLDialect::SQLITE => $this->resolveSqliteBulkGeneratedPrimaryKeys($lastInsertId, $generatedRowCount),
+            SQLDialect::SQLITE => $generatedRowCount === $totalRowCount
+                ? $this->resolveSqliteBulkGeneratedPrimaryKeys($lastInsertId, $generatedRowCount)
+                : [],
             SQLDialect::MYSQL, SQLDialect::MARIADB => $this->resolveMySqlBulkGeneratedPrimaryKeys($lastInsertId, $generatedRowCount),
             default => [],
         };
@@ -3315,6 +3321,15 @@ class EntityManager implements IEntityStoreOwner
         }
 
         $this->validateEntityName(entityClass: $entityClass);
+
+        if (!$this->hasValidEntityWriteStructure(entity: $entityOrEntities, entityClass: $entityClass)) {
+            return new InsertResult(
+                identifiers: is_array($entityOrEntities) ? (object)$entityOrEntities : $entityOrEntities,
+                raw: $this->query->queryString(),
+                generatedMaps: null,
+                errors: [new ORMException("Entity does not match the given entity class.")],
+            );
+        }
 
         $entity = $this->create(
             entityClass: $entityClass,

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -339,7 +339,6 @@ class EntityManager implements IEntityStoreOwner
      * Executes a fast and efficient `INSERT` query.
      * Does not check if the entity exist in the database, so the query will fail if
      * duplicate entity is being inserted.
-     * You can execute bulk inserts using this method.
      *
      * @template TEntity of object
      * @param class-string<TEntity> $entityClass The entity class name.
@@ -353,10 +352,6 @@ class EntityManager implements IEntityStoreOwner
      */
     public function insert(string $entityClass, array|object $entity, ?InsertOptions $options = null): InsertResult
     {
-        if (is_array($entity) && array_is_list($entity)) {
-            return $this->insertMany(entityClass: $entityClass, entities: $entity, options: $options);
-        }
-
         # Check if the entity matches the given entity class
         if (!$this->hasValidEntityWriteStructure(entity: $entity, entityClass: $entityClass)) {
             return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $this->query->queryString(), generatedMaps: null, errors: [new ORMException("Entity does not match the given entity class.")]);
@@ -487,63 +482,6 @@ class EntityManager implements IEntityStoreOwner
         $identifiers = is_array($entity) ? (object)$entity : $entity;
 
         return new InsertResult(identifiers: $identifiers, raw: $raw, generatedMaps: $generatedMaps, affected: $affected);
-    }
-
-    /**
-     * @param list<mixed> $entities
-     * @throws ClassNotFoundException
-     * @throws GeneralSQLQueryException
-     * @throws ORMException
-     * @throws ReflectionException
-     */
-    private function insertMany(string $entityClass, array $entities, ?InsertOptions $options = null): InsertResult
-    {
-        foreach ($entities as $entity) {
-            if (!is_array($entity) && !is_object($entity)) {
-                return new InsertResult(
-                    identifiers: (object)['results' => []],
-                    raw: $this->query->queryString(),
-                    generatedMaps: null,
-                    errors: [new ORMException("Entity does not match the given entity class.")],
-                );
-            }
-
-            if (!$this->hasValidEntityWriteStructure(entity: $entity, entityClass: $entityClass)) {
-                return new InsertResult(
-                    identifiers: (object)['results' => []],
-                    raw: $this->query->queryString(),
-                    generatedMaps: null,
-                    errors: [new ORMException("Entity does not match the given entity class.")],
-                );
-            }
-        }
-
-        $identifiers = [];
-        $generatedMaps = [];
-        $errors = [];
-        $affected = 0;
-        $raw = $this->query->queryString();
-
-        foreach ($entities as $entity) {
-            $result = $this->insert(entityClass: $entityClass, entity: $entity, options: $options);
-            $raw = $result->getRaw();
-            $affected += $result->getTotalAffectedRows();
-
-            if ($result->isError()) {
-                $errors = [...$errors, ...$this->publicResultErrors($result)];
-            }
-
-            $identifiers[] = $result->getIdentifiers();
-            $generatedMaps[] = $result->getGeneratedMaps();
-        }
-
-        return new InsertResult(
-            identifiers: (object)['results' => $identifiers],
-            raw: $raw,
-            generatedMaps: (object)['results' => $generatedMaps],
-            errors: $errors,
-            affected: $affected,
-        );
     }
 
     /**
@@ -2386,7 +2324,8 @@ class EntityManager implements IEntityStoreOwner
         }
 
         if (!$generatedMaps) {
-            $updatedEntity = $this->findOne(entityClass: $entityClass, options: new FindOptions(where: $conditions));
+            $readbackConditions = $this->normalizeWriteConditionsForReadback($conditions, $entityInstance);
+            $updatedEntity = $this->findOne(entityClass: $entityClass, options: new FindOptions(where: $readbackConditions));
             $generatedMaps = $updatedEntity->getData() ?? new stdClass();
         }
 
@@ -2404,6 +2343,32 @@ class EntityManager implements IEntityStoreOwner
         }
 
         return new UpdateResult(raw: $raw, affected: $affected, identifiers: $identifiers, generatedMaps: $generatedMaps);
+    }
+
+    /**
+     * @return string|array<string|int, mixed>
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function normalizeWriteConditionsForReadback(string|object|array $conditions, object $entity): string|array
+    {
+        if (is_string($conditions)) {
+            return $conditions;
+        }
+
+        $normalizedConditions = [];
+
+        foreach ((array)$conditions as $key => $value) {
+            if (!is_string($key)) {
+                $normalizedConditions[$key] = $value;
+                continue;
+            }
+
+            $normalizedConditions[$this->getWriteColumnNameFromProperty($entity, $key)] = $value;
+        }
+
+        return $normalizedConditions;
     }
 
     /**

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -2418,6 +2418,7 @@ class EntityManager implements IEntityStoreOwner
         }
 
         $columnMap = $this->entityInspector->getColumns(entity: $entityInstance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnOptions);
+        $relationIdColumns = $this->getRelationIdWriteColumnMetadataMap($entityInstance, $options->readonlyColumns ?? $this->readonlyColumns);
         $columnMap = $this->appendRelationIdWriteColumnMap($entityInstance, $columnMap, $options->readonlyColumns ?? $this->readonlyColumns);
 
         foreach ($partialEntity as $prop => $value) {
@@ -2437,6 +2438,14 @@ class EntityManager implements IEntityStoreOwner
 
                 if ($value instanceof DateTime) {
                     $value = $this->entityInspector->convertDateTimeToString($value, $prop, $columnOptions);
+                }
+
+                if (
+                    isset($relationIdColumns[$columnName]) &&
+                    $this->normalizeColumnNameForComparison($writeColumnName) ===
+                    $this->normalizeColumnNameForComparison($relationIdColumns[$columnName]['qualifiedColumn'])
+                ) {
+                    $value = $this->normalizeRelationIdWriteValue($value, $relationIdColumns[$columnName]['referencedColumn']);
                 }
 
                 if ($value instanceof stdClass) {
@@ -3279,8 +3288,8 @@ class EntityManager implements IEntityStoreOwner
         }
 
         foreach ($this->getRelationIdWriteColumnMetadataMap($entity) as $alias => $metadata) {
-            $columnMap[$alias] = $metadata['column'];
-            $columnMap[$metadata['column']] = $metadata['column'];
+            $columnMap[$alias] ??= $metadata['column'];
+            $columnMap[$metadata['column']] ??= $metadata['column'];
         }
 
         $resolved = array_map(function (string $conflictPath) use ($columnMap): string {

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -2731,8 +2731,20 @@ class EntityManager implements IEntityStoreOwner
             }
 
             $metadata = $relationIdColumns[$propertyName];
-            $normalizedValue = $this->normalizeRelationIdWriteValue($value, $metadata['referencedColumn']);
             $existingColumnIndex = array_search($propertyName, array_keys($columns), true);
+
+            if ($existingColumnIndex !== false) {
+                $existingColumn = $columns[$propertyName];
+
+                if (
+                    $this->normalizeColumnNameForComparison($existingColumn) !==
+                    $this->normalizeColumnNameForComparison($metadata['qualifiedColumn'])
+                ) {
+                    continue;
+                }
+            }
+
+            $normalizedValue = $this->normalizeRelationIdWriteValue($value, $metadata['referencedColumn']);
             $columns[$propertyName] = $metadata['qualifiedColumn'];
 
             if (!$includeValues) {

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -2501,6 +2501,7 @@ class EntityManager implements IEntityStoreOwner
         array $columns,
         array $values,
         array $exclude = [],
+        bool $includeValues = true,
     ): array
     {
         $relationIdColumns = $this->getRelationIdWriteColumnMetadataMap($entity, $exclude);
@@ -2512,8 +2513,24 @@ class EntityManager implements IEntityStoreOwner
             }
 
             $metadata = $relationIdColumns[$propertyName];
+            $normalizedValue = $this->normalizeRelationIdWriteValue($value, $metadata['referencedColumn']);
+            $existingColumnIndex = array_search($propertyName, array_keys($columns), true);
             $columns[$propertyName] = $metadata['qualifiedColumn'];
-            $values[] = $this->normalizeRelationIdWriteValue($value, $metadata['referencedColumn']);
+
+            if (!$includeValues) {
+                continue;
+            }
+
+            if ($existingColumnIndex !== false) {
+                $valueKeys = array_keys($values);
+
+                if (array_key_exists($existingColumnIndex, $valueKeys)) {
+                    $values[$valueKeys[$existingColumnIndex]] = $normalizedValue;
+                    continue;
+                }
+            }
+
+            $values[] = $normalizedValue;
         }
 
         return [$columns, $values];
@@ -2904,7 +2921,7 @@ class EntityManager implements IEntityStoreOwner
                 : UpsertOptions::fromArray($options);
         }
 
-        if (is_array($entityOrEntities)) {
+        if (is_array($entityOrEntities) && array_is_list($entityOrEntities)) {
             $results = [];
             $errors = [];
             foreach ($entityOrEntities as $entity) {
@@ -2920,7 +2937,7 @@ class EntityManager implements IEntityStoreOwner
             $generatedMaps = new stdClass();
             $generatedMaps->results = $results;
 
-            return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: $entityOrEntities, generatedMaps: $generatedMaps, errors: $errors);
+            return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: (object)$entityOrEntities, generatedMaps: $generatedMaps, errors: $errors);
         }
 
         $this->validateEntityName(entityClass: $entityClass);
@@ -2940,7 +2957,7 @@ class EntityManager implements IEntityStoreOwner
         $values = $this->entityInspector->getValues(entity: $entity);
         [$columns, $values] = $this->appendRelationIdWriteColumnsAndValues($entity, $entityOrEntities, $columns, $values);
         [$columns, $values] = $this->deduplicateWriteColumnsAndValues($columns, $values);
-        [$updateColumns] = $this->appendRelationIdWriteColumnsAndValues($entity, $entityOrEntities, $updateColumns, [], $options->readonlyColumns ?? $this->readonlyColumns);
+        [$updateColumns] = $this->appendRelationIdWriteColumnsAndValues($entity, $entityOrEntities, $updateColumns, [], $options->readonlyColumns ?? $this->readonlyColumns, includeValues: false);
         $tableName = $this->entityInspector->getTableName(entity: $entity);
 
         return match ($this->query->getDialect()) {

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -353,9 +353,13 @@ class EntityManager implements IEntityStoreOwner
      */
     public function insert(string $entityClass, array|object $entity, ?InsertOptions $options = null): InsertResult
     {
+        if (is_array($entity) && array_is_list($entity)) {
+            return $this->insertMany(entityClass: $entityClass, entities: $entity, options: $options);
+        }
+
         # Check if the entity matches the given entity class
         if (!$this->hasValidEntityWriteStructure(entity: $entity, entityClass: $entityClass)) {
-            return new InsertResult(identifiers: $entity, raw: $this->query->queryString(), generatedMaps: null, errors: [new ORMException("Entity does not match the given entity class.")]);
+            return new InsertResult(identifiers: is_array($entity) ? (object)$entity : $entity, raw: $this->query->queryString(), generatedMaps: null, errors: [new ORMException("Entity does not match the given entity class.")]);
         }
 
         $instance = $this->create(entityClass: $entityClass, entityLike: (object)$entity);
@@ -389,6 +393,7 @@ class EntityManager implements IEntityStoreOwner
 
         $result = $this->query->execute();
         $raw = $result->getRaw();
+        $affected = $this->query->rowCount() ?? 0;
 
         if ($result->isError()) {
             if (!headers_sent()) {
@@ -414,7 +419,7 @@ class EntityManager implements IEntityStoreOwner
                 raw: $raw,
                 generatedMaps: $generatedMaps,
                 errors: [],
-                affected: $this->query->rowCount() ?? 0,
+                affected: $affected,
             );
         }
 
@@ -481,7 +486,64 @@ class EntityManager implements IEntityStoreOwner
 
         $identifiers = is_array($entity) ? (object)$entity : $entity;
 
-        return new InsertResult(identifiers: $identifiers, raw: $raw, generatedMaps: $generatedMaps);
+        return new InsertResult(identifiers: $identifiers, raw: $raw, generatedMaps: $generatedMaps, affected: $affected);
+    }
+
+    /**
+     * @param list<mixed> $entities
+     * @throws ClassNotFoundException
+     * @throws GeneralSQLQueryException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function insertMany(string $entityClass, array $entities, ?InsertOptions $options = null): InsertResult
+    {
+        foreach ($entities as $entity) {
+            if (!is_array($entity) && !is_object($entity)) {
+                return new InsertResult(
+                    identifiers: (object)['results' => []],
+                    raw: $this->query->queryString(),
+                    generatedMaps: null,
+                    errors: [new ORMException("Entity does not match the given entity class.")],
+                );
+            }
+
+            if (!$this->hasValidEntityWriteStructure(entity: $entity, entityClass: $entityClass)) {
+                return new InsertResult(
+                    identifiers: (object)['results' => []],
+                    raw: $this->query->queryString(),
+                    generatedMaps: null,
+                    errors: [new ORMException("Entity does not match the given entity class.")],
+                );
+            }
+        }
+
+        $identifiers = [];
+        $generatedMaps = [];
+        $errors = [];
+        $affected = 0;
+        $raw = $this->query->queryString();
+
+        foreach ($entities as $entity) {
+            $result = $this->insert(entityClass: $entityClass, entity: $entity, options: $options);
+            $raw = $result->getRaw();
+            $affected += $result->getTotalAffectedRows();
+
+            if ($result->isError()) {
+                $errors = [...$errors, ...$this->publicResultErrors($result)];
+            }
+
+            $identifiers[] = $result->getIdentifiers();
+            $generatedMaps[] = $result->getGeneratedMaps();
+        }
+
+        return new InsertResult(
+            identifiers: (object)['results' => $identifiers],
+            raw: $raw,
+            generatedMaps: (object)['results' => $generatedMaps],
+            errors: $errors,
+            affected: $affected,
+        );
     }
 
     /**
@@ -2311,6 +2373,7 @@ class EntityManager implements IEntityStoreOwner
 
         $result = $this->query->execute();
         $raw = $result->getRaw();
+        $affected = $this->query->rowCount() ?? 0;
 
         if ($result->isError()) {
             throw $this->newGeneralSqlQueryException($this->query, $result);
@@ -2340,7 +2403,7 @@ class EntityManager implements IEntityStoreOwner
             }
         }
 
-        return new UpdateResult(raw: $raw, affected: $this->query->rowCount(), identifiers: $identifiers, generatedMaps: $generatedMaps);
+        return new UpdateResult(raw: $raw, affected: $affected, identifiers: $identifiers, generatedMaps: $generatedMaps);
     }
 
     /**
@@ -2456,7 +2519,7 @@ class EntityManager implements IEntityStoreOwner
 
         foreach ($sourceProperties as $propertyName => $propertyValue) {
             if (!is_string($propertyName)) {
-                continue;
+                return false;
             }
 
             if (property_exists($entityClass, $propertyName) || isset($relationIdColumns[$propertyName])) {
@@ -2772,6 +2835,10 @@ class EntityManager implements IEntityStoreOwner
             return $left instanceof SQLExpression && $right instanceof SQLExpression && (string)$left === (string)$right;
         }
 
+        if ($left === null || $right === null) {
+            return $left === $right;
+        }
+
         return $left == $right;
     }
 
@@ -3003,6 +3070,7 @@ class EntityManager implements IEntityStoreOwner
 
         $result = $this->query->execute();
         $raw = $result->getRaw();
+        $affected = $this->query->rowCount() ?? 0;
         $errors = [];
 
         if ($result->isError()) {
@@ -3025,7 +3093,7 @@ class EntityManager implements IEntityStoreOwner
             raw: $raw,
             generatedMaps: $entity,
             errors: $errors,
-            affected: $this->query->rowCount() ?? 0,
+            affected: $affected,
         );
     }
 
@@ -3111,6 +3179,7 @@ class EntityManager implements IEntityStoreOwner
 
         $result = $this->query->execute();
         $raw = $result->getRaw();
+        $affected = $this->query->rowCount() ?? 0;
         $errors = [];
 
         if ($result->isError()) {
@@ -3151,7 +3220,7 @@ class EntityManager implements IEntityStoreOwner
             raw: $raw,
             generatedMaps: $generatedMaps,
             errors: $errors,
-            affected: $this->query->rowCount() ?? 0,
+            affected: $affected,
         );
     }
 
@@ -3224,6 +3293,7 @@ class EntityManager implements IEntityStoreOwner
 
         $result = $this->query->execute();
         $raw = $result->getRaw();
+        $affected = $this->query->rowCount() ?? 0;
 
         $errors = [];
         if ($result->isError()) {
@@ -3263,7 +3333,7 @@ class EntityManager implements IEntityStoreOwner
             raw: $raw,
             generatedMaps: $generatedMaps,
             errors: $errors,
-            affected: $this->query->rowCount() ?? 0,
+            affected: $affected,
         );
     }
 

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -354,7 +354,7 @@ class EntityManager implements IEntityStoreOwner
     public function insert(string $entityClass, array|object $entity, ?InsertOptions $options = null): InsertResult
     {
         # Check if the entity matches the given entity class
-        if (!$this->entityInspector->hasValidEntityStructure(entity: $entity, entityClass: $entityClass)) {
+        if (!$this->hasValidEntityWriteStructure(entity: $entity, entityClass: $entityClass)) {
             return new InsertResult(identifiers: $entity, raw: $this->query->queryString(), generatedMaps: null, errors: [new ORMException("Entity does not match the given entity class.")]);
         }
 
@@ -371,6 +371,8 @@ class EntityManager implements IEntityStoreOwner
 
         $columns = $this->entityInspector->getColumns(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnsMeta);
         $values = $this->entityInspector->getValues(entity: $instance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, options: ['relations' => $relations, 'relation_properties' => $relationProperties, 'filter' => true, 'column_types' => $columnsMeta['column_types'] ?? []]);
+        [$columns, $values] = $this->appendRelationIdWriteColumnsAndValues($instance, $entity, $columns, $values, $options->readonlyColumns ?? $this->readonlyColumns);
+        [$columns, $values] = $this->deduplicateWriteColumnsAndValues($columns, $values);
 
         $columnCount = count($columns);
         $valueCount = count($values);
@@ -2222,7 +2224,7 @@ class EntityManager implements IEntityStoreOwner
             $generatedMaps = new stdClass();
 
             foreach ($partialEntity as $partialItem) {
-                $result = $this->update(entityClass: $entityClass, partialEntity: $partialItem, conditions: $conditions);
+                $result = $this->update(entityClass: $entityClass, partialEntity: $partialItem, conditions: $conditions, options: $options);
                 $generatedMaps = $result->generatedMaps;
             }
 
@@ -2240,41 +2242,47 @@ class EntityManager implements IEntityStoreOwner
         }
 
         $columnMap = $this->entityInspector->getColumns(entity: $entityInstance, exclude: $options->readonlyColumns ?? $this->readonlyColumns, relations: $relations, relationProperties: $relationProperties, meta: $columnOptions);
+        $columnMap = $this->appendRelationIdWriteColumnMap($entityInstance, $columnMap, $options->readonlyColumns ?? $this->readonlyColumns);
 
         foreach ($partialEntity as $prop => $value) {
             # Get the correct prop name
             $columnName = $this->getColumnNameFromProperty($entityInstance, $prop);
 
             if ($this->mapContainsColumnName($columnMap, $columnName)) {
-                if (!is_null($value)) {
-                    if ($value instanceof UnitEnum && property_exists($value, 'value')) {
-                        $value = $value->value;
-                    }
-
-                    if ($value instanceof DateTime) {
-                        $value = $this->entityInspector->convertDateTimeToString($value, $prop, $columnOptions);
-                    }
-
-                    if ($value instanceof stdClass) {
-                        $value = json_encode($value);
-                    }
-
-                    if (isset($columnMap[$columnName])) {
-                        if (isset($relationProperties[$columnName])) {
-                            assert($relationProperties[$columnName] instanceof RelationPropertyMetadata);
-
-                            if (is_object($value) && property_exists($value, $relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName)) {
-                                $value = $value->{$relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName};
-                            }
-
-                            $columnName = $relationProperties[$columnName]->joinColumn->effectiveColumnName;
-                        } else {
-                            $columnName = $this->getUnqualifiedColumnName($columnMap[$columnName]);
-                        }
-                    }
-
-                    $assignmentList[$columnName] = $value;
+                if (is_null($value) && !$this->shouldWriteNullAssignment($partialEntity, $prop, $columnName, $options)) {
+                    continue;
                 }
+
+                if ($value instanceof UnitEnum && property_exists($value, 'value')) {
+                    $value = $value->value;
+                }
+
+                if ($value instanceof DateTime) {
+                    $value = $this->entityInspector->convertDateTimeToString($value, $prop, $columnOptions);
+                }
+
+                if ($value instanceof stdClass) {
+                    $value = json_encode($value);
+                }
+
+                if (isset($columnMap[$columnName])) {
+                    if (isset($relationProperties[$columnName])) {
+                        assert($relationProperties[$columnName] instanceof RelationPropertyMetadata);
+
+                        if (
+                            is_object($value) &&
+                            property_exists($value, $relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName)
+                        ) {
+                            $value = $value->{$relationProperties[$columnName]->joinColumn->effectiveReferencedColumnName};
+                        }
+
+                        $columnName = $relationProperties[$columnName]->joinColumn->effectiveColumnName;
+                    } else {
+                        $columnName = $this->getUnqualifiedColumnName($columnMap[$columnName]);
+                    }
+                }
+
+                $this->putAssignmentValue($assignmentList, $columnName, $value);
             }
         }
 
@@ -2428,6 +2436,325 @@ class EntityManager implements IEntityStoreOwner
     }
 
     /**
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function hasValidEntityWriteStructure(object|array $entity, string $entityClass): bool
+    {
+        if (!class_exists($entityClass)) {
+            throw new ClassNotFoundException(className: $entityClass);
+        }
+
+        $entityInstance = (new ReflectionClass($entityClass))->newInstanceWithoutConstructor();
+        $relationIdColumns = $this->getRelationIdWriteColumnMetadataMap($entityInstance);
+        $sourceProperties = is_array($entity) ? $entity : get_object_vars($entity);
+
+        foreach ($sourceProperties as $propertyName => $propertyValue) {
+            if (!is_string($propertyName)) {
+                continue;
+            }
+
+            if (property_exists($entityClass, $propertyName) || isset($relationIdColumns[$propertyName])) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<int|string, string> $columnMap
+     * @param string[] $exclude
+     * @return array<int|string, string>
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function appendRelationIdWriteColumnMap(object $entity, array $columnMap, array $exclude = []): array
+    {
+        foreach ($this->getRelationIdWriteColumnMetadataMap($entity, $exclude) as $alias => $metadata) {
+            $columnMap[$alias] ??= $metadata['qualifiedColumn'];
+        }
+
+        return $columnMap;
+    }
+
+    /**
+     * @param array<int|string, string> $columns
+     * @param array<int|string, mixed> $values
+     * @param string[] $exclude
+     * @return array{0: array<int|string, string>, 1: array<int|string, mixed>}
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function appendRelationIdWriteColumnsAndValues(
+        object $entity,
+        object|array $source,
+        array $columns,
+        array $values,
+        array $exclude = [],
+    ): array
+    {
+        $relationIdColumns = $this->getRelationIdWriteColumnMetadataMap($entity, $exclude);
+        $sourceProperties = is_array($source) ? $source : get_object_vars($source);
+
+        foreach ($sourceProperties as $propertyName => $value) {
+            if (!is_string($propertyName) || !isset($relationIdColumns[$propertyName])) {
+                continue;
+            }
+
+            $metadata = $relationIdColumns[$propertyName];
+            $columns[$propertyName] = $metadata['qualifiedColumn'];
+            $values[] = $this->normalizeRelationIdWriteValue($value, $metadata['referencedColumn']);
+        }
+
+        return [$columns, $values];
+    }
+
+    /**
+     * @param string[] $exclude
+     * @return array<string, array{column: string, qualifiedColumn: string, referencedColumn: string}>
+     * @throws ClassNotFoundException
+     * @throws ORMException
+     * @throws ReflectionException
+     */
+    private function getRelationIdWriteColumnMetadataMap(object $entity, array $exclude = []): array
+    {
+        $metadata = [];
+        $tableName = $this->entityInspector->getTableName($entity);
+        $reflectionClass = new ReflectionClass($entity);
+
+        foreach ($reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if (!$this->isJoinColumnRelationProperty($property)) {
+                continue;
+            }
+
+            $propertyName = $property->getName();
+            $joinColumn = $this->entityInspector->getJoinColumnAttribute($entity::class, $propertyName);
+            $columnName = $joinColumn->effectiveColumnName ?? $joinColumn->name ?? strtosnake($propertyName . 'Id');
+            $referencedColumnName = $joinColumn->effectiveReferencedColumnName ?? $joinColumn->referencedColumnName ?? 'id';
+            $aliases = $this->getRelationIdWriteAliases($propertyName, $columnName, $referencedColumnName);
+
+            foreach ($aliases as $alias) {
+                if ($this->writeAliasIsExcluded($alias, $columnName, $exclude)) {
+                    continue;
+                }
+
+                $metadata[$alias] = [
+                    'column' => $columnName,
+                    'qualifiedColumn' => "$tableName.$columnName",
+                    'referencedColumn' => $referencedColumnName,
+                ];
+            }
+        }
+
+        return $metadata;
+    }
+
+    private function isJoinColumnRelationProperty(ReflectionProperty $property): bool
+    {
+        if (!empty($property->getAttributes(ManyToOne::class))) {
+            return true;
+        }
+
+        return !empty($property->getAttributes(OneToOne::class)) && !empty($property->getAttributes(JoinColumn::class));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getRelationIdWriteAliases(string $propertyName, string $columnName, string $referencedColumnName): array
+    {
+        $aliases = [$columnName];
+        $referencedAlias = $propertyName . ucfirst(strtocamel($referencedColumnName));
+        $aliases[] = $referencedAlias;
+
+        if ($referencedColumnName === 'id') {
+            $aliases[] = $propertyName . 'Id';
+        }
+
+        return array_values(array_unique($aliases));
+    }
+
+    /**
+     * @param string[] $exclude
+     */
+    private function writeAliasIsExcluded(string $alias, string $columnName, array $exclude): bool
+    {
+        foreach ($exclude as $excludedColumn) {
+            if (!is_string($excludedColumn)) {
+                continue;
+            }
+
+            if (
+                $excludedColumn === $alias ||
+                $excludedColumn === $columnName ||
+                $this->normalizeColumnNameForComparison($excludedColumn) === $this->normalizeColumnNameForComparison($columnName)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getWriteColumnNameFromProperty(object $entity, string $prop): string
+    {
+        $columnName = $this->getColumnNameFromProperty($entity, $prop);
+
+        if ($columnName !== $prop || property_exists($entity, $prop)) {
+            return $columnName;
+        }
+
+        $relationIdColumns = $this->getRelationIdWriteColumnMetadataMap($entity);
+
+        return $relationIdColumns[$prop]['column'] ?? $columnName;
+    }
+
+    private function normalizeRelationIdWriteValue(mixed $value, string $referencedColumnName): mixed
+    {
+        if ($value instanceof UnitEnum && property_exists($value, 'value')) {
+            return $value->value;
+        }
+
+        if (is_object($value)) {
+            foreach ([$referencedColumnName, strtocamel($referencedColumnName)] as $referencedPropertyName) {
+                if (property_exists($value, $referencedPropertyName)) {
+                    return $value->{$referencedPropertyName};
+                }
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<int|string, string> $columns
+     * @param array<int|string, mixed> $values
+     * @return array{0: array<int|string, string>, 1: array<int, mixed>}
+     * @throws ORMException
+     */
+    private function deduplicateWriteColumnsAndValues(array $columns, array $values): array
+    {
+        $dedupedColumns = [];
+        $dedupedValues = [];
+        $seenColumns = [];
+        $valueList = array_values($values);
+        $index = 0;
+
+        foreach ($columns as $key => $column) {
+            $value = $valueList[$index] ?? null;
+            $index++;
+            $normalizedColumnName = $this->normalizeColumnNameForComparison($column);
+
+            if (!array_key_exists($normalizedColumnName, $seenColumns)) {
+                $seenColumns[$normalizedColumnName] = count($dedupedValues);
+                $dedupedColumns[$key] = $column;
+                $dedupedValues[] = $value;
+                continue;
+            }
+
+            $existingValueIndex = $seenColumns[$normalizedColumnName];
+            $existingValue = $dedupedValues[$existingValueIndex];
+
+            if ($this->writeValuesAreEquivalent($existingValue, $value)) {
+                continue;
+            }
+
+            if ($existingValue === null && $value !== null) {
+                $dedupedValues[$existingValueIndex] = $value;
+                continue;
+            }
+
+            if ($existingValue !== null && $value === null) {
+                continue;
+            }
+
+            throw new ORMException("Column {$this->stripTableName($column)} is mapped more than once with conflicting write values.");
+        }
+
+        return [$dedupedColumns, $dedupedValues];
+    }
+
+    /**
+     * @param array<string, mixed> $assignmentList
+     * @throws ORMException
+     */
+    private function putAssignmentValue(array &$assignmentList, string $columnName, mixed $value): void
+    {
+        $normalizedColumnName = $this->normalizeColumnNameForComparison($columnName);
+
+        foreach ($assignmentList as $existingColumnName => $existingValue) {
+            if ($this->normalizeColumnNameForComparison($existingColumnName) !== $normalizedColumnName) {
+                continue;
+            }
+
+            if ($this->writeValuesAreEquivalent($existingValue, $value)) {
+                return;
+            }
+
+            if ($existingValue === null && $value !== null) {
+                $assignmentList[$existingColumnName] = $value;
+                return;
+            }
+
+            if ($existingValue !== null && $value === null) {
+                return;
+            }
+
+            throw new ORMException("Column {$this->stripTableName($columnName)} is mapped more than once with conflicting update values.");
+        }
+
+        $assignmentList[$this->stripTableName($columnName)] = $value;
+    }
+
+    private function shouldWriteNullAssignment(object|array $partialEntity, string $propertyName, string $columnName, ?UpdateOptions $options): bool
+    {
+        if (is_array($partialEntity) && !array_is_list($partialEntity)) {
+            return true;
+        }
+
+        $writeNulls = $options?->writeNulls ?? false;
+
+        if ($writeNulls === true) {
+            return true;
+        }
+
+        if (!is_array($writeNulls)) {
+            return false;
+        }
+
+        foreach ($writeNulls as $writeNullProperty) {
+            if (!is_string($writeNullProperty)) {
+                continue;
+            }
+
+            if (
+                $writeNullProperty === $propertyName ||
+                $writeNullProperty === $columnName ||
+                $this->normalizeColumnNameForComparison($writeNullProperty) === $this->normalizeColumnNameForComparison($columnName)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function writeValuesAreEquivalent(mixed $left, mixed $right): bool
+    {
+        if ($left instanceof SQLExpression || $right instanceof SQLExpression) {
+            return $left instanceof SQLExpression && $right instanceof SQLExpression && (string)$left === (string)$right;
+        }
+
+        return $left == $right;
+    }
+
+    /**
      * @param int|object|array $conditions
      * @param SQLQuery $query
      * @param object|null $entity
@@ -2443,7 +2770,7 @@ class EntityManager implements IEntityStoreOwner
 
         foreach ((array)$conditions as $key => $value) {
             $columnName = $entity && is_string($key)
-                ? $this->getColumnNameFromProperty($entity, $key)
+                ? $this->getWriteColumnNameFromProperty($entity, $key)
                 : (string)$key;
             $identifier = SqlIdentifier::quote($columnName, $query->getDialect());
 
@@ -2607,6 +2934,9 @@ class EntityManager implements IEntityStoreOwner
         $columns = $this->entityInspector->getColumns(entity: $entity);
         $updateColumns = $this->entityInspector->getColumns(entity: $entity, exclude: $options->readonlyColumns ?? $this->readonlyColumns);
         $values = $this->entityInspector->getValues(entity: $entity);
+        [$columns, $values] = $this->appendRelationIdWriteColumnsAndValues($entity, $entityOrEntities, $columns, $values);
+        [$columns, $values] = $this->deduplicateWriteColumnsAndValues($columns, $values);
+        [$updateColumns] = $this->appendRelationIdWriteColumnsAndValues($entity, $entityOrEntities, $updateColumns, [], $options->readonlyColumns ?? $this->readonlyColumns);
         $tableName = $this->entityInspector->getTableName(entity: $entity);
 
         return match ($this->query->getDialect()) {
@@ -2629,7 +2959,7 @@ class EntityManager implements IEntityStoreOwner
     {
         $originalId = $entity->{$primaryKeyField} ?? null;
         $columns = array_map([$this, 'stripTableName'], array_values($columns));
-        $updateColumns = array_map([$this, 'stripTableName'], array_values($updateColumns));
+        $updateColumns = array_values(array_unique(array_map([$this, 'stripTableName'], array_values($updateColumns))));
         $conflictPaths = $this->resolveUpsertConflictColumns($entity, $options->conflictPaths ?: [$primaryColumn]);
         [$columns, $values] = $this->filterNullableUpsertColumns($columns, $values, $conflictPaths, $updateColumns);
 
@@ -2734,7 +3064,7 @@ class EntityManager implements IEntityStoreOwner
     {
         $originalId = $entity->{$primaryKeyField} ?? null;
         $columns = array_map([$this, 'stripTableName'], array_values($columns));
-        $updateColumns = array_map([$this, 'stripTableName'], array_values($updateColumns));
+        $updateColumns = array_values(array_unique(array_map([$this, 'stripTableName'], array_values($updateColumns))));
         $conflictPaths = $this->resolveUpsertConflictColumns($entity, $options->conflictPaths ?: [$primaryColumn]);
         [$columns, $values] = $this->filterNullableUpsertColumns($columns, $values, $conflictPaths, $updateColumns);
 
@@ -2862,6 +3192,7 @@ class EntityManager implements IEntityStoreOwner
         string        $primaryColumn,
     ): InsertResult
     {
+        $updateColumns = array_values(array_unique(array_map([$this, 'stripTableName'], array_values($updateColumns))));
         $assignmentList = $this->buildMySqlUpsertAssignments($entityOrEntities, $updateColumns, $primaryColumn);
 
         $this->query->insertInto(tableName: $tableName)->singleRow(columns: $columns)->values(valuesList: $values)->onDuplicateKeyUpdate(assignmentList: $assignmentList);

--- a/src/Management/Options/UpdateOptions.php
+++ b/src/Management/Options/UpdateOptions.php
@@ -19,12 +19,15 @@ readonly class UpdateOptions
      *
      * @param object|string[]|null $relations The relations to include.
      * @param bool $isDebug Whether to output debug information.
+     * @param bool|string[] $writeNulls Whether null values should be written for object DTOs. Pass true for every
+     *   mapped null property, or a list of property/column names for selected nullable assignments.
      */
     public function __construct(
         object|array|null $relations = null,
         public bool       $isDebug = false,
         public ?array     $readonlyColumns = null,
         public string     $primaryKeyField = 'id',
+        public bool|array  $writeNulls = false,
     )
     {
         $this->relations = $this->normalizeRelations($relations);

--- a/src/Management/Repository.php
+++ b/src/Management/Repository.php
@@ -115,7 +115,7 @@ readonly class Repository implements RepositoryInterface
    */
   public function insert(array|object $entity, ?InsertOptions $options = null): InsertResult
   {
-    return $this->manager->insert(entityClass: $this->entityId, entity: $entity);
+    return $this->manager->insert(entityClass: $this->entityId, entity: $entity, options: $options);
   }
 
   /**

--- a/tests/PHPUnit/MySQLIntegration/EntityManagerMySqlIntegrationTest.php
+++ b/tests/PHPUnit/MySQLIntegration/EntityManagerMySqlIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\PHPUnit\MySQLIntegration;
 
 use Assegai\Orm\Exceptions\ORMException;
+use Assegai\Orm\Management\Options\InsertOptions;
 use Assegai\Orm\Management\Options\UpsertOptions;
 use Assegai\Orm\Queries\QueryBuilder\Results\InsertResult;
 use Tests\PHPUnit\Support\MySqlIntegrationTestCase;
@@ -142,6 +143,47 @@ final class EntityManagerMySqlIntegrationTest extends MySqlIntegrationTestCase
         self::assertSame('mysql bulk insert second', $secondRow['name']);
         self::assertSame(MockColorType::GREEN->value, $firstRow['color_type']);
         self::assertSame(MockColorType::BLUE->value, $secondRow['color_type']);
+    }
+
+    public function testBulkInsertPopulatesGeneratedIdentifiersWhenRowsMixExplicitAndGeneratedIds(): void
+    {
+        $result = $this->manager->insert(
+            MockEntity::class,
+            [
+                [
+                    'id' => 100000,
+                    'name' => 'mysql bulk explicit id',
+                    'description' => 'Explicit identifier',
+                    'colorType' => MockColorType::GREEN,
+                ],
+                [
+                    'name' => 'mysql bulk generated id',
+                    'description' => 'Generated identifier',
+                    'colorType' => MockColorType::BLUE,
+                ],
+            ],
+            new InsertOptions(readonlyColumns: ['createdAt', 'updatedAt', 'deletedAt']),
+        );
+
+        self::assertInstanceOf(InsertResult::class, $result);
+        self::assertTrue($result->isOk());
+
+        $identifiers = $result->getIdentifiers()->results ?? [];
+        $generatedMaps = $result->getGeneratedMaps()->results ?? [];
+
+        self::assertCount(2, $identifiers);
+        self::assertCount(2, $generatedMaps);
+        self::assertSame(100000, $identifiers[0]->id);
+        self::assertSame(100000, $generatedMaps[0]->id);
+        self::assertGreaterThan(0, $identifiers[1]->id);
+        self::assertSame($identifiers[1]->id, $generatedMaps[1]->id);
+        self::assertNotSame($identifiers[0]->id, $identifiers[1]->id);
+
+        $explicitRow = $this->fetchMocksRowById((int)$identifiers[0]->id);
+        $generatedRow = $this->fetchMocksRowById((int)$identifiers[1]->id);
+
+        self::assertSame('mysql bulk explicit id', $explicitRow['name']);
+        self::assertSame('mysql bulk generated id', $generatedRow['name']);
     }
 
     public function testInsertReturnsErrorForInvalidStructure(): void

--- a/tests/PHPUnit/MySQLIntegration/EntityManagerMySqlIntegrationTest.php
+++ b/tests/PHPUnit/MySQLIntegration/EntityManagerMySqlIntegrationTest.php
@@ -104,6 +104,46 @@ final class EntityManagerMySqlIntegrationTest extends MySqlIntegrationTestCase
         self::assertSame(MockColorType::YELLOW->value, $row['color_type']);
     }
 
+    public function testBulkInsertPopulatesGeneratedIdentifiers(): void
+    {
+        $result = $this->manager->insert(
+            MockEntity::class,
+            [
+                [
+                    'name' => 'mysql bulk insert first',
+                    'description' => 'First generated identifier',
+                    'colorType' => MockColorType::GREEN,
+                ],
+                [
+                    'name' => 'mysql bulk insert second',
+                    'description' => 'Second generated identifier',
+                    'colorType' => MockColorType::BLUE,
+                ],
+            ],
+        );
+
+        self::assertInstanceOf(InsertResult::class, $result);
+        self::assertTrue($result->isOk());
+
+        $identifiers = $result->getIdentifiers()->results ?? [];
+        $generatedMaps = $result->getGeneratedMaps()->results ?? [];
+
+        self::assertCount(2, $identifiers);
+        self::assertCount(2, $generatedMaps);
+        self::assertGreaterThan(0, $identifiers[0]->id);
+        self::assertGreaterThan(0, $identifiers[1]->id);
+        self::assertSame($identifiers[0]->id, $generatedMaps[0]->id);
+        self::assertSame($identifiers[1]->id, $generatedMaps[1]->id);
+
+        $firstRow = $this->fetchMocksRowById((int)$identifiers[0]->id);
+        $secondRow = $this->fetchMocksRowById((int)$identifiers[1]->id);
+
+        self::assertSame('mysql bulk insert first', $firstRow['name']);
+        self::assertSame('mysql bulk insert second', $secondRow['name']);
+        self::assertSame(MockColorType::GREEN->value, $firstRow['color_type']);
+        self::assertSame(MockColorType::BLUE->value, $secondRow['color_type']);
+    }
+
     public function testInsertReturnsErrorForInvalidStructure(): void
     {
         $invalid = (object) [

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -136,6 +136,24 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
     }
 
+    public function testRelationIdAliasUpdateNormalizesRelatedObjectValue(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+        $this->insertCatalogListing('Object Alias Update', null);
+
+        $category = new CatalogCategoryEntity();
+        $category->id = 42;
+
+        $result = $this->createManager(CatalogListingEntity::class)->update(
+            CatalogListingEntity::class,
+            ['categoryId' => $category],
+            ['name' => 'Object Alias Update'],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertSame(42, $this->fetchCatalogListing('Object Alias Update')['category_id']);
+    }
+
     public function testArrayPayloadIdStaysReadonlyWhenRelationIdAliasExists(): void
     {
         $this->insertCategory(42, 'Hardware');
@@ -379,6 +397,26 @@ final class EntityManagerPartialWriteTest extends TestCase
 
         $row = $this->fetchAliasCollisionListing('Alias Collision Upsert');
         self::assertTrue($result->isOk());
+        self::assertSame(7, (int)$row['category_code']);
+        self::assertNull($row['category_id']);
+    }
+
+    public function testUpsertConflictPathPrefersDeclaredColumnOverGeneratedRelationAlias(): void
+    {
+        $this->dataSource->getClient()->exec(
+            'CREATE UNIQUE INDEX catalog_listing_alias_collision_category_code_unique ON catalog_listing_alias_collisions (category_code)'
+        );
+
+        $result = $this->createManager(CatalogListingWithAliasCollisionEntity::class)->upsert(
+            CatalogListingWithAliasCollisionEntity::class,
+            ['name' => 'Alias Collision Conflict Path', 'categoryId' => 7],
+            ['categoryId'],
+        );
+
+        $row = $this->fetchAliasCollisionListing('Alias Collision Conflict Path');
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('ON CONFLICT ("category_code")', $result->getRaw());
+        self::assertStringNotContainsString('ON CONFLICT ("category_id")', $result->getRaw());
         self::assertSame(7, (int)$row['category_code']);
         self::assertNull($row['category_id']);
     }

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace Tests\PHPUnit\Unit;
+
+use Assegai\Orm\Attributes\Columns\Column;
+use Assegai\Orm\Attributes\Columns\PrimaryGeneratedColumn;
+use Assegai\Orm\Attributes\Entity;
+use Assegai\Orm\Attributes\Relations\JoinColumn;
+use Assegai\Orm\Attributes\Relations\ManyToOne;
+use Assegai\Orm\DataSource\DataSource;
+use Assegai\Orm\DataSource\DataSourceOptions;
+use Assegai\Orm\Enumerations\DataSourceType;
+use Assegai\Orm\Enumerations\SQLDialect;
+use Assegai\Orm\Exceptions\ORMException;
+use Assegai\Orm\Management\EntityManager;
+use Assegai\Orm\Management\Options\InsertOptions;
+use Assegai\Orm\Management\Options\UpdateOptions;
+use Assegai\Orm\Management\Repository;
+use Assegai\Orm\Queries\Sql\ColumnType;
+use Assegai\Orm\Queries\Sql\SQLQuery;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class EntityManagerPartialWriteTest extends TestCase
+{
+    private ?DataSource $dataSource = null;
+    private string $databasePath;
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/assegai-partial-write-' . uniqid('', true) . '.sqlite';
+        $this->cleanupSqliteFiles($this->databasePath);
+        $this->dataSource = new DataSource(new DataSourceOptions(
+            entities: [
+                NullableCatalogItemEntity::class,
+                CatalogCategoryEntity::class,
+                CatalogListingEntity::class,
+                CatalogListingWithScalarEntity::class,
+            ],
+            name: $this->databasePath,
+            type: DataSourceType::SQLITE,
+        ));
+
+        $this->dataSource->getClient()->exec(
+            'CREATE TABLE nullable_catalog_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NULL
+            )'
+        );
+        $this->dataSource->getClient()->exec(
+            'CREATE TABLE catalog_categories (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL
+            )'
+        );
+        $this->dataSource->getClient()->exec(
+            'CREATE TABLE catalog_listings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                category_id INTEGER NULL
+            )'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dataSource?->disconnect();
+        $this->cleanupSqliteFiles($this->databasePath);
+    }
+
+    public function testArrayPartialUpdateWritesExplicitNull(): void
+    {
+        $this->insertCatalogItem('Widget', 'Ready to clear');
+
+        $result = $this->createManager(NullableCatalogItemEntity::class)->update(
+            NullableCatalogItemEntity::class,
+            ['description' => null],
+            ['name' => 'Widget'],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertNull($this->fetchCatalogItem('Widget')['description']);
+    }
+
+    public function testObjectPartialUpdateSkipsDefaultNullsUnlessRequested(): void
+    {
+        $this->insertCatalogItem('Gadget', 'Keep this value');
+
+        $payload = new NullableCatalogItemPatch();
+        $result = $this->createManager(NullableCatalogItemEntity::class)->update(
+            NullableCatalogItemEntity::class,
+            $payload,
+            ['name' => 'Gadget'],
+        );
+
+        self::assertSame(0, $result->affected);
+        self::assertSame('Keep this value', $this->fetchCatalogItem('Gadget')['description']);
+
+        $result = $this->createManager(NullableCatalogItemEntity::class)->update(
+            NullableCatalogItemEntity::class,
+            $payload,
+            ['name' => 'Gadget'],
+            new UpdateOptions(writeNulls: ['description']),
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertNull($this->fetchCatalogItem('Gadget')['description']);
+    }
+
+    public function testRelationIdAliasUpdatesJoinColumnWithoutPublicScalarProperty(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+        $this->insertCatalogListing('Cordless Drill', null);
+
+        $payload = new CatalogListingRelationPatch();
+        $payload->categoryId = 42;
+
+        $result = $this->createManager(CatalogListingEntity::class)->update(
+            CatalogListingEntity::class,
+            $payload,
+            ['name' => 'Cordless Drill'],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertSame(42, $this->fetchCatalogListing('Cordless Drill')['category_id']);
+        self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
+    }
+
+    public function testRelationIdAliasClearRequiresObjectNullWriteOptIn(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+        $this->insertCatalogListing('Workbench', 42);
+
+        $payload = new CatalogListingRelationPatch();
+        $result = $this->createManager(CatalogListingEntity::class)->update(
+            CatalogListingEntity::class,
+            $payload,
+            ['name' => 'Workbench'],
+        );
+
+        self::assertSame(0, $result->affected);
+        self::assertSame(42, $this->fetchCatalogListing('Workbench')['category_id']);
+
+        $result = $this->createManager(CatalogListingEntity::class)->update(
+            CatalogListingEntity::class,
+            $payload,
+            ['name' => 'Workbench'],
+            new UpdateOptions(writeNulls: ['categoryId']),
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertNull($this->fetchCatalogListing('Workbench')['category_id']);
+        self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
+    }
+
+    public function testRepositoryInsertAcceptsRelationIdAliasWithoutPublicScalarProperty(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+
+        $payload = new CatalogListingCreatePayload();
+        $payload->name = 'Cordless Sander';
+        $payload->categoryId = 42;
+
+        $repository = new Repository(CatalogListingEntity::class, $this->createManager(CatalogListingEntity::class));
+        $result = $repository->insert($payload);
+
+        self::assertTrue($result->isOk());
+        self::assertSame(1, substr_count($result->getRaw(), '"category_id"'));
+        self::assertSame(42, $this->fetchCatalogListing('Cordless Sander')['category_id']);
+        self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
+    }
+
+    public function testSqliteUpsertAcceptsRelationIdAliasWithoutPublicScalarProperty(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+
+        $payload = new CatalogListingCreatePayload();
+        $payload->name = 'Cordless Router';
+        $payload->categoryId = 42;
+
+        $result = $this->createManager(CatalogListingEntity::class)->upsert(
+            CatalogListingEntity::class,
+            $payload,
+            ['name'],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('"category_id"', $result->getRaw());
+        self::assertSame(42, $this->fetchCatalogListing('Cordless Router')['category_id']);
+        self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
+    }
+
+    public function testInsertDedupeAllowsScalarAndRelationToShareAJoinColumn(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+
+        $listing = new CatalogListingWithScalarEntity();
+        $listing->name = 'Cordless Driver';
+        $listing->category = new CatalogCategoryEntity();
+        $listing->category->id = 42;
+
+        $result = $this->createManager(CatalogListingWithScalarEntity::class)->insert(
+            CatalogListingWithScalarEntity::class,
+            $listing,
+            new InsertOptions(relations: ['category']),
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertSame(1, substr_count($result->getRaw(), '"category_id"'));
+        self::assertSame(42, $this->fetchCatalogListing('Cordless Driver')['category_id']);
+    }
+
+    public function testConflictingScalarAndRelationJoinColumnWritesFailClearly(): void
+    {
+        $listing = new CatalogListingWithScalarEntity();
+        $listing->name = 'Conflicted Listing';
+        $listing->categoryId = 7;
+        $listing->category = new CatalogCategoryEntity();
+        $listing->category->id = 42;
+
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('category_id is mapped more than once');
+
+        $this->createManager(CatalogListingWithScalarEntity::class)->insert(
+            CatalogListingWithScalarEntity::class,
+            $listing,
+            new InsertOptions(relations: ['category']),
+        );
+    }
+
+    /**
+     * @param class-string $entityClass
+     */
+    private function createManager(string $entityClass): EntityManager
+    {
+        return new EntityManager(
+            connection: $this->dataSource,
+            query: new SQLQuery(
+                db: $this->dataSource->getClient(),
+                fetchClass: $entityClass,
+                fetchMode: PDO::FETCH_CLASS,
+                dialect: SQLDialect::SQLITE,
+            ),
+        );
+    }
+
+    private function insertCatalogItem(string $name, ?string $description): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO nullable_catalog_items (name, description) VALUES (?, ?)'
+        );
+        $statement->execute([$name, $description]);
+    }
+
+    private function insertCategory(int $id, string $name): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO catalog_categories (id, name) VALUES (?, ?)'
+        );
+        $statement->execute([$id, $name]);
+    }
+
+    private function insertCatalogListing(string $name, ?int $categoryId): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO catalog_listings (name, category_id) VALUES (?, ?)'
+        );
+        $statement->execute([$name, $categoryId]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchCatalogItem(string $name): array
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT name, description FROM nullable_catalog_items WHERE name = ?'
+        );
+        $statement->execute([$name]);
+
+        return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchCatalogListing(string $name): array
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT name, category_id FROM catalog_listings WHERE name = ?'
+        );
+        $statement->execute([$name]);
+
+        return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+
+    private function cleanupSqliteFiles(string $path): void
+    {
+        foreach ([$path, $path . '-wal', $path . '-shm'] as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+}
+
+#[Entity(table: 'nullable_catalog_items')]
+class NullableCatalogItemEntity
+{
+    #[PrimaryGeneratedColumn]
+    public ?int $id = null;
+
+    #[Column(type: ColumnType::VARCHAR, nullable: false)]
+    public string $name = '';
+
+    #[Column(type: ColumnType::TEXT, nullable: true)]
+    public ?string $description = null;
+}
+
+class NullableCatalogItemPatch
+{
+    public ?string $description = null;
+}
+
+#[Entity(table: 'catalog_categories')]
+class CatalogCategoryEntity
+{
+    #[PrimaryGeneratedColumn]
+    public ?int $id = null;
+
+    #[Column(type: ColumnType::VARCHAR, nullable: false)]
+    public string $name = '';
+}
+
+class CatalogListingCreatePayload
+{
+    public string $name = '';
+    public ?int $categoryId = null;
+}
+
+class CatalogListingRelationPatch
+{
+    public ?int $categoryId = null;
+}
+
+#[Entity(table: 'catalog_listings')]
+class CatalogListingEntity
+{
+    #[PrimaryGeneratedColumn]
+    public ?int $id = null;
+
+    #[Column(type: ColumnType::VARCHAR, nullable: false)]
+    public string $name = '';
+
+    #[ManyToOne(type: CatalogCategoryEntity::class)]
+    #[JoinColumn(name: 'category_id', referencedColumnName: 'id')]
+    public ?CatalogCategoryEntity $category = null;
+}
+
+#[Entity(table: 'catalog_listings')]
+class CatalogListingWithScalarEntity
+{
+    #[PrimaryGeneratedColumn]
+    public ?int $id = null;
+
+    #[Column(type: ColumnType::VARCHAR, nullable: false)]
+    public string $name = '';
+
+    #[Column(name: 'category_id', type: ColumnType::INT, nullable: true)]
+    public ?int $categoryId = null;
+
+    #[ManyToOne(type: CatalogCategoryEntity::class)]
+    #[JoinColumn(name: 'category_id', referencedColumnName: 'id')]
+    public ?CatalogCategoryEntity $category = null;
+}

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -282,6 +282,35 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertSame((int)$secondRow['id'], $generatedMaps[1]->id);
     }
 
+    public function testSqliteBulkInsertPopulatesGeneratedIdsWhenRowsMixExplicitAndGeneratedIds(): void
+    {
+        $result = $this->createManager(NullableCatalogItemEntity::class)->insert(
+            NullableCatalogItemEntity::class,
+            [
+                ['id' => 100, 'name' => 'Bulk Explicit Id', 'description' => 'supplied id'],
+                ['name' => 'Bulk Generated Id', 'description' => 'generated id'],
+            ],
+            new InsertOptions(readonlyColumns: ['createdAt', 'updatedAt', 'deletedAt']),
+        );
+
+        $explicitRow = $this->fetchCatalogItem('Bulk Explicit Id');
+        $generatedRow = $this->fetchCatalogItem('Bulk Generated Id');
+        $identifiers = $result->getIdentifiers()->results ?? [];
+        $generatedMaps = $result->getGeneratedMaps()->results ?? [];
+
+        self::assertTrue($result->isOk());
+        self::assertSame(2, $result->getTotalAffectedRows());
+        self::assertCount(2, $identifiers);
+        self::assertCount(2, $generatedMaps);
+        self::assertSame(100, $identifiers[0]->id);
+        self::assertSame(100, $generatedMaps[0]->id);
+        self::assertSame((int)$generatedRow['id'], $identifiers[1]->id);
+        self::assertSame((int)$generatedRow['id'], $generatedMaps[1]->id);
+        self::assertGreaterThan(0, $identifiers[1]->id);
+        self::assertNotSame($identifiers[0]->id, $identifiers[1]->id);
+        self::assertSame(100, (int)$explicitRow['id']);
+    }
+
     public function testBulkInsertRejectsRowsWithNumericKeysBeforeWriting(): void
     {
         $result = $this->createManager(NullableCatalogItemEntity::class)->insert(
@@ -308,6 +337,19 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertTrue($result->isError());
         self::assertInstanceOf(ORMException::class, $result->getErrors()[0] ?? null);
         self::assertFalse($this->catalogItemExistsByName('Numeric Key Item'));
+    }
+
+    public function testUpsertRejectsInvalidAssociativePayloadBeforeHydration(): void
+    {
+        $result = $this->createManager(NullableCatalogItemEntity::class)->upsert(
+            NullableCatalogItemEntity::class,
+            ['name' => 'Invalid Upsert Payload', 'descrption' => 'typo should be rejected'],
+            ['name'],
+        );
+
+        self::assertTrue($result->isError());
+        self::assertInstanceOf(ORMException::class, $result->getErrors()[0] ?? null);
+        self::assertFalse($this->catalogItemExistsByName('Invalid Upsert Payload'));
     }
 
     public function testSqliteUpsertAcceptsRelationIdAliasWithoutPublicScalarProperty(): void
@@ -574,7 +616,7 @@ final class EntityManagerPartialWriteTest extends TestCase
     private function fetchCatalogItem(string $name): array
     {
         $statement = $this->dataSource->getClient()->prepare(
-            'SELECT name, description FROM nullable_catalog_items WHERE name = ?'
+            'SELECT id, name, description FROM nullable_catalog_items WHERE name = ?'
         );
         $statement->execute([$name]);
 

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -207,33 +207,28 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
     }
 
-    public function testInsertAcceptsListArrayRows(): void
-    {
-        $this->insertCategory(42, 'Hardware');
-
-        $result = $this->createManager(CatalogListingEntity::class)->insert(
-            CatalogListingEntity::class,
-            [
-                ['name' => 'Bulk Cordless Saw', 'categoryId' => 42],
-                ['name' => 'Bulk Bench Plane', 'category_id' => 42],
-            ],
-        );
-
-        self::assertTrue($result->isOk());
-        self::assertSame(2, $result->getTotalAffectedRows());
-        self::assertSame(42, $this->fetchCatalogListing('Bulk Cordless Saw')['category_id']);
-        self::assertSame(42, $this->fetchCatalogListing('Bulk Bench Plane')['category_id']);
-    }
-
-    public function testInsertRejectsListRowsWithNumericKeys(): void
+    public function testInsertRejectsListArrayRows(): void
     {
         $result = $this->createManager(NullableCatalogItemEntity::class)->insert(
             NullableCatalogItemEntity::class,
-            [['Numeric Key Item']],
+            [['name' => 'Bulk Widget']],
         );
 
         self::assertTrue($result->isError());
         self::assertInstanceOf(ORMException::class, $result->getErrors()[0] ?? null);
+        self::assertFalse($this->catalogItemExistsByName('Bulk Widget'));
+    }
+
+    public function testInsertRejectsMixedNumericKeyPayload(): void
+    {
+        $result = $this->createManager(NullableCatalogItemEntity::class)->insert(
+            NullableCatalogItemEntity::class,
+            ['name' => 'Numeric Key Item', 0 => 'ignored'],
+        );
+
+        self::assertTrue($result->isError());
+        self::assertInstanceOf(ORMException::class, $result->getErrors()[0] ?? null);
+        self::assertFalse($this->catalogItemExistsByName('Numeric Key Item'));
     }
 
     public function testSqliteUpsertAcceptsRelationIdAliasWithoutPublicScalarProperty(): void
@@ -254,6 +249,22 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertStringContainsString('"category_id"', $result->getRaw());
         self::assertSame(42, $this->fetchCatalogListing('Cordless Router')['category_id']);
         self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
+    }
+
+    public function testUpdateReadbackNormalizesRelationIdAliasConditions(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+        $this->insertCatalogListing('Cordless Jigsaw', 42);
+
+        $result = $this->createManager(CatalogListingEntity::class)->update(
+            CatalogListingEntity::class,
+            ['name' => 'Cordless Jigsaw Kit'],
+            ['categoryId' => 42],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertSame('Cordless Jigsaw Kit', $result->generatedMaps->name ?? null);
+        self::assertSame(42, $this->fetchCatalogListing('Cordless Jigsaw Kit')['category_id']);
     }
 
     public function testInsertDedupeAllowsScalarAndRelationToShareAJoinColumn(): void
@@ -436,6 +447,16 @@ final class EntityManagerPartialWriteTest extends TestCase
         $statement->execute([$name]);
 
         return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+
+    private function catalogItemExistsByName(string $name): bool
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT COUNT(*) FROM nullable_catalog_items WHERE name = ?'
+        );
+        $statement->execute([$name]);
+
+        return (int)$statement->fetchColumn() > 0;
     }
 
     private function catalogListingExistsById(int $id): bool

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -207,6 +207,35 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
     }
 
+    public function testInsertAcceptsListArrayRows(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+
+        $result = $this->createManager(CatalogListingEntity::class)->insert(
+            CatalogListingEntity::class,
+            [
+                ['name' => 'Bulk Cordless Saw', 'categoryId' => 42],
+                ['name' => 'Bulk Bench Plane', 'category_id' => 42],
+            ],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertSame(2, $result->getTotalAffectedRows());
+        self::assertSame(42, $this->fetchCatalogListing('Bulk Cordless Saw')['category_id']);
+        self::assertSame(42, $this->fetchCatalogListing('Bulk Bench Plane')['category_id']);
+    }
+
+    public function testInsertRejectsListRowsWithNumericKeys(): void
+    {
+        $result = $this->createManager(NullableCatalogItemEntity::class)->insert(
+            NullableCatalogItemEntity::class,
+            [['Numeric Key Item']],
+        );
+
+        self::assertTrue($result->isError());
+        self::assertInstanceOf(ORMException::class, $result->getErrors()[0] ?? null);
+    }
+
     public function testSqliteUpsertAcceptsRelationIdAliasWithoutPublicScalarProperty(): void
     {
         $this->insertCategory(42, 'Hardware');
@@ -245,6 +274,49 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertTrue($result->isOk());
         self::assertSame(1, substr_count($result->getRaw(), '"category_id"'));
         self::assertSame(42, $this->fetchCatalogListing('Cordless Driver')['category_id']);
+    }
+
+    public function testInsertDedupePreservesZeroRelationAliasValue(): void
+    {
+        $result = $this->createManager(CatalogListingWithScalarEntity::class)->insert(
+            CatalogListingWithScalarEntity::class,
+            ['name' => 'Zero Alias Insert', 'category_id' => 0],
+        );
+
+        $value = $this->fetchCatalogListing('Zero Alias Insert')['category_id'];
+        self::assertTrue($result->isOk());
+        self::assertNotNull($value);
+        self::assertSame(0, (int)$value);
+    }
+
+    public function testUpsertDedupePreservesZeroRelationAliasValue(): void
+    {
+        $result = $this->createManager(CatalogListingWithScalarEntity::class)->upsert(
+            CatalogListingWithScalarEntity::class,
+            ['name' => 'Zero Alias Upsert', 'category_id' => 0],
+            ['name'],
+        );
+
+        $value = $this->fetchCatalogListing('Zero Alias Upsert')['category_id'];
+        self::assertTrue($result->isOk());
+        self::assertNotNull($value);
+        self::assertSame(0, (int)$value);
+    }
+
+    public function testUpdateDedupePreservesZeroRelationAliasValue(): void
+    {
+        $this->insertCatalogListing('Zero Alias Update', 42);
+
+        $result = $this->createManager(CatalogListingWithScalarEntity::class)->update(
+            CatalogListingWithScalarEntity::class,
+            ['categoryId' => null, 'category_id' => 0],
+            ['name' => 'Zero Alias Update'],
+        );
+
+        $value = $this->fetchCatalogListing('Zero Alias Update')['category_id'];
+        self::assertTrue($result->isOk());
+        self::assertNotNull($value);
+        self::assertSame(0, (int)$value);
     }
 
     public function testConflictingScalarAndRelationJoinColumnWritesFailClearly(): void

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -190,6 +190,24 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
     }
 
+    public function testRelationIdAliasClearHonorsColumnNameWriteNullOptIn(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+        $this->insertCatalogListing('Column Opt In Workbench', 42);
+
+        $payload = new CatalogListingRelationPatch();
+        $result = $this->createManager(CatalogListingEntity::class)->update(
+            CatalogListingEntity::class,
+            $payload,
+            ['name' => 'Column Opt In Workbench'],
+            new UpdateOptions(writeNulls: ['category_id']),
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertNull($this->fetchCatalogListing('Column Opt In Workbench')['category_id']);
+        self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
+    }
+
     public function testRepositoryInsertAcceptsRelationIdAliasWithoutPublicScalarProperty(): void
     {
         $this->insertCategory(42, 'Hardware');
@@ -265,6 +283,25 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertTrue($result->isOk());
         self::assertSame('Cordless Jigsaw Kit', $result->generatedMaps->name ?? null);
         self::assertSame(42, $this->fetchCatalogListing('Cordless Jigsaw Kit')['category_id']);
+    }
+
+    public function testUpsertConflictPathsResolveRelationIdAliases(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+        $this->dataSource->getClient()->exec(
+            'CREATE UNIQUE INDEX catalog_listings_category_id_unique ON catalog_listings (category_id)'
+        );
+
+        $result = $this->createManager(CatalogListingEntity::class)->upsert(
+            CatalogListingEntity::class,
+            ['name' => 'Category Conflict Router', 'categoryId' => 42],
+            ['categoryId'],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertStringContainsString('"category_id"', $result->getRaw());
+        self::assertStringNotContainsString('"categoryId"', $result->getRaw());
+        self::assertSame(42, $this->fetchCatalogListing('Category Conflict Router')['category_id']);
     }
 
     public function testInsertDedupeAllowsScalarAndRelationToShareAJoinColumn(): void

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -265,6 +265,41 @@ final class EntityManagerPartialWriteTest extends TestCase
         );
     }
 
+    public function testConflictingScalarAndRawRelationAliasInsertWritesFailClearly(): void
+    {
+        $payload = [
+            'name' => 'Conflicted Alias Insert',
+            'categoryId' => 7,
+            'category_id' => 42,
+        ];
+
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('category_id is mapped more than once');
+
+        $this->createManager(CatalogListingWithScalarEntity::class)->insert(
+            CatalogListingWithScalarEntity::class,
+            $payload,
+        );
+    }
+
+    public function testConflictingScalarAndRawRelationAliasUpsertWritesFailClearly(): void
+    {
+        $payload = [
+            'name' => 'Conflicted Alias Upsert',
+            'categoryId' => 7,
+            'category_id' => 42,
+        ];
+
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('category_id is mapped more than once');
+
+        $this->createManager(CatalogListingWithScalarEntity::class)->upsert(
+            CatalogListingWithScalarEntity::class,
+            $payload,
+            ['name'],
+        );
+    }
+
     /**
      * @param class-string $entityClass
      */

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -36,6 +36,7 @@ final class EntityManagerPartialWriteTest extends TestCase
                 CatalogCategoryEntity::class,
                 CatalogListingEntity::class,
                 CatalogListingWithScalarEntity::class,
+                CatalogListingWithAliasCollisionEntity::class,
             ],
             name: $this->databasePath,
             type: DataSourceType::SQLITE,
@@ -58,6 +59,14 @@ final class EntityManagerPartialWriteTest extends TestCase
             'CREATE TABLE catalog_listings (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 name TEXT NOT NULL UNIQUE,
+                category_id INTEGER NULL
+            )'
+        );
+        $this->dataSource->getClient()->exec(
+            'CREATE TABLE catalog_listing_alias_collisions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                category_code INTEGER NULL,
                 category_id INTEGER NULL
             )'
         );
@@ -347,6 +356,33 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertSame(42, $this->fetchCatalogListing('Cordless Driver')['category_id']);
     }
 
+    public function testDeclaredColumnWinsOverGeneratedRelationAliasOnInsert(): void
+    {
+        $result = $this->createManager(CatalogListingWithAliasCollisionEntity::class)->insert(
+            CatalogListingWithAliasCollisionEntity::class,
+            ['name' => 'Alias Collision Insert', 'categoryId' => 7],
+        );
+
+        $row = $this->fetchAliasCollisionListing('Alias Collision Insert');
+        self::assertTrue($result->isOk());
+        self::assertSame(7, (int)$row['category_code']);
+        self::assertNull($row['category_id']);
+    }
+
+    public function testDeclaredColumnWinsOverGeneratedRelationAliasOnUpsert(): void
+    {
+        $result = $this->createManager(CatalogListingWithAliasCollisionEntity::class)->upsert(
+            CatalogListingWithAliasCollisionEntity::class,
+            ['name' => 'Alias Collision Upsert', 'categoryId' => 7],
+            ['name'],
+        );
+
+        $row = $this->fetchAliasCollisionListing('Alias Collision Upsert');
+        self::assertTrue($result->isOk());
+        self::assertSame(7, (int)$row['category_code']);
+        self::assertNull($row['category_id']);
+    }
+
     public function testInsertDedupePreservesZeroRelationAliasValue(): void
     {
         $result = $this->createManager(CatalogListingWithScalarEntity::class)->insert(
@@ -509,6 +545,19 @@ final class EntityManagerPartialWriteTest extends TestCase
         return $statement->fetch(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchAliasCollisionListing(string $name): array
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT id, name, category_code, category_id FROM catalog_listing_alias_collisions WHERE name = ?'
+        );
+        $statement->execute([$name]);
+
+        return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+
     private function catalogItemExistsByName(string $name): bool
     {
         $statement = $this->dataSource->getClient()->prepare(
@@ -607,6 +656,23 @@ class CatalogListingWithScalarEntity
     public string $name = '';
 
     #[Column(name: 'category_id', type: ColumnType::INT, nullable: true)]
+    public ?int $categoryId = null;
+
+    #[ManyToOne(type: CatalogCategoryEntity::class)]
+    #[JoinColumn(name: 'category_id', referencedColumnName: 'id')]
+    public ?CatalogCategoryEntity $category = null;
+}
+
+#[Entity(table: 'catalog_listing_alias_collisions')]
+class CatalogListingWithAliasCollisionEntity
+{
+    #[PrimaryGeneratedColumn]
+    public ?int $id = null;
+
+    #[Column(type: ColumnType::VARCHAR, nullable: false)]
+    public string $name = '';
+
+    #[Column(name: 'category_code', type: ColumnType::INT, nullable: true)]
     public ?int $categoryId = null;
 
     #[ManyToOne(type: CatalogCategoryEntity::class)]

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -264,11 +264,22 @@ final class EntityManagerPartialWriteTest extends TestCase
             ],
         );
 
+        $firstRow = $this->fetchCatalogListing('Bulk Cordless Saw');
+        $secondRow = $this->fetchCatalogListing('Bulk Bench Plane');
+        $identifiers = $result->getIdentifiers()->results ?? [];
+        $generatedMaps = $result->getGeneratedMaps()->results ?? [];
+
         self::assertTrue($result->isOk());
         self::assertSame(2, $result->getTotalAffectedRows());
         self::assertStringContainsString('), (', $result->getRaw());
-        self::assertSame(42, $this->fetchCatalogListing('Bulk Cordless Saw')['category_id']);
-        self::assertSame(42, $this->fetchCatalogListing('Bulk Bench Plane')['category_id']);
+        self::assertSame(42, $firstRow['category_id']);
+        self::assertSame(42, $secondRow['category_id']);
+        self::assertCount(2, $identifiers);
+        self::assertCount(2, $generatedMaps);
+        self::assertSame((int)$firstRow['id'], $identifiers[0]->id);
+        self::assertSame((int)$secondRow['id'], $identifiers[1]->id);
+        self::assertSame((int)$firstRow['id'], $generatedMaps[0]->id);
+        self::assertSame((int)$secondRow['id'], $generatedMaps[1]->id);
     }
 
     public function testBulkInsertRejectsRowsWithNumericKeysBeforeWriting(): void

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -225,16 +225,39 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
     }
 
-    public function testInsertRejectsListArrayRows(): void
+    public function testInsertAcceptsListArrayRows(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+
+        $result = $this->createManager(CatalogListingEntity::class)->insert(
+            CatalogListingEntity::class,
+            [
+                ['name' => 'Bulk Cordless Saw', 'categoryId' => 42],
+                ['name' => 'Bulk Bench Plane', 'category_id' => 42],
+            ],
+        );
+
+        self::assertTrue($result->isOk());
+        self::assertSame(2, $result->getTotalAffectedRows());
+        self::assertStringContainsString('), (', $result->getRaw());
+        self::assertSame(42, $this->fetchCatalogListing('Bulk Cordless Saw')['category_id']);
+        self::assertSame(42, $this->fetchCatalogListing('Bulk Bench Plane')['category_id']);
+    }
+
+    public function testBulkInsertRejectsRowsWithNumericKeysBeforeWriting(): void
     {
         $result = $this->createManager(NullableCatalogItemEntity::class)->insert(
             NullableCatalogItemEntity::class,
-            [['name' => 'Bulk Widget']],
+            [
+                ['name' => 'Bulk Widget'],
+                ['Numeric Key Item'],
+            ],
         );
 
         self::assertTrue($result->isError());
         self::assertInstanceOf(ORMException::class, $result->getErrors()[0] ?? null);
         self::assertFalse($this->catalogItemExistsByName('Bulk Widget'));
+        self::assertFalse($this->catalogItemExistsByName('Numeric Key Item'));
     }
 
     public function testInsertRejectsMixedNumericKeyPayload(): void

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -127,6 +127,42 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
     }
 
+    public function testArrayPayloadIdStaysReadonlyWhenRelationIdAliasExists(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+        $this->insertCatalogListing('Bench Vise', 42);
+        $original = $this->fetchCatalogListing('Bench Vise');
+
+        $result = $this->createManager(CatalogListingEntity::class)->update(
+            CatalogListingEntity::class,
+            ['id' => 999],
+            ['name' => 'Bench Vise'],
+        );
+
+        $updated = $this->fetchCatalogListing('Bench Vise');
+        self::assertSame(0, $result->affected);
+        self::assertSame($original['id'], $updated['id']);
+        self::assertFalse($this->catalogListingExistsById(999));
+    }
+
+    public function testObjectPayloadIdStaysReadonlyWhenRelationIdAliasExists(): void
+    {
+        $this->insertCategory(42, 'Hardware');
+        $this->insertCatalogListing('Table Saw', 42);
+        $original = $this->fetchCatalogListing('Table Saw');
+
+        $result = $this->createManager(CatalogListingEntity::class)->update(
+            CatalogListingEntity::class,
+            new CatalogListingReadonlyIdPatch(),
+            ['name' => 'Table Saw'],
+        );
+
+        $updated = $this->fetchCatalogListing('Table Saw');
+        self::assertSame(0, $result->affected);
+        self::assertSame($original['id'], $updated['id']);
+        self::assertFalse($this->catalogListingExistsById(999));
+    }
+
     public function testRelationIdAliasClearRequiresObjectNullWriteOptIn(): void
     {
         $this->insertCategory(42, 'Hardware');
@@ -288,11 +324,21 @@ final class EntityManagerPartialWriteTest extends TestCase
     private function fetchCatalogListing(string $name): array
     {
         $statement = $this->dataSource->getClient()->prepare(
-            'SELECT name, category_id FROM catalog_listings WHERE name = ?'
+            'SELECT id, name, category_id FROM catalog_listings WHERE name = ?'
         );
         $statement->execute([$name]);
 
         return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+
+    private function catalogListingExistsById(int $id): bool
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT COUNT(*) FROM catalog_listings WHERE id = ?'
+        );
+        $statement->execute([$id]);
+
+        return (int)$statement->fetchColumn() > 0;
     }
 
     private function cleanupSqliteFiles(string $path): void
@@ -342,6 +388,11 @@ class CatalogListingCreatePayload
 class CatalogListingRelationPatch
 {
     public ?int $categoryId = null;
+}
+
+class CatalogListingReadonlyIdPatch
+{
+    public int $id = 999;
 }
 
 #[Entity(table: 'catalog_listings')]


### PR DESCRIPTION
This pull request introduces significant improvements to relation-backed foreign key writes and partial update handling in Assegai ORM, focusing on supporting relation ID write aliases, cleaner entity shapes, safer handling of duplicate column writes, and more flexible partial null updates. These changes make it easier to work with foreign keys via relation aliases (like `categoryId`) without cluttering entity models, and improve the reliability and safety of insert and update operations.

**Relation-backed write support and safer updates:**

* Added support for writing foreign keys through relation ID aliases derived from `ManyToOne`/`JoinColumn` metadata, allowing DTOs and arrays to use properties like `categoryId` without requiring duplicate public scalar properties on the entity. (`src/Management/EntityManager.php`, `docs/release-notes/0.9.4.md`) [[1]](diffhunk://#diff-a6ef52828745997d818e49846b9f3a0fc688e31062eb76e795ab8b867c131a90R1-R89) [[2]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R2438-R2756)
* Enhanced validation to accept relation ID write aliases in entity payloads, while still rejecting unknown or unrelated fields.
* Insert and update logic now deduplicates writes to the same join column, failing clearly if conflicting values are provided, and collapsing matching values into a single assignment. [[1]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R374-R375) [[2]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1L2276-R2285) [[3]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R2438-R2756)
* Partial object-based updates now preserve existing nullable values by default, with an explicit `UpdateOptions::writeNulls` opt-in to assign nulls. Array-based updates continue to treat `null` as an explicit value. [[1]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R2245-R2255) [[2]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R2438-R2756)
* `Repository::insert()` now forwards `InsertOptions` to the underlying `EntityManager`, ensuring consistent behavior for relation and read-only columns.

**Documentation:**

* Added comprehensive release notes for versions 0.9.3 and 0.9.4, detailing improvements to relation loading, metadata inference, alias-safe relation loading, and the new relation ID write alias feature. (`docs/release-notes/0.9.3.md`, `docs/release-notes/0.9.4.md`) [[1]](diffhunk://#diff-0eeab37e9b587800ba447ba15d30d8a63445da0b10494816661c1720eda790c4R1-R60) [[2]](diffhunk://#diff-a6ef52828745997d818e49846b9f3a0fc688e31062eb76e795ab8b867c131a90R1-R89)