### PR TITLE
Add soft removable catalog items with enum status and tests

### DIFF
--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -843,11 +843,11 @@ class EntityManager implements IEntityStoreOwner
                         if ($sourceType !== $targetType && !str_contains($targetType, $sourceType)) {
                             $convertedValue = $this->castValue(value: $entityLikePropertyValue, sourceType: $sourceType, targetType: $targetType);
 
-                            if (is_null($convertedValue) && !$entityClassReflectionProperty->getType()?->allowsNull()) {
+                            if (is_null($convertedValue) && is_null($entityLikePropertyValue) && !$entityClassReflectionProperty->getType()?->allowsNull()) {
                                 throw new TypeConversionException("Cannot convert value for $entityLikePropertyName from $sourceType to $targetType.");
                             }
 
-                            $entityLikePropertyValue = $convertedValue;
+                            $entityLikePropertyValue = $convertedValue ?? $entityLikePropertyValue;
                         }
                     }
 
@@ -4084,11 +4084,11 @@ class EntityManager implements IEntityStoreOwner
                 if ($sourceType !== $targetType && !str_contains($targetType, $sourceType)) {
                     $convertedValue = $this->castValue(value: $value, sourceType: $sourceType, targetType: $targetType);
 
-                    if (is_null($convertedValue) && !$targetAllowsNull) {
+                    if (is_null($convertedValue) && is_null($value) && !$targetAllowsNull) {
                         throw new TypeConversionException("Cannot convert value for $prop from $sourceType to $targetType.");
                     }
 
-                    $value = $convertedValue;
+                    $value = $convertedValue ?? $value;
                 }
 
                 if (is_null($value) && !$targetAllowsNull) {

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -797,12 +797,18 @@ class EntityManager implements IEntityStoreOwner
                 if (property_exists($entity, $entityLikePropertyName)) {
                     $entityClassReflectionProperty = new ReflectionProperty($entityClass, $entityLikePropertyName);
 
-                    if (is_null($entityLikePropertyValue)) {
-                        $entityLikePropertyValue = $this->getDefaultColumnValue($entityClassReflectionProperty);
+                    $targetAllowsNull = $entityClassReflectionProperty->getType()?->allowsNull() ?? true;
 
-                        if (!$entityClassReflectionProperty->getType()->allowsNull()) {
-                            continue;
+                    if (is_null($entityLikePropertyValue)) {
+                        if (!$targetAllowsNull) {
+                            if ($this->hasColumnDefaultValue($entityClassReflectionProperty)) {
+                                continue;
+                            }
+
+                            throw new TypeConversionException("Cannot assign null to non-nullable property $entityLikePropertyName.");
                         }
+
+                        $entityLikePropertyValue = $this->getDefaultColumnValue($entityClassReflectionProperty);
                     }
 
                     $entityLikeReflectionPropertyType = is_array($entityLike)
@@ -841,18 +847,25 @@ class EntityManager implements IEntityStoreOwner
                         }
 
                         if ($sourceType !== $targetType && !str_contains($targetType, $sourceType)) {
-                            $convertedValue = $this->castValue(value: $entityLikePropertyValue, sourceType: $sourceType, targetType: $targetType);
+                            $converted = false;
+                            $convertedValue = $this->castValue(value: $entityLikePropertyValue, sourceType: $sourceType, targetType: $targetType, converted: $converted);
 
-                            if (is_null($convertedValue) && is_null($entityLikePropertyValue) && !$entityClassReflectionProperty->getType()?->allowsNull()) {
-                                throw new TypeConversionException("Cannot convert value for $entityLikePropertyName from $sourceType to $targetType.");
+                            if ($converted) {
+                                if (is_null($convertedValue) && !$targetAllowsNull) {
+                                    throw new TypeConversionException("Cannot convert value for $entityLikePropertyName from $sourceType to $targetType.");
+                                }
+
+                                $entityLikePropertyValue = $convertedValue;
                             }
-
-                            $entityLikePropertyValue = $convertedValue ?? $entityLikePropertyValue;
                         }
                     }
 
-                    if (is_null($entityLikePropertyValue) && !$entityClassReflectionProperty->getType()?->allowsNull()) {
-                        continue;
+                    if (is_null($entityLikePropertyValue) && !$targetAllowsNull) {
+                        if ($this->hasColumnDefaultValue($entityClassReflectionProperty)) {
+                            continue;
+                        }
+
+                        throw new TypeConversionException("Cannot assign null to non-nullable property $entityLikePropertyName.");
                     }
 
                     $entity->$entityLikePropertyName = $entityLikePropertyValue;
@@ -922,6 +935,23 @@ class EntityManager implements IEntityStoreOwner
         return null;
     }
 
+    private function hasColumnDefaultValue(ReflectionProperty $reflectionProperty): bool
+    {
+        foreach ($reflectionProperty->getAttributes() as $attribute) {
+            $attributeInstance = $attribute->newInstance();
+
+            if (property_exists($attributeInstance, 'default') && !is_null($attributeInstance->default)) {
+                return true;
+            }
+
+            if (property_exists($attributeInstance, 'autoIncrement') && $attributeInstance->autoIncrement) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function normalizePhpTypeName(string $type): string
     {
         return match (strtolower($type)) {
@@ -936,24 +966,30 @@ class EntityManager implements IEntityStoreOwner
      * @throws ReflectionException
      * @throws TypeConversionException
      */
-    private function castValue(mixed $value, string $sourceType, string $targetType): mixed
+    private function castValue(mixed $value, string $sourceType, string $targetType, bool &$converted = false): mixed
     {
+        $converted = false;
+
         if (is_null($value)) {
             return null;
         }
 
         foreach ($this->customConverters as $converter) {
-            $result = $this->typeResolver->resolve(converterHost: $converter, value: $value, fromType: $sourceType, toType: $targetType);
+            $resolved = false;
+            $result = $this->typeResolver->tryResolve($converter, $value, $sourceType, $targetType, $resolved);
 
-            if (!is_null($result)) {
+            if ($resolved) {
+                $converted = true;
                 return $result;
             }
         }
 
         foreach ($this->defaultConverters as $converter) {
-            $result = $this->typeResolver->resolve(converterHost: $converter, value: $value, fromType: $sourceType, toType: $targetType);
+            $resolved = false;
+            $result = $this->typeResolver->tryResolve($converter, $value, $sourceType, $targetType, $resolved);
 
-            if (!is_null($result)) {
+            if ($resolved) {
+                $converted = true;
                 return $result;
             }
         }
@@ -4058,7 +4094,11 @@ class EntityManager implements IEntityStoreOwner
                 $targetAllowsNull = $targetReflectionType?->allowsNull() ?? true;
 
                 if (is_null($value) && !$targetAllowsNull) {
-                    continue;
+                    if ($this->hasColumnDefaultValue($targetReflection)) {
+                        continue;
+                    }
+
+                    throw new TypeConversionException("Cannot assign null to non-nullable property $prop.");
                 }
 
                 if (is_null($sourceType) || is_null($targetType)) {
@@ -4088,17 +4128,24 @@ class EntityManager implements IEntityStoreOwner
                 }
 
                 if ($sourceType !== $targetType && !str_contains($targetType, $sourceType)) {
-                    $convertedValue = $this->castValue(value: $value, sourceType: $sourceType, targetType: $targetType);
+                    $converted = false;
+                    $convertedValue = $this->castValue(value: $value, sourceType: $sourceType, targetType: $targetType, converted: $converted);
 
-                    if (is_null($convertedValue) && is_null($value) && !$targetAllowsNull) {
-                        throw new TypeConversionException("Cannot convert value for $prop from $sourceType to $targetType.");
+                    if ($converted) {
+                        if (is_null($convertedValue) && !$targetAllowsNull) {
+                            throw new TypeConversionException("Cannot convert value for $prop from $sourceType to $targetType.");
+                        }
+
+                        $value = $convertedValue;
                     }
-
-                    $value = $convertedValue ?? $value;
                 }
 
                 if (is_null($value) && !$targetAllowsNull) {
-                    continue;
+                    if ($this->hasColumnDefaultValue($targetReflection)) {
+                        continue;
+                    }
+
+                    throw new TypeConversionException("Cannot assign null to non-nullable property $prop.");
                 }
 
                 $entity->$prop = $value;

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -55,6 +55,7 @@ use Assegai\Orm\Util\Log\Logger;
 use Assegai\Orm\Util\SqlIdentifier;
 use Assegai\Orm\Util\TypeConversion\BasicTypeConverter;
 use Assegai\Orm\Util\TypeConversion\TypeResolver;
+use BackedEnum;
 use DateInvalidTimeZoneException;
 use DateMalformedStringException;
 use DateTime;
@@ -805,9 +806,9 @@ class EntityManager implements IEntityStoreOwner
                     }
 
                     $entityLikeReflectionPropertyType = is_array($entityLike)
-                        ? strtolower(gettype($entityLikePropertyValue))
+                        ? $this->normalizePhpTypeName(gettype($entityLikePropertyValue))
                         : match (true) {
-                            (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType() instanceof ReflectionUnionType => strtolower(gettype($entityLikePropertyValue)),
+                            (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType() instanceof ReflectionUnionType => $this->normalizePhpTypeName(gettype($entityLikePropertyValue)),
                             default => (new ReflectionProperty($entityLike, $entityLikePropertyName))->getType()?->getName()
                         };
                     $entityClassReflectionPropertyType = match (true) {
@@ -816,10 +817,45 @@ class EntityManager implements IEntityStoreOwner
                     };
                     $typesMatch = ($entityLikeReflectionPropertyType === $entityClassReflectionPropertyType) || ((!empty($entityClassReflectionPropertyType) && !empty($entityLikeReflectionPropertyType)) && str_contains($entityClassReflectionPropertyType, ($entityLikeReflectionPropertyType ?? '')));
 
-                    $sourceType = $entityLikeReflectionPropertyType ?? gettype($entityLikePropertyValue);
-                    $targetType = $entityClassReflectionPropertyType ?? gettype($entityLikePropertyValue);
+                    $sourceType = $entityLikeReflectionPropertyType ?? $this->normalizePhpTypeName(gettype($entityLikePropertyValue));
+                    $targetType = $entityClassReflectionPropertyType ?? $this->normalizePhpTypeName(gettype($entityLikePropertyValue));
 
-                    $entity->$entityLikePropertyName = $typesMatch ? $entityLikePropertyValue : $this->castValue(value: $entityLikePropertyValue, sourceType: $sourceType, targetType: $targetType) ?? $entityLikePropertyValue;
+                    if (!$typesMatch) {
+                        if (
+                            !($entityClassReflectionProperty->getType() instanceof ReflectionUnionType) &&
+                            is_string($targetType) &&
+                            enum_exists($targetType)
+                        ) {
+                            if ($entityLikePropertyValue instanceof $targetType) {
+                                $sourceType = $targetType;
+                            } elseif (is_subclass_of($targetType, BackedEnum::class) && (is_string($entityLikePropertyValue) || is_int($entityLikePropertyValue))) {
+                                $enumValue = $targetType::tryFrom($entityLikePropertyValue);
+
+                                if ($enumValue === null) {
+                                    throw new TypeConversionException("Cannot convert value for $entityLikePropertyName to $targetType.");
+                                }
+
+                                $entityLikePropertyValue = $enumValue;
+                                $sourceType = $targetType;
+                            }
+                        }
+
+                        if ($sourceType !== $targetType && !str_contains($targetType, $sourceType)) {
+                            $convertedValue = $this->castValue(value: $entityLikePropertyValue, sourceType: $sourceType, targetType: $targetType);
+
+                            if (is_null($convertedValue) && !$entityClassReflectionProperty->getType()?->allowsNull()) {
+                                throw new TypeConversionException("Cannot convert value for $entityLikePropertyName from $sourceType to $targetType.");
+                            }
+
+                            $entityLikePropertyValue = $convertedValue;
+                        }
+                    }
+
+                    if (is_null($entityLikePropertyValue) && !$entityClassReflectionProperty->getType()?->allowsNull()) {
+                        continue;
+                    }
+
+                    $entity->$entityLikePropertyName = $entityLikePropertyValue;
                 }
             }
         }
@@ -880,6 +916,16 @@ class EntityManager implements IEntityStoreOwner
         return null;
     }
 
+    private function normalizePhpTypeName(string $type): string
+    {
+        return match (strtolower($type)) {
+            'integer' => 'int',
+            'double' => 'float',
+            'boolean' => 'bool',
+            'null' => 'null',
+            default => strtolower($type),
+        };
+    }
     /**
      * @throws ReflectionException
      * @throws TypeConversionException
@@ -4003,12 +4049,50 @@ class EntityManager implements IEntityStoreOwner
                     };
                 }
 
+                $targetAllowsNull = $targetReflectionType?->allowsNull() ?? true;
+
+                if (is_null($value) && !$targetAllowsNull) {
+                    continue;
+                }
+
                 if (is_null($sourceType) || is_null($targetType)) {
                     continue;
                 }
 
+                if (
+                    !($targetReflectionType instanceof ReflectionUnionType) &&
+                    is_string($targetType) &&
+                    enum_exists($targetType) &&
+                    !($value instanceof $targetType)
+                ) {
+                    if ($value instanceof $targetType) {
+                        $sourceType = $targetType;
+                    } elseif (is_subclass_of($targetType, BackedEnum::class) && (is_string($value) || is_int($value))) {
+                        $enumValue = $targetType::tryFrom($value);
+
+                        if ($enumValue === null) {
+                            throw new TypeConversionException("Cannot convert value for $prop to $targetType.");
+                        }
+
+                        $value = $enumValue;
+                        $sourceType = $targetType;
+                    } else {
+                        throw new TypeConversionException("Cannot convert value for $prop to $targetType.");
+                    }
+                }
+
                 if ($sourceType !== $targetType && !str_contains($targetType, $sourceType)) {
-                    $value = $this->castValue(value: $value, sourceType: $sourceType, targetType: $targetType);
+                    $convertedValue = $this->castValue(value: $value, sourceType: $sourceType, targetType: $targetType);
+
+                    if (is_null($convertedValue) && !$targetAllowsNull) {
+                        throw new TypeConversionException("Cannot convert value for $prop from $sourceType to $targetType.");
+                    }
+
+                    $value = $convertedValue;
+                }
+
+                if (is_null($value) && !$targetAllowsNull) {
+                    continue;
                 }
 
                 $entity->$prop = $value;

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -898,13 +898,19 @@ class EntityManager implements IEntityStoreOwner
             try {
                 # Check if a default value is specified
                 if (!is_null($attributeInstance->default)) {
+                    $default = $attributeInstance->default;
+
+                    if (!is_string($default)) {
+                        return $default;
+                    }
+
                     return match (true) {
-                        $attributeInstance->default === 'CURRENT_TIMESTAMP', $attributeInstance->default === 'NOW()' => new DateTime(),
+                        $default === 'CURRENT_TIMESTAMP', $default === 'NOW()' => new DateTime(),
                         # Match ISO 8601 date format
-                        preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $attributeInstance->default) => new DateTime($attributeInstance->default),
+                        preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $default) => new DateTime($default),
                         # Match ATOM date format
-                        preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+$/', $attributeInstance->default) => new DateTime($attributeInstance->default),
-                        default => $attributeInstance->default
+                        preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+$/', $default) => new DateTime($default),
+                        default => $default
                     };
                 }
             } catch (Exception $exception) {

--- a/src/Management/EntityManager.php
+++ b/src/Management/EntityManager.php
@@ -788,6 +788,21 @@ class EntityManager implements IEntityStoreOwner
      */
     public function create(string $entityClass, null|object|array $entityLike = null): object
     {
+        return $this->createEntityInstance(entityClass: $entityClass, entityLike: $entityLike);
+    }
+
+    /**
+     * Hydrates an entity-like payload into an entity instance.
+     *
+     * @throws ClassNotFoundException
+     * @throws ORMException|ReflectionException
+     */
+    private function createEntityInstance(
+        string $entityClass,
+        null|object|array $entityLike = null,
+        bool $omitNullsForNonNullableProperties = false,
+    ): object
+    {
         $this->validateEntityName(entityClass: $entityClass);
 
         $entity = new $entityClass;
@@ -801,7 +816,7 @@ class EntityManager implements IEntityStoreOwner
 
                     if (is_null($entityLikePropertyValue)) {
                         if (!$targetAllowsNull) {
-                            if ($this->hasColumnDefaultValue($entityClassReflectionProperty)) {
+                            if ($this->hasColumnDefaultValue($entityClassReflectionProperty) || $omitNullsForNonNullableProperties) {
                                 continue;
                             }
 
@@ -2632,7 +2647,11 @@ class EntityManager implements IEntityStoreOwner
             return new UpdateResult(raw: $this->query->queryString(), affected: $this->query->rowCount(), identifiers: (object)$partialEntity, generatedMaps: $generatedMaps);
         }
 
-        $entityInstance = $this->create(entityClass: $entityClass, entityLike: $partialEntity);
+        $entityInstance = $this->createEntityInstance(
+            entityClass: $entityClass,
+            entityLike: $partialEntity,
+            omitNullsForNonNullableProperties: is_object($partialEntity),
+        );
         $assignmentList = [];
         $columnOptions = [];
         $relations = [];
@@ -3382,7 +3401,6 @@ class EntityManager implements IEntityStoreOwner
      */
     public function upsert(string $entityClass, object|array $entityOrEntities, array|UpsertOptions $options): InsertResult|UpdateResult
     {
-        // TODO: #83 Implement EntityManager::upsert @amasiye
         if (is_array($options)) {
             $options = array_is_list($options)
                 ? new UpsertOptions(conflictPaths: $options)
@@ -3424,7 +3442,6 @@ class EntityManager implements IEntityStoreOwner
             entityLike: is_array($entityOrEntities) ? $entityOrEntities : (object)$entityOrEntities,
         );
 
-        // TODO: Configure the upsert options
         $primaryKey = $this->getPrimaryKeyMetadata($entity);
         $primaryKeyField = $primaryKey['field'];
         $primaryColumn = $primaryKey['column'];
@@ -3855,7 +3872,6 @@ class EntityManager implements IEntityStoreOwner
                 throw $this->newGeneralSqlQueryException($this->query, $result);
             }
 
-            // TODO: #88 Verify that delete occurred @amasiye
             $generatedMaps = new stdClass();
             foreach ($result->value() as $key => $value) {
                 $generatedMaps->$key = $value;

--- a/src/Management/Inspectors/EntityInspector.php
+++ b/src/Management/Inspectors/EntityInspector.php
@@ -41,9 +41,9 @@ final class EntityInspector
   protected Logger $logger;
 
   /**
-   * Constructs a new EntityInspector
+   * Constructs a new EntityInspector.
    */
-  private final function __construct()
+  public function __construct()
   {
     $this->logger = new Logger(new ConsoleOutput());
   }
@@ -52,6 +52,7 @@ final class EntityInspector
    * Returns the singleton instance of the EntityInspector.
    *
    * @return EntityInspector The singleton instance of the EntityInspector.
+   * @deprecated Will be removed in Assegai ORM 0.10.0. Create and inject EntityInspector instead.
    */
   public static function getInstance(): EntityInspector
   {

--- a/src/Util/TypeConversion/TypeResolver.php
+++ b/src/Util/TypeConversion/TypeResolver.php
@@ -16,12 +16,18 @@ final class TypeResolver
   private static ?TypeResolver $instance = null;
 
   /**
-   * Constructs
+   * Constructs a new TypeResolver.
    */
-  private final function __construct()
+  public function __construct()
   {
   }
 
+  /**
+   * Returns the singleton instance of the TypeResolver.
+   *
+   * @return self The singleton instance of the TypeResolver.
+   * @deprecated Will be removed in Assegai ORM 0.10.0. Create and inject TypeResolver instead.
+   */
   public static function getInstance(): self
   {
     if (!self::$instance) {

--- a/src/Util/TypeConversion/TypeResolver.php
+++ b/src/Util/TypeConversion/TypeResolver.php
@@ -42,13 +42,31 @@ final class TypeResolver
    */
   public function resolve(object $converterHost, mixed $value, string $fromType, string $toType): mixed
   {
+    $resolved = false;
+    return $this->tryResolve($converterHost, $value, $fromType, $toType, $resolved);
+  }
+
+  /**
+   * @param object $converterHost
+   * @param mixed $value
+   * @param string $fromType
+   * @param string $toType
+   * @param bool $resolved
+   * @return mixed
+   * @throws ReflectionException
+   * @throws TypeConversionException
+   */
+  public function tryResolve(object $converterHost, mixed $value, string $fromType, string $toType, bool &$resolved): mixed
+  {
     if ( $method =
           $this->findConverter(
             converterHostClassName: $converterHost::class, sourceType: $fromType, targetType: $toType
           ) ) {
+      $resolved = true;
       return $method->invokeArgs($converterHost, [$value]);
     }
 
+    $resolved = false;
     return null;
   }
 

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -289,6 +289,26 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertSame(CatalogItemStatus::ACTIVE->value, $row['status']);
     }
 
+    public function testObjectPartialUpdateSkipsNullsForRequiredColumnsWithoutDefaults(): void
+    {
+        $this->insertCatalogItem('Patch Target', 'Original description');
+
+        $payload = new NullableCatalogItemNameDescriptionPatch();
+        $payload->description = 'Updated description';
+
+        $result = $this->createManager(NullableCatalogItemEntity::class)->update(
+            NullableCatalogItemEntity::class,
+            $payload,
+            ['name' => 'Patch Target'],
+        );
+        $row = $this->fetchCatalogItem('Patch Target');
+
+        self::assertTrue($result->isOk());
+        self::assertSame(1, $result->affected);
+        self::assertSame('Patch Target', $row['name']);
+        self::assertSame('Updated description', $row['description']);
+    }
+
     public function testManagerUpsertUsesDefaultsForNonNullableNullsOnObjectPayloads(): void
     {
         $payload = new SoftRemovableCatalogItemWritePayload();
@@ -468,6 +488,36 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertTrue($result->isOk());
         self::assertSame(CatalogItemStatus::ACTIVE->value, $row['status']);
         self::assertNotNull($row['deleted_at']);
+    }
+
+    public function testSoftRemoveReportsOneAffectedRowWhenEntityExists(): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO soft_removable_catalog_items (name, status, deleted_at) VALUES (?, ?, NULL)'
+        );
+        $statement->execute(['Affected Soft Remove', CatalogItemStatus::ACTIVE->value]);
+        $id = (int)$this->dataSource->getClient()->lastInsertId();
+
+        $entity = new SoftRemovableCatalogItemEntity();
+        $entity->id = $id;
+
+        $result = $this->createManager(SoftRemovableCatalogItemEntity::class)->softRemove($entity);
+        $row = $this->fetchSoftRemovableCatalogItem($id);
+
+        self::assertTrue($result->isOk());
+        self::assertSame(1, $result->affected);
+        self::assertNotNull($row['deleted_at']);
+    }
+
+    public function testSoftRemoveReportsZeroAffectedRowsWhenEntityDoesNotExist(): void
+    {
+        $entity = new SoftRemovableCatalogItemEntity();
+        $entity->id = 987654321;
+
+        $result = $this->createManager(SoftRemovableCatalogItemEntity::class)->softRemove($entity);
+
+        self::assertTrue($result->isOk());
+        self::assertSame(0, $result->affected);
     }
 
     public function testInsertAcceptsListArrayRows(): void
@@ -1022,6 +1072,12 @@ class NullableCatalogItemPatch
 class NullableCatalogItemNullNamePayload
 {
     public ?string $name = null;
+}
+
+class NullableCatalogItemNameDescriptionPatch
+{
+    public ?string $name = null;
+    public ?string $description = null;
 }
 
 #[Entity(table: 'nullable_catalog_item_schedules')]

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -8,6 +8,7 @@ use Assegai\Orm\Attributes\Columns\PrimaryGeneratedColumn;
 use Assegai\Orm\Attributes\Entity;
 use Assegai\Orm\Attributes\Relations\JoinColumn;
 use Assegai\Orm\Attributes\Relations\ManyToOne;
+use Assegai\Orm\Attributes\TypeConverter;
 use Assegai\Orm\DataSource\DataSource;
 use Assegai\Orm\DataSource\DataSourceOptions;
 use Assegai\Orm\Enumerations\DataSourceType;
@@ -20,6 +21,7 @@ use Assegai\Orm\Management\Options\UpdateOptions;
 use Assegai\Orm\Management\Repository;
 use Assegai\Orm\Queries\Sql\ColumnType;
 use Assegai\Orm\Queries\Sql\SQLQuery;
+use DateTime;
 use PDO;
 use PHPUnit\Framework\TestCase;
 
@@ -35,6 +37,7 @@ final class EntityManagerPartialWriteTest extends TestCase
         $this->dataSource = new DataSource(new DataSourceOptions(
             entities: [
                 NullableCatalogItemEntity::class,
+                NullableCatalogItemScheduleEntity::class,
                 CatalogCategoryEntity::class,
                 CatalogListingEntity::class,
                 CatalogListingWithScalarEntity::class,
@@ -374,6 +377,34 @@ final class EntityManagerPartialWriteTest extends TestCase
 
         self::assertTrue($result->isOk());
         self::assertSame(CatalogItemStatus::DRAFT->value, $row['status']);
+    }
+
+    public function testCustomConverterNullResultIsPreservedForNullableTargets(): void
+    {
+        $payload = new CatalogItemSchedulePayload();
+        $payload->availableAt = '';
+
+        $manager = $this->createManager(NullableCatalogItemScheduleEntity::class);
+        $manager->useConverters([new BlankStringToDateTimeConverter()]);
+
+        $entity = $manager->getEntityFromObject(NullableCatalogItemScheduleEntity::class, $payload);
+
+        self::assertNull($entity->availableAt);
+    }
+
+    public function testRepositoryUpsertRejectsNullForRequiredColumnsWithoutDefaults(): void
+    {
+        $payload = new NullableCatalogItemNullNamePayload();
+
+        $repository = new Repository(
+            NullableCatalogItemEntity::class,
+            $this->createManager(NullableCatalogItemEntity::class),
+        );
+
+        $this->expectException(TypeConversionException::class);
+        $this->expectExceptionMessage('Cannot assign null to non-nullable property name.');
+
+        $repository->upsert($payload, ['name']);
     }
 
     public function testRepositorySoftRemoveConvertsBackedEnumScalarsOnPartialObjects(): void
@@ -986,6 +1017,35 @@ class NullableCatalogItemEntity
 class NullableCatalogItemPatch
 {
     public ?string $description = null;
+}
+
+class NullableCatalogItemNullNamePayload
+{
+    public ?string $name = null;
+}
+
+#[Entity(table: 'nullable_catalog_item_schedules')]
+class NullableCatalogItemScheduleEntity
+{
+    #[PrimaryGeneratedColumn]
+    public ?int $id = null;
+
+    #[Column(type: ColumnType::DATETIME, nullable: true)]
+    public ?DateTime $availableAt = null;
+}
+
+class CatalogItemSchedulePayload
+{
+    public string $availableAt = '';
+}
+
+class BlankStringToDateTimeConverter
+{
+    #[TypeConverter]
+    public function fromStringToDateTime(string $value): ?DateTime
+    {
+        return trim($value) === '' ? null : new DateTime($value);
+    }
 }
 
 #[Entity(table: 'catalog_categories')]

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -469,6 +469,41 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertSame((int)$secondRow['id'], $generatedMaps[1]->id);
     }
 
+    public function testCreatePreservesNonNullValuesWhenNullableConversionIsMissing(): void
+    {
+        $entity = $this->createManager(NullableCatalogItemEntity::class)->create(
+            NullableCatalogItemEntity::class,
+            ['name' => 'Created Nullable Conversion', 'description' => 123],
+        );
+
+        self::assertSame('123', $entity->description);
+    }
+
+    public function testInsertPreservesNonNullValuesWhenNullableConversionIsMissing(): void
+    {
+        $result = $this->createManager(NullableCatalogItemEntity::class)->insert(
+            NullableCatalogItemEntity::class,
+            ['name' => 'Inserted Nullable Conversion', 'description' => 123],
+        );
+        $row = $this->fetchCatalogItem('Inserted Nullable Conversion');
+
+        self::assertTrue($result->isOk());
+        self::assertSame('123', $row['description']);
+    }
+
+    public function testUpsertPreservesNonNullValuesWhenNullableConversionIsMissing(): void
+    {
+        $result = $this->createManager(NullableCatalogItemEntity::class)->upsert(
+            NullableCatalogItemEntity::class,
+            ['name' => 'Upserted Nullable Conversion', 'description' => 123],
+            ['name'],
+        );
+        $row = $this->fetchCatalogItem('Upserted Nullable Conversion');
+
+        self::assertTrue($result->isOk());
+        self::assertSame('123', $row['description']);
+    }
+
     public function testSqliteBulkInsertPopulatesGeneratedIdsWhenRowsMixExplicitAndGeneratedIds(): void
     {
         $result = $this->createManager(NullableCatalogItemEntity::class)->insert(

--- a/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
+++ b/tests/PHPUnit/Unit/EntityManagerPartialWriteTest.php
@@ -3,6 +3,7 @@
 namespace Tests\PHPUnit\Unit;
 
 use Assegai\Orm\Attributes\Columns\Column;
+use Assegai\Orm\Attributes\Columns\DeleteDateColumn;
 use Assegai\Orm\Attributes\Columns\PrimaryGeneratedColumn;
 use Assegai\Orm\Attributes\Entity;
 use Assegai\Orm\Attributes\Relations\JoinColumn;
@@ -12,6 +13,7 @@ use Assegai\Orm\DataSource\DataSourceOptions;
 use Assegai\Orm\Enumerations\DataSourceType;
 use Assegai\Orm\Enumerations\SQLDialect;
 use Assegai\Orm\Exceptions\ORMException;
+use Assegai\Orm\Exceptions\TypeConversionException;
 use Assegai\Orm\Management\EntityManager;
 use Assegai\Orm\Management\Options\InsertOptions;
 use Assegai\Orm\Management\Options\UpdateOptions;
@@ -37,6 +39,7 @@ final class EntityManagerPartialWriteTest extends TestCase
                 CatalogListingEntity::class,
                 CatalogListingWithScalarEntity::class,
                 CatalogListingWithAliasCollisionEntity::class,
+                SoftRemovableCatalogItemEntity::class,
             ],
             name: $this->databasePath,
             type: DataSourceType::SQLITE,
@@ -68,6 +71,14 @@ final class EntityManagerPartialWriteTest extends TestCase
                 name TEXT NOT NULL UNIQUE,
                 category_code INTEGER NULL,
                 category_id INTEGER NULL
+            )'
+        );
+        $this->dataSource->getClient()->exec(
+            'CREATE TABLE soft_removable_catalog_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                status TEXT NOT NULL,
+                deleted_at TEXT NULL
             )'
         );
     }
@@ -250,6 +261,182 @@ final class EntityManagerPartialWriteTest extends TestCase
         self::assertSame(1, substr_count($result->getRaw(), '"category_id"'));
         self::assertSame(42, $this->fetchCatalogListing('Cordless Sander')['category_id']);
         self::assertObjectNotHasProperty('categoryId', $result->generatedMaps);
+    }
+
+    public function testObjectPartialUpdateSkipsNullsForNonNullableDefaults(): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO soft_removable_catalog_items (name, status, deleted_at) VALUES (?, ?, NULL)'
+        );
+        $statement->execute(['Pending Update', CatalogItemStatus::ACTIVE->value]);
+        $id = (int)$this->dataSource->getClient()->lastInsertId();
+
+        $payload = new SoftRemovableCatalogItemWritePayload();
+        $payload->name = 'Updated Without Status';
+
+        $result = $this->createManager(SoftRemovableCatalogItemEntity::class)->update(
+            SoftRemovableCatalogItemEntity::class,
+            $payload,
+            ['id' => $id],
+        );
+        $row = $this->fetchSoftRemovableCatalogItem($id);
+
+        self::assertTrue($result->isOk());
+        self::assertSame('Updated Without Status', $row['name']);
+        self::assertSame(CatalogItemStatus::ACTIVE->value, $row['status']);
+    }
+
+    public function testManagerUpsertUsesDefaultsForNonNullableNullsOnObjectPayloads(): void
+    {
+        $payload = new SoftRemovableCatalogItemWritePayload();
+        $payload->name = 'Manager Upsert Default Status';
+
+        $result = $this->createManager(SoftRemovableCatalogItemEntity::class)->upsert(
+            SoftRemovableCatalogItemEntity::class,
+            $payload,
+            ['name'],
+        );
+        $row = $this->fetchSoftRemovableCatalogItemByName('Manager Upsert Default Status');
+
+        self::assertTrue($result->isOk());
+        self::assertSame(CatalogItemStatus::ACTIVE->value, $row['status']);
+    }
+
+    public function testManagerUpdateConvertsBackedEnumScalarsOnObjectPayloads(): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO soft_removable_catalog_items (name, status, deleted_at) VALUES (?, ?, NULL)'
+        );
+        $statement->execute(['Pending Scalar Update', CatalogItemStatus::ACTIVE->value]);
+        $id = (int)$this->dataSource->getClient()->lastInsertId();
+
+        $payload = new SoftRemovableCatalogItemRawWritePayload();
+        $payload->name = 'Updated With Scalar Status';
+        $payload->status = CatalogItemStatus::DRAFT->value;
+
+        $result = $this->createManager(SoftRemovableCatalogItemEntity::class)->update(
+            SoftRemovableCatalogItemEntity::class,
+            $payload,
+            ['id' => $id],
+        );
+        $row = $this->fetchSoftRemovableCatalogItem($id);
+
+        self::assertTrue($result->isOk());
+        self::assertSame('Updated With Scalar Status', $row['name']);
+        self::assertSame(CatalogItemStatus::DRAFT->value, $row['status']);
+    }
+
+    public function testManagerUpsertConvertsBackedEnumScalarsOnObjectPayloads(): void
+    {
+        $payload = new SoftRemovableCatalogItemRawWritePayload();
+        $payload->name = 'Manager Upsert Scalar Status';
+        $payload->status = CatalogItemStatus::DRAFT->value;
+
+        $result = $this->createManager(SoftRemovableCatalogItemEntity::class)->upsert(
+            SoftRemovableCatalogItemEntity::class,
+            $payload,
+            ['name'],
+        );
+        $row = $this->fetchSoftRemovableCatalogItemByName('Manager Upsert Scalar Status');
+
+        self::assertTrue($result->isOk());
+        self::assertSame(CatalogItemStatus::DRAFT->value, $row['status']);
+    }
+
+    public function testRepositoryUpsertSkipsNullsForNonNullableDefaultsOnPartialObjects(): void
+    {
+        $payload = new SoftRemovableCatalogItemWritePayload();
+        $payload->name = 'Repository Upsert Default Status';
+
+        $repository = new Repository(
+            SoftRemovableCatalogItemEntity::class,
+            $this->createManager(SoftRemovableCatalogItemEntity::class),
+        );
+        $result = $repository->upsert($payload, ['name']);
+        $row = $this->fetchSoftRemovableCatalogItemByName('Repository Upsert Default Status');
+
+        self::assertTrue($result->isOk());
+        self::assertSame(CatalogItemStatus::ACTIVE->value, $row['status']);
+    }
+
+    public function testRepositoryUpsertConvertsBackedEnumScalarsOnPartialObjects(): void
+    {
+        $payload = new SoftRemovableCatalogItemRawWritePayload();
+        $payload->name = 'Repository Upsert Scalar Status';
+        $payload->status = CatalogItemStatus::DRAFT->value;
+
+        $repository = new Repository(
+            SoftRemovableCatalogItemEntity::class,
+            $this->createManager(SoftRemovableCatalogItemEntity::class),
+        );
+        $result = $repository->upsert($payload, ['name']);
+        $row = $this->fetchSoftRemovableCatalogItemByName('Repository Upsert Scalar Status');
+
+        self::assertTrue($result->isOk());
+        self::assertSame(CatalogItemStatus::DRAFT->value, $row['status']);
+    }
+
+    public function testRepositorySoftRemoveConvertsBackedEnumScalarsOnPartialObjects(): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO soft_removable_catalog_items (name, status, deleted_at) VALUES (?, ?, NULL)'
+        );
+        $statement->execute(['Archive Scalar Candidate', CatalogItemStatus::ACTIVE->value]);
+        $id = (int)$this->dataSource->getClient()->lastInsertId();
+
+        $payload = new SoftRemovableCatalogItemRawDeletionPayload();
+        $payload->id = $id;
+        $payload->status = CatalogItemStatus::ACTIVE->value;
+
+        $repository = new Repository(
+            SoftRemovableCatalogItemEntity::class,
+            $this->createManager(SoftRemovableCatalogItemEntity::class),
+        );
+        $result = $repository->softRemove($payload);
+        $row = $this->fetchSoftRemovableCatalogItem($id);
+
+        self::assertTrue($result->isOk());
+        self::assertSame(CatalogItemStatus::ACTIVE->value, $row['status']);
+        self::assertNotNull($row['deleted_at']);
+    }
+
+    public function testRepositoryUpsertRejectsInvalidBackedEnumScalarsClearly(): void
+    {
+        $payload = new SoftRemovableCatalogItemRawWritePayload();
+        $payload->name = 'Repository Upsert Invalid Status';
+        $payload->status = 'archived';
+
+        $repository = new Repository(
+            SoftRemovableCatalogItemEntity::class,
+            $this->createManager(SoftRemovableCatalogItemEntity::class),
+        );
+
+        $this->expectException(TypeConversionException::class);
+        $this->expectExceptionMessage('Cannot convert value for status');
+
+        $repository->upsert($payload, ['name']);
+    }
+    public function testRepositorySoftRemoveSkipsNullsForNonNullableDefaultsOnPartialObjects(): void
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'INSERT INTO soft_removable_catalog_items (name, status, deleted_at) VALUES (?, ?, NULL)'
+        );
+        $statement->execute(['Archive Candidate', CatalogItemStatus::ACTIVE->value]);
+        $id = (int)$this->dataSource->getClient()->lastInsertId();
+
+        $payload = new SoftRemovableCatalogItemDeletionPayload();
+        $payload->id = $id;
+
+        $repository = new Repository(
+            SoftRemovableCatalogItemEntity::class,
+            $this->createManager(SoftRemovableCatalogItemEntity::class),
+        );
+        $result = $repository->softRemove($payload);
+        $row = $this->fetchSoftRemovableCatalogItem($id);
+
+        self::assertTrue($result->isOk());
+        self::assertSame(CatalogItemStatus::ACTIVE->value, $row['status']);
+        self::assertNotNull($row['deleted_at']);
     }
 
     public function testInsertAcceptsListArrayRows(): void
@@ -649,6 +836,31 @@ final class EntityManagerPartialWriteTest extends TestCase
         return $statement->fetch(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchSoftRemovableCatalogItem(int $id): array
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT id, name, status, deleted_at FROM soft_removable_catalog_items WHERE id = ?'
+        );
+        $statement->execute([$id]);
+
+        return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchSoftRemovableCatalogItemByName(string $name): array
+    {
+        $statement = $this->dataSource->getClient()->prepare(
+            'SELECT id, name, status, deleted_at FROM soft_removable_catalog_items WHERE name = ?'
+        );
+        $statement->execute([$name]);
+
+        return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+
     private function catalogItemExistsByName(string $name): bool
     {
         $statement = $this->dataSource->getClient()->prepare(
@@ -677,6 +889,50 @@ final class EntityManagerPartialWriteTest extends TestCase
             }
         }
     }
+}
+
+enum CatalogItemStatus: string
+{
+    case ACTIVE = 'active';
+    case DRAFT = 'draft';
+}
+
+#[Entity(table: 'soft_removable_catalog_items')]
+class SoftRemovableCatalogItemEntity
+{
+    #[PrimaryGeneratedColumn]
+    public ?int $id = null;
+
+    #[Column(type: ColumnType::VARCHAR, nullable: false)]
+    public string $name = '';
+
+    #[Column(type: ColumnType::ENUM, nullable: false, default: CatalogItemStatus::ACTIVE, enum: CatalogItemStatus::class)]
+    public CatalogItemStatus $status = CatalogItemStatus::ACTIVE;
+
+    #[DeleteDateColumn]
+    public ?string $deletedAt = null;
+}
+
+class SoftRemovableCatalogItemDeletionPayload
+{
+    public ?int $id = null;
+    public ?CatalogItemStatus $status = null;
+}
+class SoftRemovableCatalogItemWritePayload
+{
+    public string $name = '';
+    public ?CatalogItemStatus $status = null;
+}
+class SoftRemovableCatalogItemRawDeletionPayload
+{
+    public ?int $id = null;
+    public string $status = '';
+}
+
+class SoftRemovableCatalogItemRawWritePayload
+{
+    public string $name = '';
+    public string $status = '';
 }
 
 #[Entity(table: 'nullable_catalog_items')]


### PR DESCRIPTION
This pull request significantly improves the handling of type conversion and enum support in the `EntityManager`, especially for partial updates and upserts. It ensures that scalar values are correctly converted to backed enums, non-nullable fields with defaults are preserved when omitted from payloads, and errors are clearly surfaced for invalid enum values. A comprehensive suite of tests has been added to verify these behaviors.

### Type Conversion and Enum Handling Improvements

* Enhanced the `EntityManager` to automatically convert scalar values (string/int) into backed enum instances when updating or upserting entities, throwing clear exceptions if conversion fails. This includes support for skipping null assignments to non-nullable fields and using default values where appropriate. [[1]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1L808-R811) [[2]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1L819-R858) [[3]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R4052-R4095)
* Added a `normalizePhpTypeName` helper to standardize PHP type names for more reliable type comparisons and conversions. [[1]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1L808-R811) [[2]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R919-R928)
* Imported `BackedEnum` to support enum type checks and conversions.

### Test Coverage

* Added a new test entity (`SoftRemovableCatalogItemEntity`) with a backed enum field and corresponding payload classes to cover various update, upsert, and soft-remove scenarios.
* Created and registered a new test table for soft-removable catalog items. [[1]](diffhunk://#diff-c344bfe8360dd1e1f68bdffa0f1855821505d2a55ebac84caf75d60db4b6f427R42) [[2]](diffhunk://#diff-c344bfe8360dd1e1f68bdffa0f1855821505d2a55ebac84caf75d60db4b6f427R76-R83)
* Implemented comprehensive tests to verify:
  - Skipping nulls for non-nullable defaults in partial updates/upserts/soft-removes.
  - Correct conversion of scalar values to enums.
  - Proper error handling for invalid enum values.
* Added helper methods for fetching test entity rows by ID and name.

### Error Handling

* Improved exception messages for failed type conversions, especially when invalid enum values are provided. [[1]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1L819-R858) [[2]](diffhunk://#diff-6ab9a02a2ebd3cb9907a13e3d833303ff7a93b2d91f31a92ca9c8f60bb6a56d1R4052-R4095)

These changes make the entity management system more robust, especially when dealing with partial updates and enum fields, and provide clear feedback for developers when type mismatches occur.